### PR TITLE
Even G2ページ復旧失敗時に切断状態へ遷移して再接続する

### DIFF
--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -473,14 +473,19 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   }
 
   private async recoverPage(): Promise<void> {
-    if (!this.bridge) return;
+    // Once disconnected, the reconnect loop owns recovery: never resurrect the
+    // session from a stale foreground event.
+    if (!this.bridge || !this.isConnected) return;
     console.log('[EvenG2Adapter] FOREGROUND_ENTER — rebuilding page containers');
     try {
       await this.enqueueBridgeOperation(async () => {
+        // A disconnect may have landed while this rebuild waited in the queue.
+        if (!this.isConnected) throw new Error('bridge disconnected before rebuild');
         const rebuilt = await this.bridge.rebuildPageContainer(
           new RebuildPageContainer({ containerTotalNum: 4, ...this.createPageDefinition() })
         );
         if (!rebuilt) throw new Error('rebuildPageContainer failed');
+        if (!this.isConnected) throw new Error('bridge disconnected during rebuild');
         this.lastHeaderContent = '';
         this.lastSegmentContent = '';
         this.lastFooterContent = '';
@@ -490,21 +495,31 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         this.pageReady = true;
         this.isConnected = true;
       });
-
-      if (this.lastModel) {
-        // Force a fresh flush of the latest HUD after rebuild.
-        this.renderGeneration += 1;
-        this.queueHudFlush();
-      } else {
-        await this.queueSpeedImageUpdate(
-          this.latestRequestedSpeedKmh,
-          this.latestRequestedIsEstimated,
-          true
-        );
-      }
     } catch (error) {
-      this.pageReady = false;
       console.warn('[EvenG2Adapter] Page recovery failed:', error);
+      // A failed rebuild leaves no usable page: transition to the disconnected
+      // state so waitUntilDisconnected() resolves and AppController reconnects.
+      this.markDisconnected('page recovery failed');
+      return;
+    }
+
+    if (this.lastModel) {
+      // Force a fresh flush of the latest HUD after rebuild.
+      this.renderGeneration += 1;
+      this.queueHudFlush();
+      return;
+    }
+
+    // Mirrors connect(): the image push is a soft failure and must never drop a
+    // page that was rebuilt successfully.
+    try {
+      await this.queueSpeedImageUpdate(
+        this.latestRequestedSpeedKmh,
+        this.latestRequestedIsEstimated,
+        true
+      );
+    } catch (imgErr) {
+      console.warn('[EvenG2Adapter] Recovery speed PNG update notice:', imgErr);
     }
   }
 }

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -147,8 +147,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         const isSuccess = result === StartUpPageCreateResult.success;
 
         if (!isSuccess) {
-          this.isConnected = false;
-          this.pageReady = false;
+          this.markDisconnected('createStartUpPageContainer failed');
           throw new Error(`createStartUpPageContainer failed with code: ${String(result)}`);
         }
 
@@ -175,8 +174,9 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
       }
     } catch (err) {
       console.log('[EvenG2Adapter] Bridge connection notice:', err);
-      this.isConnected = false;
-      this.pageReady = false;
+      // Always route failures through markDisconnected so any waiter registered
+      // by a previous session is released instead of stranding the caller.
+      this.markDisconnected('connect() failed');
     }
     return this.isConnected;
   }

--- a/tests/even-g2/even-g2-adapter-recovery.test.ts
+++ b/tests/even-g2/even-g2-adapter-recovery.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HudViewModel } from '../../src/domain/models/hud';
+import { AppController } from '../../src/app/app-controller';
+import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
+import { EstimationLogger } from '../../src/infrastructure/logging/logger';
+
+const sdk = vi.hoisted(() => ({
+  bridge: {
+    createStartUpPageContainer: vi.fn(),
+    rebuildPageContainer: vi.fn(),
+    updateImageRawData: vi.fn(),
+    textContainerUpgrade: vi.fn(),
+    shutDownPageContainer: vi.fn(),
+    onEvenHubEvent: vi.fn(),
+  },
+  waitForEvenAppBridge: vi.fn(),
+}));
+
+vi.mock('@evenrealities/even_hub_sdk', () => {
+  class Model {
+    constructor(data: Record<string, unknown>) { Object.assign(this, data); }
+  }
+  return {
+    waitForEvenAppBridge: sdk.waitForEvenAppBridge,
+    ImageContainerProperty: Model,
+    ImageRawDataUpdate: Model,
+    TextContainerProperty: Model,
+    TextContainerUpgrade: Model,
+    CreateStartUpPageContainer: Model,
+    RebuildPageContainer: Model,
+    StartUpPageCreateResult: { success: 'success' },
+    ImageRawDataUpdateResult: { isSuccess: (value: string) => value === 'success' },
+    OsEventTypeList: {
+      FOREGROUND_ENTER_EVENT: 4,
+      FOREGROUND_EXIT_EVENT: 5,
+      ABNORMAL_EXIT_EVENT: 6,
+      SYSTEM_EXIT_EVENT: 7,
+    },
+  };
+});
+
+vi.mock('../../src/infrastructure/even-g2/speed-png-generator', () => ({
+  createSpeedPng: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+}));
+
+import { EvenG2Adapter, HybridEvenG2Adapter } from '../../src/infrastructure/even-g2/even-g2-adapter';
+
+const FOREGROUND_EXIT = 5;
+const FOREGROUND_ENTER = 4;
+
+function viewModel(speed: string, lineName = '小田急線'): HudViewModel {
+  return {
+    header: { lineName, serviceOrDirection: '上り' },
+    speed: { displaySpeedKmhText: speed, unitText: 'km/h', isEstimated: false },
+    segment: {
+      previousStationName: '海老名',
+      nextStationName: '座間',
+      progressRatio: 0.5,
+      distanceToNextText: '次まで 1km',
+    },
+    footer: { leftInfo: '上り', statusRight: 'GPS' },
+    statusMode: 'GPS',
+    rawFormattedText: speed,
+    timestampMs: 1000,
+  };
+}
+
+/** Drain microtasks + any queued bridge flushes. */
+async function flushBridge(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/** Observe a promise without hanging the test when it never settles. */
+async function settle(promise: Promise<unknown>): Promise<'resolved' | 'pending'> {
+  return Promise.race([
+    promise.then(() => 'resolved' as const),
+    new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 25)),
+  ]);
+}
+
+describe('HybridEvenG2Adapter foreground recovery failure', () => {
+  let hubEvent: ((event: any) => void) | undefined;
+  let warn: ReturnType<typeof vi.spyOn>;
+  let now = 1000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    now = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(true);
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
+    sdk.bridge.shutDownPageContainer.mockResolvedValue(true);
+    sdk.bridge.onEvenHubEvent.mockImplementation((callback) => {
+      hubEvent = callback;
+      return vi.fn();
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function connectedAdapter(): Promise<HybridEvenG2Adapter> {
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true);
+    now += 1000;
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+    return adapter;
+  }
+
+  it('transitions to disconnected when rebuildPageContainer returns false', async () => {
+    const adapter = await connectedAdapter();
+    // The waiter must be registered *before* the failure: that is the deadlock case.
+    const disconnected = adapter.waitUntilDisconnected();
+
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(false);
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_EXIT } });
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_ENTER } });
+    await flushBridge();
+
+    expect(sdk.bridge.rebuildPageContainer).toHaveBeenCalledOnce();
+    expect(await settle(disconnected)).toBe('resolved');
+    expect(adapter.isBridgeConnected()).toBe(false);
+
+    // None of the rebuild side effects took: the HUD stays off the bridge.
+    sdk.bridge.textContainerUpgrade.mockClear();
+    now += 1000;
+    await adapter.render(viewModel('88'));
+    await flushBridge();
+    expect(sdk.bridge.textContainerUpgrade).not.toHaveBeenCalled();
+  });
+
+  it('transitions to disconnected when rebuildPageContainer throws', async () => {
+    const adapter = await connectedAdapter();
+    const disconnected = adapter.waitUntilDisconnected();
+
+    const rebuildError = new Error('native rebuild exploded');
+    sdk.bridge.rebuildPageContainer.mockRejectedValue(rebuildError);
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_EXIT } });
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_ENTER } });
+    await flushBridge();
+
+    expect(await settle(disconnected)).toBe('resolved');
+    expect(adapter.isBridgeConnected()).toBe(false);
+    expect(warn).toHaveBeenCalledWith('[EvenG2Adapter] Page recovery failed:', rebuildError);
+    // A late foreground event must not resurrect the dead session.
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_ENTER } });
+    await flushBridge();
+    expect(sdk.bridge.rebuildPageContainer).toHaveBeenCalledOnce();
+    expect(adapter.isBridgeConnected()).toBe(false);
+  });
+
+  it('reconnects cleanly after a failed recovery', async () => {
+    const adapter = await connectedAdapter();
+    const disconnected = adapter.waitUntilDisconnected();
+
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(false);
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_EXIT } });
+    hubEvent?.({ sysEvent: { eventType: FOREGROUND_ENTER } });
+    await flushBridge();
+    expect(await settle(disconnected)).toBe('resolved');
+
+    // AppController's reconnect loop calls connect() again.
+    sdk.bridge.createStartUpPageContainer.mockClear();
+    expect(await adapter.connect()).toBe(true);
+    expect(sdk.bridge.createStartUpPageContainer).toHaveBeenCalledOnce();
+    expect(adapter.isBridgeConnected()).toBe(true);
+
+    // HUD updates reach the bridge again...
+    sdk.bridge.textContainerUpgrade.mockClear();
+    now += 1000;
+    await adapter.render(viewModel('95', '中央線'));
+    await flushBridge();
+    expect(sdk.bridge.textContainerUpgrade).toHaveBeenCalledWith(
+      expect.objectContaining({ containerName: 'header', content: expect.stringContaining('中央線') })
+    );
+
+    // ...and a fresh waiter stays pending until the next disconnect.
+    const nextDisconnect = adapter.waitUntilDisconnected();
+    expect(await settle(nextDisconnect)).toBe('pending');
+  });
+});
+
+describe('AppController reconnect after a failed page recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('reconnects once the adapter resolves its disconnect waiter, backing off on a failed attempt', async () => {
+    let waiterCount = 0;
+    let resolveDisconnect: () => void = () => {
+      throw new Error('waitUntilDisconnected() was never awaited');
+    };
+    const connect = vi
+      .fn()
+      .mockResolvedValueOnce(true) // initial connect
+      .mockResolvedValueOnce(false) // first reconnect attempt fails -> backoff
+      .mockResolvedValue(true); // recovers afterwards
+    const adapter: EvenG2Adapter = {
+      connect,
+      render: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      getLastImageResult: () => 'none',
+      isBridgeConnected: () => true,
+      waitUntilDisconnected: () =>
+        new Promise<void>((resolve) => {
+          waiterCount++;
+          resolveDisconnect = resolve;
+        }),
+    };
+
+    const controller = new AppController(
+      { start: vi.fn(), stop: vi.fn() },
+      { match: vi.fn().mockResolvedValue(null), reset: vi.fn() } as any,
+      { update: vi.fn(), reset: vi.fn() } as any,
+      {} as any,
+      adapter,
+      new EstimationLogger(),
+      // Park the HUD render tick so only the reconnect loop drives this test.
+      { ...DEFAULT_TRACKING_CONFIG, hudRefreshMs: 1_000_000 }
+    );
+
+    await controller.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    // The loop parks on the adapter's disconnect waiter instead of reconnecting.
+    expect(waiterCount).toBe(1);
+
+    // Failed foreground recovery resolves the disconnect waiter.
+    resolveDisconnect();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    // That attempt failed, so the third one only lands after the backoff delay.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(connect).toHaveBeenCalledTimes(3);
+
+    await controller.stop();
+  });
+});


### PR DESCRIPTION
Closes #17

## 問題

`recoverPage()` の失敗パスは `pageReady = false` にするだけで `isConnected` が true のまま残っていた。そのため `waitUntilDisconnected()` が解決されず、AppController の再接続ループが待機し続けて HUD が停止していた。

## 対応

- rebuild が `false` を返した場合／throw した場合に `markDisconnected()` を呼び、disconnect waiter を確実に解決して切断状態へ遷移する
- 失敗ハンドリングを rebuild ステップに限定。rebuild 成功後の画像送信は `connect()` と同じくソフト失敗のままとし、正常なページを落とさない
- 切断後の FOREGROUND_ENTER は無視し、キュー待ち中／rebuild 中に切断が入った場合も接続状態を再確認する（再接続ループが所有するセッションを古いイベントが復活させないため）
- `connect()` の失敗パス 2 か所も `markDisconnected()` 経由に統一。現在の呼び出し順では no-op（waiter は connect 成功後にしか登録されない）だが、再入時にも waiter が取り残されない不変条件になる

`src/app/app-controller.ts` は変更していない。再接続の確認はスタブアダプタで AppController を駆動するテストで行っている。

## テスト

新規 `tests/even-g2/even-g2-adapter-recovery.test.ts`:

- rebuild が false → waiter が解決し、以降の render がブリッジへ届かない
- rebuild が throw → waiter が解決し、遅れて届いた FOREGROUND_ENTER でも復活しない
- 復旧失敗後に `connect()` が成功し、HUD 更新が再開、新しい waiter は pending のまま
- AppController がスタブアダプタの waiter 解決後に即再接続し、その試行が失敗した場合は backoff 後に再試行する

修正を stash して確認したところ、アダプタ側の 3 件は修正前に失敗する。4 件目（AppController）は修正前後どちらでも通る characterization test で、`app-controller.ts` を触らずに「AppControllerが再接続へ進む」条件を担保するためのもの。

## 検証

- `pnpm test` → Test Files 20 passed (20) / Tests 68 passed (68)
- `npx tsc --noEmit` → 出力なし
- `pnpm lint` → 出力なし

## 挙動の変化

復旧失敗後は `recoverPage()` が早期 return し、復旧は再接続ループが所有する。結果としてバックグラウンド中は最大 10 秒間隔で `connect()` 再試行が走る（サイレントに固まる代わりのトレードオフ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk