### PR TITLE
fix: Location Providerの開始停止と切替を直列化する

### DIFF
--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -27,6 +27,16 @@ export class AppController {
   private renderTickInFlight = false;
   private renderTickPending = false;
 
+  // Location provider lifecycle serialization.
+  // - `locationLifecycle` is a never-rejecting tail promise used as a FIFO queue so that
+  //   start/stop/switch never overlap (a new provider is only started once the previous
+  //   provider has fully stopped).
+  // - `locationGeneration` is bumped whenever the active provider is invalidated, so
+  //   notifications arriving late from an outgoing provider are ignored.
+  private locationLifecycle: Promise<void> = Promise.resolve();
+  private locationGeneration = 0;
+  private activeLocationProvider: LocationProvider | null = null;
+
   constructor(
     private locationProvider: LocationProvider,
     private mapMatcher: MapMatcher,
@@ -91,16 +101,19 @@ export class AppController {
     if (this.isRunning) return;
     this.isRunning = true;
 
-    // 1. Immediately start location provider & GPS updates (non-blocking)
-    this.startLocationProvider(this.locationProvider);
-
-    // 2. Immediately start HUD render timer (Web Viewport DOM / Local Preview)
+    // 1. Immediately start HUD render timer (Web Viewport DOM / Local Preview)
     this.renderTimerId = setInterval(() => {
       void this.runRenderTick();
     }, this.config.hudRefreshMs);
 
-    // 3. Connect Even G2 in background with persistent auto-reconnect
+    // 2. Connect Even G2 in background with persistent auto-reconnect
     void this.connectEvenG2InBackground();
+
+    // 3. Start the location provider through the lifecycle queue so start/stop/switch
+    //    never interleave. Provider startup failures are reported through
+    //    onLocationError and leave the controller running (HUD keeps rendering and
+    //    falls back to GPS_UNAVAILABLE).
+    await this.enqueueLocationLifecycle(() => this.activateLocationProvider(this.locationProvider));
   }
 
   private async connectEvenG2InBackground(): Promise<void> {
@@ -147,38 +160,108 @@ export class AppController {
     if (!this.isRunning) return;
     this.isRunning = false;
 
-    await this.locationProvider.stop();
+    // Ignore any notification still in flight from the running provider.
+    this.locationGeneration++;
+
     if (this.renderTimerId) {
       clearInterval(this.renderTimerId);
       this.renderTimerId = null;
     }
+
+    // Wait for any queued start/switch to settle before stopping the provider.
+    await this.enqueueLocationLifecycle(() => this.deactivateLocationProvider());
     await this.evenG2Adapter.clear();
   }
 
-  public switchLocationProvider(newProvider: LocationProvider): void {
-    void this.locationProvider.stop();
-    this.speedEstimator.reset();
-    this.journeyEstimator.reset();
-    this.mapMatcher.reset();
-
+  /**
+   * Replaces the active location provider. The returned promise resolves once the
+   * previous provider has been stopped and the new one has been started (or has
+   * failed to start). Consecutive calls are serialized: only the most recently
+   * requested provider is ever started.
+   */
+  public switchLocationProvider(newProvider: LocationProvider): Promise<void> {
+    // Invalidate the outgoing provider immediately so its late notifications are
+    // dropped even before its stop() resolves.
+    this.locationGeneration++;
     this.locationProvider = newProvider;
-    if (this.isRunning) {
-      this.startLocationProvider(this.locationProvider);
+    this.resetEstimationState();
+
+    return this.enqueueLocationLifecycle(async () => {
+      await this.deactivateLocationProvider();
+      if (!this.isRunning) return;
+      // A newer switch superseded this one while we were stopping: skip straight to it.
+      if (this.locationProvider !== newProvider) return;
+      await this.activateLocationProvider(newProvider);
+    });
+  }
+
+  /** Serializes location provider lifecycle work (start / stop / switch) into a FIFO queue. */
+  private enqueueLocationLifecycle(task: () => Promise<void>): Promise<void> {
+    const run = this.locationLifecycle.then(task);
+    // Keep the queue tail non-rejecting so one failure cannot poison later transitions
+    // nor surface as an unhandled rejection.
+    this.locationLifecycle = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async activateLocationProvider(provider: LocationProvider): Promise<void> {
+    if (!this.isRunning) return;
+
+    const generation = ++this.locationGeneration;
+    this.activeLocationProvider = provider;
+    try {
+      await provider.start(
+        (sample) => {
+          if (generation !== this.locationGeneration) return;
+          void this.onLocationUpdate(sample).catch((error) => {
+            console.warn('[AppController] Location update failed:', error);
+          });
+        },
+        (err) => {
+          if (generation !== this.locationGeneration) return;
+          this.onLocationError(err);
+        }
+      );
+    } catch (error) {
+      // Recover to a consistent state: no provider is considered active, the partially
+      // started provider is torn down and stale estimation state is dropped so the HUD
+      // reports GPS_UNAVAILABLE instead of freezing on pre-failure values.
+      this.locationGeneration++;
+      this.activeLocationProvider = null;
+      await this.stopProviderSafely(provider);
+      this.resetEstimationState();
+      this.onLocationError(this.toLocationProviderError(error));
     }
   }
 
-  private startLocationProvider(provider: LocationProvider): void {
+  private async deactivateLocationProvider(): Promise<void> {
+    const provider = this.activeLocationProvider;
+    this.activeLocationProvider = null;
+    if (!provider) return;
+    this.locationGeneration++;
+    await this.stopProviderSafely(provider);
+  }
+
+  private async stopProviderSafely(provider: LocationProvider): Promise<void> {
     try {
-      const startResult = provider.start(
-        (sample) => void this.onLocationUpdate(sample),
-        (err) => this.onLocationError(err)
-      );
-      if (startResult) {
-        void startResult.catch((error) => this.onLocationError(this.toLocationProviderError(error)));
-      }
+      await provider.stop();
     } catch (error) {
-      this.onLocationError(this.toLocationProviderError(error));
+      console.warn(
+        '[AppController] Location provider stop notice:',
+        error instanceof Error ? error.message : String(error)
+      );
     }
+  }
+
+  private resetEstimationState(): void {
+    this.speedEstimator.reset();
+    this.journeyEstimator.reset();
+    this.mapMatcher.reset();
+    this.latestSample = null;
+    this.currentMatch = null;
   }
 
   private toLocationProviderError(error: unknown): { message: string } {

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -268,7 +268,23 @@ export class AppController {
     return { message: error instanceof Error ? error.message : String(error) };
   }
 
+  /**
+   * Processes one location sample. Results are computed into locals and only committed
+   * while the sample's provider generation is still the current one: a switch/stop that
+   * lands while map matching or journey estimation is awaited must not be able to write
+   * stale state (or mutate the estimators) once it resolves.
+   *
+   * Called directly (without an active provider) the captured generation is the current
+   * one, so the sample is always treated as live.
+   */
   public async onLocationUpdate(sample: LocationSample): Promise<void> {
+    // Captured synchronously at invocation: the provider callback checks the generation
+    // and calls this in the same synchronous block, so both observe the same value.
+    const generation = this.locationGeneration;
+
+    // Safe to publish immediately: this runs before any await, so a later switch's
+    // resetEstimationState() clears it rather than being overwritten by it. Keeping it
+    // here avoids delaying HUD data by a full map-matching round trip on the normal path.
     this.latestSample = sample;
 
     // 1. NON-BLOCKING: Trigger background coverage fetch (do not await)
@@ -277,15 +293,18 @@ export class AppController {
     });
 
     // 2. Perform map matching with currently available segments
-    this.currentMatch = await this.mapMatcher.match(sample);
+    const match = await this.mapMatcher.match(sample);
+    // The provider was switched/stopped while matching: drop the sample before it can
+    // mutate the (already reset) speed estimator.
+    if (generation !== this.locationGeneration) return;
 
     // 3. Compute track distance progress if match is valid
     let trackProgress: { distanceAlongPolylineMeters: number; timestampMs: number } | undefined;
-    if (this.currentMatch) {
+    if (match) {
       const closest = findClosestPointOnPolyline(
         sample.latitude,
         sample.longitude,
-        this.currentMatch.selectedSegment.coordinates
+        match.selectedSegment.coordinates
       );
       trackProgress = {
         distanceAlongPolylineMeters: closest.distanceAlongPolylineMeters,
@@ -294,15 +313,21 @@ export class AppController {
     }
 
     // 4. Immediate Speed Estimation (Un-blocked by network)
-    this.currentFullSpeedState = this.speedEstimator.update(sample, this.currentMatch, trackProgress);
+    const speedState = this.speedEstimator.update(sample, match, trackProgress);
 
     // 5. Estimate journey state & recover status if valid GPS returned
-    this.currentJourney = await this.journeyEstimator.update(
+    const journey = await this.journeyEstimator.update(
       sample,
-      this.currentMatch,
-      this.currentFullSpeedState,
-      this.currentFullSpeedState.navState
+      match,
+      speedState,
+      speedState.navState
     );
+    // Last checkpoint before publishing: a switch/stop during journey estimation wins.
+    if (generation !== this.locationGeneration) return;
+
+    this.currentMatch = match;
+    this.currentFullSpeedState = speedState;
+    this.currentJourney = journey;
     this.speedEstimator.getNavStateEstimator().setDirection(
       this.toNavigationDirection(this.currentJourney.direction)
     );

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -12,6 +12,75 @@ import { LocationProvider } from '../infrastructure/geolocation/browser-location
 import { EstimationLogEntry, EstimationLogger } from '../infrastructure/logging/logger';
 import { findClosestPointOnPolyline } from '../domain/geo/polyline';
 
+/**
+ * Upper bound for a single location provider `start()` / `stop()` call.
+ *
+ * These calls run inside the lifecycle FIFO queue, so one that never settles would
+ * never release the queue tail and would wedge every later start/stop/switch. The
+ * providers can genuinely park forever: `EvenAppLocationProvider.start()` awaits the
+ * SDK's `waitForEvenAppBridge()`, which resolves on an `evenAppBridgeReady` event and
+ * exposes no timeout of its own. Ten seconds is generous next to the provider's own
+ * 5s `getAppLocation` bound while still failing fast enough that the user can reach
+ * the demo/replay buttons.
+ */
+export const DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS = 10_000;
+
+/**
+ * Largest delay `setTimeout` can actually hold (2^31 - 1 ms, ~24.9 days).
+ *
+ * Anything above it overflows the 32-bit timer and fires after ~1ms instead, so a
+ * caller asking for a very long bound would silently get an instant one.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/** Raised when a provider lifecycle call exceeds its bound and is abandoned. */
+export class LocationLifecycleTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LocationLifecycleTimeoutError';
+  }
+}
+
+export interface AppControllerOptions {
+  /**
+   * Overrides {@link DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS}.
+   *
+   * Must be a finite, positive number of milliseconds. Anything else falls back to
+   * the default; values beyond {@link MAX_TIMER_DELAY_MS} are clamped.
+   */
+  locationLifecycleTimeoutMs?: number;
+}
+
+/**
+ * Resolves the configured lifecycle bound to a delay `setTimeout` can honour.
+ *
+ * `setTimeout` never rejects a bad delay, it quietly substitutes 1ms: `Infinity`,
+ * `NaN` and negatives all fire on the next tick. Passing one through would not
+ * restore the unbounded wait this bound exists to prevent — it causes the opposite
+ * failure, every provider start being abandoned before it can succeed.
+ */
+function resolveLocationLifecycleTimeoutMs(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    console.warn(
+      `[AppController] Ignoring invalid locationLifecycleTimeoutMs (${value}); ` +
+        `falling back to ${DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS}ms.`
+    );
+    return DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS;
+  }
+
+  if (value > MAX_TIMER_DELAY_MS) {
+    console.warn(
+      `[AppController] Clamping locationLifecycleTimeoutMs (${value}) to ` +
+        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+
+  return value;
+}
+
 export class AppController {
   private latestSample: LocationSample | null = null;
   private currentFullSpeedState: FullSpeedState;
@@ -30,12 +99,14 @@ export class AppController {
   // Location provider lifecycle serialization.
   // - `locationLifecycle` is a never-rejecting tail promise used as a FIFO queue so that
   //   start/stop/switch never overlap (a new provider is only started once the previous
-  //   provider has fully stopped).
+  //   provider has fully stopped). Every provider call inside it is time-bounded so a
+  //   provider that never settles cannot hold the tail and wedge all later transitions.
   // - `locationGeneration` is bumped whenever the active provider is invalidated, so
   //   notifications arriving late from an outgoing provider are ignored.
   private locationLifecycle: Promise<void> = Promise.resolve();
   private locationGeneration = 0;
   private activeLocationProvider: LocationProvider | null = null;
+  private readonly locationLifecycleTimeoutMs: number;
 
   constructor(
     private locationProvider: LocationProvider,
@@ -44,8 +115,10 @@ export class AppController {
     private repository: RailwayDataRepository,
     private evenG2Adapter: EvenG2Adapter,
     private logger: EstimationLogger,
-    private config: TrackingConfig
+    private config: TrackingConfig,
+    options: AppControllerOptions = {}
   ) {
+    this.locationLifecycleTimeoutMs = resolveLocationLifecycleTimeoutMs(options.locationLifecycleTimeoutMs);
     this.speedEstimator = new SpeedEstimator(config);
     this.hudRenderer = new HudRenderer();
 
@@ -207,23 +280,69 @@ export class AppController {
     return run;
   }
 
+  /**
+   * Runs one provider lifecycle call under {@link locationLifecycleTimeoutMs}.
+   *
+   * Every start/stop happens inside the FIFO queue, so an unbounded call is not just
+   * slow — it holds the queue tail forever and silently bricks the whole location
+   * subsystem (later switches never run, stop() never reaches evenG2Adapter.clear()).
+   * Bounding each call turns that permanent stall into an ordinary failure the
+   * existing recovery path already handles.
+   *
+   * The abandoned call keeps running: `LocationProvider` has no abort protocol, so a
+   * `start()` that eventually succeeds leaves a provider nobody will stop. Its
+   * callbacks are gated on the generation captured before the call, which the
+   * timeout path invalidates, so it can no longer write state — it just idles.
+   */
+  private async runProviderCall(description: string, call: () => void | Promise<void>): Promise<void> {
+    // Normalizes the interface's `void | Promise<void>` return so synchronous
+    // providers (BrowserLocationProvider) take exactly the same path.
+    const pending = Promise.resolve(call());
+    // Promise.race already tolerates a late settle, but keep the abandoned call
+    // handled so a post-timeout rejection cannot surface as an unhandled rejection.
+    void pending.catch(() => {});
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new LocationLifecycleTimeoutError(
+              `${description} timed out after ${this.locationLifecycleTimeoutMs}ms`
+            )
+          ),
+        this.locationLifecycleTimeoutMs
+      );
+    });
+
+    try {
+      await Promise.race([pending, expiry]);
+    } finally {
+      // Also covers the synchronous-provider path, which resolves before the timer
+      // ever fires and would otherwise keep a live handle for the full bound.
+      clearTimeout(timer);
+    }
+  }
+
   private async activateLocationProvider(provider: LocationProvider): Promise<void> {
     if (!this.isRunning) return;
 
     const generation = ++this.locationGeneration;
     this.activeLocationProvider = provider;
     try {
-      await provider.start(
-        (sample) => {
-          if (generation !== this.locationGeneration) return;
-          void this.onLocationUpdate(sample).catch((error) => {
-            console.warn('[AppController] Location update failed:', error);
-          });
-        },
-        (err) => {
-          if (generation !== this.locationGeneration) return;
-          this.onLocationError(err);
-        }
+      await this.runProviderCall('Location provider start()', () =>
+        provider.start(
+          (sample) => {
+            if (generation !== this.locationGeneration) return;
+            void this.onLocationUpdate(sample).catch((error) => {
+              console.warn('[AppController] Location update failed:', error);
+            });
+          },
+          (err) => {
+            if (generation !== this.locationGeneration) return;
+            this.onLocationError(err);
+          }
+        )
       );
     } catch (error) {
       // Recover to a consistent state: no provider is considered active, the partially
@@ -247,8 +366,14 @@ export class AppController {
 
   private async stopProviderSafely(provider: LocationProvider): Promise<void> {
     try {
-      await provider.stop();
+      await this.runProviderCall('Location provider stop()', () => provider.stop());
     } catch (error) {
+      if (error instanceof LocationLifecycleTimeoutError) {
+        // Reported separately from a stop() rejection: the call is still running and
+        // the provider may never actually release its subscription.
+        console.warn('[AppController] Location provider stop abandoned:', error.message);
+        return;
+      }
       console.warn(
         '[AppController] Location provider stop notice:',
         error instanceof Error ? error.message : String(error)

--- a/tests/app/app-controller-provider-lifecycle.test.ts
+++ b/tests/app/app-controller-provider-lifecycle.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppController } from '../../src/app/app-controller';
+import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
+import { RailwayDataRepository } from '../../src/domain/railway/repository';
+import { RailwayLine, Station, TrackSegment } from '../../src/domain/models/railway';
+import { LocationSample } from '../../src/domain/models/location';
+import { LocationProvider, LocationProviderError } from '../../src/infrastructure/geolocation/browser-location-provider';
+import { EstimationLogger } from '../../src/infrastructure/logging/logger';
+
+const line: RailwayLine = { id: 'line', operatorId: 'op', name: 'Test Line' };
+const stations: Station[] = [
+  { id: 'a', lineId: 'line', name: 'A', sequence: 1, latitude: 35, longitude: 139 },
+  { id: 'b', lineId: 'line', name: 'B', sequence: 2, latitude: 35.01, longitude: 139 },
+];
+const segment: TrackSegment = {
+  id: 'ab', lineId: 'line', routeId: 'route-line-main', fromStationId: 'a', toStationId: 'b',
+  coordinates: [[35, 139], [35.01, 139]], lengthMeters: 1112, startOffsetMeters: 0,
+};
+
+const repository: RailwayDataRepository = {
+  ensureCoverageAround: async () => ({ state: 'bundled', loadedTileCount: 0 }),
+  findSegmentsNear: async () => [segment],
+  getLine: async () => line,
+  getRoute: async () => undefined,
+  getStation: async (id) => stations.find((station) => station.id === id),
+  getStationsByLine: async () => stations,
+  getSegmentsByRoute: async () => [segment],
+  getDataState: () => 'bundled',
+};
+
+function sample(timestampMs: number): LocationSample {
+  return {
+    latitude: 35.005,
+    longitude: 139,
+    accuracyMeters: 5,
+    speedMps: 10,
+    headingDegrees: 0,
+    timestampMs,
+  };
+}
+
+/** Flushes pending microtasks and timer-0 callbacks. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+type Deferred = { promise: Promise<void>; resolve: () => void };
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Test double that records lifecycle calls and exposes the callbacks it received. */
+class FakeLocationProvider implements LocationProvider {
+  public startCalls = 0;
+  public stopCalls = 0;
+  public onLocation: ((sample: LocationSample) => void) | null = null;
+  public onError: ((err: LocationProviderError) => void) | null = null;
+
+  constructor(
+    private readonly hooks: {
+      startResult?: () => Promise<void>;
+      stopResult?: () => Promise<void>;
+    } = {}
+  ) {}
+
+  public async start(
+    onLocation: (sample: LocationSample) => void,
+    onError?: (err: LocationProviderError) => void
+  ): Promise<void> {
+    this.startCalls++;
+    this.onLocation = onLocation;
+    this.onError = onError ?? null;
+    if (this.hooks.startResult) await this.hooks.startResult();
+  }
+
+  public async stop(): Promise<void> {
+    this.stopCalls++;
+    if (this.hooks.stopResult) await this.hooks.stopResult();
+  }
+}
+
+function createController(provider: LocationProvider, mapMatcher = { match: vi.fn().mockResolvedValue(null), reset: vi.fn() }) {
+  const controller = new AppController(
+    provider,
+    mapMatcher as any,
+    { update: vi.fn().mockResolvedValue({
+      line: null,
+      direction: 'UNKNOWN',
+      directionName: null,
+      previousStation: null,
+      nextStation: null,
+      distanceToNextStationMeters: null,
+      progressRatio: null,
+      confidence: 0,
+      status: 'INITIALIZING',
+    }), reset: vi.fn() } as any,
+    repository,
+    // No waitUntilDisconnected: the background connect loop exits after one connect.
+    { connect: async () => true, render: vi.fn().mockResolvedValue(undefined), clear: vi.fn().mockResolvedValue(undefined), getLastImageResult: () => 'none' },
+    new EstimationLogger(),
+    DEFAULT_TRACKING_CONFIG
+  );
+  return { controller, mapMatcher };
+}
+
+describe('AppController location provider lifecycle', () => {
+  it('starts the new provider only after a slow stop of the previous one resolves', async () => {
+    const slowStop = deferred();
+    const initial = new FakeLocationProvider({ stopResult: () => slowStop.promise });
+    const replacement = new FakeLocationProvider();
+    const { controller } = createController(initial);
+
+    await controller.start();
+    expect(initial.startCalls).toBe(1);
+
+    const switching = controller.switchLocationProvider(replacement);
+    await flush();
+
+    // The outgoing provider has been asked to stop but has not finished yet,
+    // so the replacement must not be started (no overlapping providers).
+    expect(initial.stopCalls).toBe(1);
+    expect(replacement.startCalls).toBe(0);
+
+    slowStop.resolve();
+    await switching;
+
+    expect(replacement.startCalls).toBe(1);
+    expect(initial.stopCalls).toBe(1);
+
+    await controller.stop();
+    expect(replacement.stopCalls).toBe(1);
+  });
+
+  it('ignores location notifications emitted by the outgoing provider after a switch', async () => {
+    const slowStop = deferred();
+    const initial = new FakeLocationProvider({ stopResult: () => slowStop.promise });
+    const replacement = new FakeLocationProvider();
+    const mapMatcher = { match: vi.fn().mockResolvedValue(null), reset: vi.fn() };
+    const { controller } = createController(initial, mapMatcher);
+
+    await controller.start();
+    initial.onLocation?.(sample(1_000));
+    await flush();
+    expect(mapMatcher.match).toHaveBeenCalledTimes(1);
+
+    const switching = controller.switchLocationProvider(replacement);
+    // Late notification from the provider that is being torn down.
+    initial.onLocation?.(sample(2_000));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    initial.onError?.({ message: 'stale provider error' });
+    await flush();
+
+    expect(mapMatcher.match).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalledWith('[AppController] Location error:', 'stale provider error');
+
+    slowStop.resolve();
+    await switching;
+
+    // The new provider's notifications are processed normally.
+    replacement.onLocation?.(sample(3_000));
+    await flush();
+    expect(mapMatcher.match).toHaveBeenCalledTimes(2);
+    expect((controller as any).latestSample?.timestampMs).toBe(3_000);
+
+    warn.mockRestore();
+    await controller.stop();
+  });
+
+  it('recovers to a consistent state when the provider fails to start', async () => {
+    const failing = new FakeLocationProvider({
+      startResult: () => Promise.reject(new Error('provider start failed')),
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { controller, mapMatcher } = createController(failing);
+
+    await controller.start();
+
+    expect(warn).toHaveBeenCalledWith('[AppController] Location error:', 'provider start failed');
+    // The half-started provider is torn down and no provider is left marked active.
+    expect(failing.stopCalls).toBe(1);
+    expect((controller as any).activeLocationProvider).toBeNull();
+    // Estimation state is reset so the HUD falls back to a GPS-unavailable view.
+    expect((controller as any).latestSample).toBeNull();
+    expect((controller as any).currentMatch).toBeNull();
+    expect(mapMatcher.reset).toHaveBeenCalled();
+
+    await (controller as any).onRenderTick();
+    expect((controller as any).currentJourney.status).toBe('GPS_UNAVAILABLE');
+
+    // Late callbacks from the failed provider must not be processed.
+    failing.onLocation?.(sample(1_000));
+    await flush();
+    expect((controller as any).latestSample).toBeNull();
+
+    // The controller keeps running and can still adopt a working provider.
+    const healthy = new FakeLocationProvider();
+    await controller.switchLocationProvider(healthy);
+    expect(healthy.startCalls).toBe(1);
+    // The failed provider is not stopped twice.
+    expect(failing.stopCalls).toBe(1);
+
+    await controller.stop();
+    warn.mockRestore();
+  });
+
+  it('serializes rapid consecutive switches and only starts the final provider', async () => {
+    const slowStop = deferred();
+    const initial = new FakeLocationProvider({ stopResult: () => slowStop.promise });
+    const intermediate = new FakeLocationProvider();
+    const final = new FakeLocationProvider();
+    const { controller } = createController(initial);
+
+    await controller.start();
+
+    const first = controller.switchLocationProvider(intermediate);
+    const second = controller.switchLocationProvider(final);
+    slowStop.resolve();
+    await Promise.all([first, second]);
+
+    expect(initial.stopCalls).toBe(1);
+    expect(intermediate.startCalls).toBe(0);
+    expect(intermediate.stopCalls).toBe(0);
+    expect(final.startCalls).toBe(1);
+    expect((controller as any).activeLocationProvider).toBe(final);
+
+    await controller.stop();
+    expect(final.stopCalls).toBe(1);
+  });
+
+  it('does not start a provider when switching while the controller is stopped', async () => {
+    const initial = new FakeLocationProvider();
+    const replacement = new FakeLocationProvider();
+    const { controller } = createController(initial);
+
+    await controller.start();
+    await controller.stop();
+    expect(initial.stopCalls).toBe(1);
+
+    await controller.switchLocationProvider(replacement);
+    expect(replacement.startCalls).toBe(0);
+  });
+
+  it('reports a provider stop failure without an unhandled rejection', async () => {
+    const initial = new FakeLocationProvider({
+      stopResult: () => Promise.reject(new Error('stop failed')),
+    });
+    const replacement = new FakeLocationProvider();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { controller } = createController(initial);
+
+    await controller.start();
+    await controller.switchLocationProvider(replacement);
+
+    expect(warn).toHaveBeenCalledWith('[AppController] Location provider stop notice:', 'stop failed');
+    expect(replacement.startCalls).toBe(1);
+
+    warn.mockRestore();
+    await controller.stop();
+  });
+});

--- a/tests/app/app-controller-provider-lifecycle.test.ts
+++ b/tests/app/app-controller-provider-lifecycle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AppController } from '../../src/app/app-controller';
+import {
+  AppController,
+  AppControllerOptions,
+  DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS,
+} from '../../src/app/app-controller';
 import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
 import { RailwayDataRepository } from '../../src/domain/railway/repository';
 import { RailwayLine, RouteMatch, Station, TrackSegment } from '../../src/domain/models/railway';
@@ -57,6 +61,27 @@ function deferred(): Deferred {
   return { promise, resolve };
 }
 
+/** A promise that never settles — models a provider call that parks forever. */
+function never(): Promise<void> {
+  return new Promise<void>(() => {});
+}
+
+/**
+ * Resolves to true if `promise` settles within `ms`, false otherwise.
+ *
+ * Used so a wedged lifecycle queue fails as an explicit assertion instead of an
+ * opaque vitest timeout.
+ */
+function settlesWithin(promise: Promise<unknown>, ms: number): Promise<boolean> {
+  return Promise.race([
+    promise.then(
+      () => true,
+      () => true
+    ),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms)),
+  ]);
+}
+
 /** Test double that records lifecycle calls and exposes the callbacks it received. */
 class FakeLocationProvider implements LocationProvider {
   public startCalls = 0;
@@ -107,19 +132,27 @@ function createJourneyEstimator() {
 function createController(
   provider: LocationProvider,
   mapMatcher = { match: vi.fn().mockResolvedValue(null), reset: vi.fn() },
-  journeyEstimator = createJourneyEstimator()
+  journeyEstimator = createJourneyEstimator(),
+  options: AppControllerOptions = {}
 ) {
+  // No waitUntilDisconnected: the background connect loop exits after one connect.
+  const evenG2Adapter = {
+    connect: async () => true,
+    render: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    getLastImageResult: () => 'none',
+  };
   const controller = new AppController(
     provider,
     mapMatcher as any,
     journeyEstimator as any,
     repository,
-    // No waitUntilDisconnected: the background connect loop exits after one connect.
-    { connect: async () => true, render: vi.fn().mockResolvedValue(undefined), clear: vi.fn().mockResolvedValue(undefined), getLastImageResult: () => 'none' },
+    evenG2Adapter,
     new EstimationLogger(),
-    DEFAULT_TRACKING_CONFIG
+    DEFAULT_TRACKING_CONFIG,
+    options
   );
-  return { controller, mapMatcher, journeyEstimator };
+  return { controller, mapMatcher, journeyEstimator, evenG2Adapter };
 }
 
 describe('AppController location provider lifecycle', () => {
@@ -312,6 +345,94 @@ describe('AppController location provider lifecycle', () => {
 
     expect(warn).toHaveBeenCalledWith('[AppController] Location provider stop notice:', 'stop failed');
     expect(replacement.startCalls).toBe(1);
+
+    warn.mockRestore();
+    await controller.stop();
+  });
+
+  it('keeps switching and stopping possible when a provider start() never settles', async () => {
+    // `EvenAppLocationProvider.start()` awaits the SDK's `waitForEvenAppBridge()`,
+    // which has no timeout of its own: a bridge that never signals ready parks the
+    // call forever. Without a bound it would hold the lifecycle queue's tail and
+    // every later transition would be queued behind it indefinitely.
+    const hanging = new FakeLocationProvider({ startResult: never });
+    const replacement = new FakeLocationProvider();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { controller, evenG2Adapter } = createController(
+      hanging,
+      undefined,
+      undefined,
+      { locationLifecycleTimeoutMs: 20 }
+    );
+
+    expect(await settlesWithin(controller.start(), 500)).toBe(true);
+    expect(hanging.startCalls).toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      '[AppController] Location error:',
+      'Location provider start() timed out after 20ms'
+    );
+    // The abandoned provider is treated as a start failure, so nothing is left active.
+    expect((controller as any).activeLocationProvider).toBeNull();
+
+    // The user can still reach the demo/replay providers.
+    const switching = controller.switchLocationProvider(replacement);
+    expect(await settlesWithin(switching, 500)).toBe(true);
+    expect(replacement.startCalls).toBe(1);
+
+    // ...and stop() still runs to completion, so the glass gets cleared.
+    const stopping = controller.stop();
+    expect(await settlesWithin(stopping, 500)).toBe(true);
+    expect(replacement.stopCalls).toBe(1);
+    expect(evenG2Adapter.clear).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  it('keeps switching and stopping possible when a provider stop() never settles', async () => {
+    // The bound has to cover stop() too: the start-failure recovery path and every
+    // switch await it, so a stop() that parks forever wedges the queue just as badly.
+    const hanging = new FakeLocationProvider({ stopResult: never });
+    const replacement = new FakeLocationProvider();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { controller, evenG2Adapter } = createController(
+      hanging,
+      undefined,
+      undefined,
+      { locationLifecycleTimeoutMs: 20 }
+    );
+
+    await controller.start();
+    expect(hanging.startCalls).toBe(1);
+
+    const switching = controller.switchLocationProvider(replacement);
+    expect(await settlesWithin(switching, 500)).toBe(true);
+    expect(hanging.stopCalls).toBe(1);
+    expect(replacement.startCalls).toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      '[AppController] Location provider stop abandoned:',
+      'Location provider stop() timed out after 20ms'
+    );
+
+    const stopping = controller.stop();
+    expect(await settlesWithin(stopping, 500)).toBe(true);
+    expect(evenG2Adapter.clear).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  it('falls back to the default bound when the configured one is unusable', async () => {
+    // setTimeout silently substitutes 1ms for Infinity/NaN/negatives, which would
+    // abandon every start instead of restoring the unbounded wait.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { controller } = createController(new FakeLocationProvider(), undefined, undefined, {
+      locationLifecycleTimeoutMs: Number.POSITIVE_INFINITY,
+    });
+
+    expect((controller as any).locationLifecycleTimeoutMs).toBe(DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS);
+    expect(warn).toHaveBeenCalledWith(
+      `[AppController] Ignoring invalid locationLifecycleTimeoutMs (Infinity); ` +
+        `falling back to ${DEFAULT_LOCATION_LIFECYCLE_TIMEOUT_MS}ms.`
+    );
 
     warn.mockRestore();
     await controller.stop();

--- a/tests/app/app-controller-provider-lifecycle.test.ts
+++ b/tests/app/app-controller-provider-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { AppController } from '../../src/app/app-controller';
 import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
 import { RailwayDataRepository } from '../../src/domain/railway/repository';
-import { RailwayLine, Station, TrackSegment } from '../../src/domain/models/railway';
+import { RailwayLine, RouteMatch, Station, TrackSegment } from '../../src/domain/models/railway';
 import { LocationSample } from '../../src/domain/models/location';
 import { LocationProvider, LocationProviderError } from '../../src/infrastructure/geolocation/browser-location-provider';
 import { EstimationLogger } from '../../src/infrastructure/logging/logger';
@@ -15,6 +15,9 @@ const stations: Station[] = [
 const segment: TrackSegment = {
   id: 'ab', lineId: 'line', routeId: 'route-line-main', fromStationId: 'a', toStationId: 'b',
   coordinates: [[35, 139], [35.01, 139]], lengthMeters: 1112, startOffsetMeters: 0,
+};
+const routeMatch: RouteMatch = {
+  selectedLine: line, selectedSegment: segment, confidence: 0.9, candidates: [], timestampMs: 0,
 };
 
 const repository: RailwayDataRepository = {
@@ -84,11 +87,9 @@ class FakeLocationProvider implements LocationProvider {
   }
 }
 
-function createController(provider: LocationProvider, mapMatcher = { match: vi.fn().mockResolvedValue(null), reset: vi.fn() }) {
-  const controller = new AppController(
-    provider,
-    mapMatcher as any,
-    { update: vi.fn().mockResolvedValue({
+function createJourneyEstimator() {
+  return {
+    update: vi.fn().mockResolvedValue({
       line: null,
       direction: 'UNKNOWN',
       directionName: null,
@@ -98,14 +99,27 @@ function createController(provider: LocationProvider, mapMatcher = { match: vi.f
       progressRatio: null,
       confidence: 0,
       status: 'INITIALIZING',
-    }), reset: vi.fn() } as any,
+    }),
+    reset: vi.fn(),
+  };
+}
+
+function createController(
+  provider: LocationProvider,
+  mapMatcher = { match: vi.fn().mockResolvedValue(null), reset: vi.fn() },
+  journeyEstimator = createJourneyEstimator()
+) {
+  const controller = new AppController(
+    provider,
+    mapMatcher as any,
+    journeyEstimator as any,
     repository,
     // No waitUntilDisconnected: the background connect loop exits after one connect.
     { connect: async () => true, render: vi.fn().mockResolvedValue(undefined), clear: vi.fn().mockResolvedValue(undefined), getLastImageResult: () => 'none' },
     new EstimationLogger(),
     DEFAULT_TRACKING_CONFIG
   );
-  return { controller, mapMatcher };
+  return { controller, mapMatcher, journeyEstimator };
 }
 
 describe('AppController location provider lifecycle', () => {
@@ -168,6 +182,46 @@ describe('AppController location provider lifecycle', () => {
     expect((controller as any).latestSample?.timestampMs).toBe(3_000);
 
     warn.mockRestore();
+    await controller.stop();
+  });
+
+  it('does not commit a location update that was still in flight when the provider was switched', async () => {
+    const initial = new FakeLocationProvider();
+    const replacement = new FakeLocationProvider();
+
+    // Map matching for the stale sample stays pending across the switch.
+    let resolveMatch!: (value: RouteMatch | null) => void;
+    const pendingMatch = new Promise<RouteMatch | null>((resolve) => {
+      resolveMatch = resolve;
+    });
+    const mapMatcher = { match: vi.fn().mockReturnValue(pendingMatch), reset: vi.fn() };
+    const { controller, journeyEstimator } = createController(initial, mapMatcher);
+
+    await controller.start();
+
+    // Accepted while `initial` is still the current generation, so the callback gate
+    // lets it through — the staleness only appears while it is awaiting map matching.
+    initial.onLocation?.(sample(1_000));
+    await flush();
+    expect(mapMatcher.match).toHaveBeenCalledTimes(1);
+    expect((controller as any).currentMatch).toBeNull();
+
+    await controller.switchLocationProvider(replacement);
+    expect(mapMatcher.reset).toHaveBeenCalled();
+    expect((controller as any).currentMatch).toBeNull();
+
+    // Map matching for the stale sample completes only now, after the switch.
+    resolveMatch(routeMatch);
+    await flush();
+
+    // It must not resurrect state the switch just cleared, nor feed the (already reset)
+    // estimators with the outgoing provider's sample.
+    expect((controller as any).currentMatch).toBeNull();
+    expect((controller as any).latestSample).toBeNull();
+    expect(
+      journeyEstimator.update.mock.calls.some((call) => call[0]?.timestampMs === 1_000)
+    ).toBe(false);
+
     await controller.stop();
   });
 

--- a/tests/app/app-controller-route-loss.test.ts
+++ b/tests/app/app-controller-route-loss.test.ts
@@ -66,8 +66,7 @@ describe('AppController route loss', () => {
     await Promise.resolve();
     expect(warn).toHaveBeenCalledWith('[AppController] Location error:', 'initial provider failed');
 
-    controller.switchLocationProvider({ start: replacementStart, stop: vi.fn() });
-    await Promise.resolve();
+    await controller.switchLocationProvider({ start: replacementStart, stop: vi.fn() });
     expect(warn).toHaveBeenCalledWith('[AppController] Location error:', 'replacement provider failed');
 
     await controller.stop();


### PR DESCRIPTION
## 背景 / Root cause

`AppController.start()` と `switchLocationProvider()` は Location Provider の `start()` / `stop()` を await せず、返された Promise の reject も処理していなかった。

- `switchLocationProvider()` は `void this.locationProvider.stop()` の直後に新 provider を同期的に start していたため、旧 provider の停止完了前に新 provider が動き出し、両方から位置通知が届く競合が発生し得た。
- 旧 provider の停止後に遅れて届く通知を無視する仕組みがなく、stale なサンプルが推定に混入し得た。
- `stop()` は `this.locationProvider`（= 切替後の新 provider）を止めており、実際に動いている provider を止めているとは限らなかった。
- provider の `start()` が失敗した場合、half-started の provider が放置され、controller / HUD の状態も一貫していなかった。

## 変更内容

- **直列化**: provider の lifecycle 処理（start / stop / switch）を FIFO キュー（reject しない tail promise）経由に統一。新 provider は旧 provider の `stop()` が resolve した後にのみ start される。
- **世代トークン**: activation ごとに generation を発行し、switch / stop 要求時に同期的に invalidate。旧 provider からの `onLocation` / `onError` 通知は破棄される。
- **start 失敗時の復旧**: half-started provider を best-effort で `stop()` し、active provider スロットを null に戻し、推定状態をリセットして HUD を `GPS_UNAVAILABLE` にフォールバックさせる。controller 自体は動作を継続し、その後の switch も正常に機能する。
- **連続切替の合流**: 切替が連続した場合、中間の provider は start されず、最後に要求された provider だけが起動する。
- `stop()` は実際に active な provider を停止し、`stop()` の例外も warn ログに集約して未処理 rejection を出さない。
- API 変更: `switchLocationProvider()` の戻り値が `void` → `Promise<void>`。`src/main.ts` は既に `void controller.switchLocationProvider(...)` で呼んでいるため変更不要。既存テスト `tests/app/app-controller-route-loss.test.ts` は1行のみ `await` を付与（構成は変更なし）。

## テスト

新規 `tests/app/app-controller-provider-lifecycle.test.ts`（6件）:

- stop が遅延している間は新 provider が start されない（重複起動なし）
- 切替後に旧 provider が出す位置通知 / エラー通知が無視される
- start 失敗時に active provider が null に戻り、half-started provider が停止され、HUD が `GPS_UNAVAILABLE` になり、その後の切替が成功する
- 連続切替で中間 provider が起動されず最終 provider のみ start される
- 停止中の切替では provider を起動しない
- `stop()` の失敗が未処理 rejection にならず warn される

## 検証

```
pnpm test    → Test Files 20 passed (20) / Tests 70 passed (70)
npx tsc --noEmit → エラーなし
pnpm lint    → eslint . --max-warnings=0 エラーなし
```

## Copilot レビュー対応

**世代チェックが in-flight な `onLocationUpdate` を止めていなかった問題** (e8e39f9)

コールバック側の世代チェックは「新しい通知の入口」しか塞げておらず、すでに `onLocationUpdate` の中で `mapMatcher.match()` / `journeyEstimator.update()` を await している処理は switch/stop の影響を受けなかった。await 中に switch が走ると `resetEstimationState()` が状態をクリアするが、その後 await が解決した継続が stale なサンプルから `currentMatch` / `currentFullSpeedState` / `currentJourney` を書き戻し、switch が消したはずの状態が復活していた。

- `onLocationUpdate` の先頭で `locationGeneration` を捕捉し、`match` / `speedState` / `journey` をローカルに計算する形へ変更。
- `mapMatcher.match()` の直後（`speedEstimator.update()` が推定器を破壊的に更新する前）と `journeyEstimator.update()` の直後の 2 箇所で世代を再チェックし、現行世代のときだけ 3 フィールドと `setDirection()` をコミットする。
- シグネチャは非変更。世代はメソッド内部で捕捉するため、直接呼び出し（既存テスト）は常に現行世代 = live として扱われる。
- `this.latestSample = sample` は先頭のまま。最初の await より前に実行されるため後続の switch の reset が勝ち、末尾へ移すと正常系で HUD 反映が 1 往復ぶん遅れるため。
- 回帰テスト追加: `does not commit a location update that was still in flight when the provider was switched`（修正前は `currentMatch` が非 null になり失敗することを確認済み）。

再検証: `pnpm test` → 20 files / 71 tests pass、`npx tsc --noEmit` / `pnpm lint` → エラーなし。

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk

