### PR TITLE
下り方向の次駅距離と進捗を方向別に整合させる (#18)

### DIFF
--- a/src/domain/railway/journey-state-estimator.ts
+++ b/src/domain/railway/journey-state-estimator.ts
@@ -5,6 +5,61 @@ import { calculateBearing, calculateHeadingDifference } from '../geo/heading';
 import { haversineDistance } from '../geo/distance';
 import { RailwayDataRepository } from './repository';
 
+const DEFAULT_SEGMENT_LENGTH_METERS = 2000;
+
+type SegmentProgress = {
+  distanceToNextStationMeters: number;
+  progressRatio: number;
+};
+
+/**
+ * DOWN側の別名(DIRECTION_B)も含めて「下り方向かどうか」を判定する。
+ * 駅の割り当て・距離計算・方向名がすべて同じ判定を使うようにするためのヘルパー。
+ */
+export function isDownDirection(direction: TravelDirection): boolean {
+  return direction === 'DOWN' || direction === 'DIRECTION_B';
+}
+
+/**
+ * UP側の別名(DIRECTION_A)も含めて「上り方向かどうか」を判定する。
+ */
+export function isUpDirection(direction: TravelDirection): boolean {
+  return direction === 'UP' || direction === 'DIRECTION_A';
+}
+
+/**
+ * 現在セグメント内の走行位置から、次駅までの距離と進捗率を方向別に算出する。
+ *
+ * - UP  : セグメント終点(toStation)へ向かうため 残距離 = segmentEnd - trackPosition
+ * - DOWN: セグメント始点(fromStation)へ向かうため 残距離 = trackPosition - segmentStart
+ *
+ * trackPosition がセグメント外(手前 / 行き過ぎ)にある場合でも、
+ * 距離は [0, segmentLength]、進捗率は [0, 1] にclampする。
+ * 距離と進捗率は同じセグメント長を基準に導出するため、常に整合する。
+ */
+export function computeSegmentProgress(
+  trackPositionMeters: number,
+  startOffsetMeters: number,
+  segmentLengthMeters: number,
+  isDown: boolean
+): SegmentProgress {
+  if (!Number.isFinite(segmentLengthMeters) || segmentLengthMeters <= 0) {
+    return { distanceToNextStationMeters: 0, progressRatio: 1 };
+  }
+
+  const offsetWithinSegment = Math.min(
+    segmentLengthMeters,
+    Math.max(0, trackPositionMeters - startOffsetMeters)
+  );
+  const remainingMeters = isDown ? offsetWithinSegment : segmentLengthMeters - offsetWithinSegment;
+  const traveledMeters = segmentLengthMeters - remainingMeters;
+
+  return {
+    distanceToNextStationMeters: Math.round(remainingMeters),
+    progressRatio: Math.min(1, Math.max(0, traveledMeters / segmentLengthMeters)),
+  };
+}
+
 export class JourneyStateEstimator {
   private lastSample: LocationSample | null = null;
   private lastConfirmedDirection: TravelDirection = 'UNKNOWN';
@@ -152,12 +207,13 @@ export class JourneyStateEstimator {
     let progressRatio: number | null = null;
 
     const currentSeg = currentSegmentInput || match?.selectedSegment;
+    const isDown = isDownDirection(direction);
 
     if (currentSeg && (currentSeg.fromStationId || currentSeg.toStationId)) {
       const fromSt = lineStations.find((st) => st.id === currentSeg.fromStationId) ?? null;
       const toSt = lineStations.find((st) => st.id === currentSeg.toStationId) ?? null;
 
-      if (direction === 'DOWN') {
+      if (isDown) {
         previousStation = toSt || fromSt;
         nextStation = fromSt || toSt;
       } else {
@@ -166,12 +222,15 @@ export class JourneyStateEstimator {
       }
 
       if (navState && navState.trackPositionMeters !== null && currentSeg.startOffsetMeters !== undefined) {
-        const segLength = currentSeg.lengthMeters ?? 2000;
-        const endOffset = currentSeg.startOffsetMeters + segLength;
-        const remainingMeters = direction === 'DOWN'
-          ? navState.trackPositionMeters - currentSeg.startOffsetMeters
-          : endOffset - navState.trackPositionMeters;
-        distanceToNextStationMeters = Math.max(0, Math.min(segLength, Math.round(remainingMeters)));
+        const segLength = currentSeg.lengthMeters ?? DEFAULT_SEGMENT_LENGTH_METERS;
+        const progress = computeSegmentProgress(
+          navState.trackPositionMeters,
+          currentSeg.startOffsetMeters,
+          segLength,
+          isDown
+        );
+        distanceToNextStationMeters = progress.distanceToNextStationMeters;
+        progressRatio = progress.progressRatio;
       }
     }
 
@@ -187,7 +246,7 @@ export class JourneyStateEstimator {
         refLon = sample.longitude;
       }
 
-      if (direction === 'UP') {
+      if (!isDown) {
         for (let i = 0; i < orderedStations.length; i++) {
           const st = orderedStations[i];
           let stDistFromRef: number | null = null;
@@ -197,7 +256,7 @@ export class JourneyStateEstimator {
           }
 
           if (refTrackOffset !== null) {
-            const stOffset = (st.sequence - 1) * 2000;
+            const stOffset = (st.sequence - 1) * DEFAULT_SEGMENT_LENGTH_METERS;
             if (stOffset <= refTrackOffset) {
               previousStation = st;
             } else if (!nextStation) {
@@ -214,12 +273,12 @@ export class JourneyStateEstimator {
             }
           }
         }
-      } else if (direction === 'DOWN') {
+      } else {
         const reversed = [...orderedStations].reverse();
         for (let i = 0; i < reversed.length; i++) {
           const st = reversed[i];
           if (refTrackOffset !== null) {
-            const stOffset = (st.sequence - 1) * 2000;
+            const stOffset = (st.sequence - 1) * DEFAULT_SEGMENT_LENGTH_METERS;
             if (stOffset >= refTrackOffset) {
               previousStation = st;
             } else if (!nextStation) {
@@ -239,7 +298,8 @@ export class JourneyStateEstimator {
       }
     }
 
-    if (previousStation && nextStation && distanceToNextStationMeters !== null) {
+    // セグメント長ベースで進捗率を確定できなかった場合のみ、駅間の直線距離で近似する。
+    if (progressRatio === null && previousStation && nextStation && distanceToNextStationMeters !== null) {
       const totalSegDist = haversineDistance(
         previousStation.latitude,
         previousStation.longitude,
@@ -252,10 +312,12 @@ export class JourneyStateEstimator {
       }
     }
 
-    const directionName = direction === 'UP' || direction === 'DIRECTION_A'
-      ? selectedLine.directionAName ?? '上り'
-      : direction === 'DOWN' || direction === 'DIRECTION_B'
-        ? selectedLine.directionBName ?? '下り'
+    // 方向が確定していない場合は方向名を出さない(現状の制御フローでは到達しないが、
+    // 誤った方向名をHUDに出さないためのガードとして残す)。
+    const directionName = isDown
+      ? selectedLine.directionBName ?? '下り'
+      : isUpDirection(direction)
+        ? selectedLine.directionAName ?? '上り'
         : null;
     const confidence = match ? match.confidence : (navState?.confidence ?? 0.5);
 

--- a/src/domain/railway/journey-state-estimator.ts
+++ b/src/domain/railway/journey-state-estimator.ts
@@ -36,15 +36,21 @@ export function isUpDirection(direction: TravelDirection): boolean {
  * trackPosition がセグメント外(手前 / 行き過ぎ)にある場合でも、
  * 距離は [0, segmentLength]、進捗率は [0, 1] にclampする。
  * 距離と進捗率は同じセグメント長を基準に導出するため、常に整合する。
+ *
+ * セグメント長が有限の正数でない場合は「算出不能」を意味する null を返す。
+ * ここで 0m / 進捗1.0 を返してしまうと、入力が壊れているだけなのにHUD上は
+ * 「次駅に到着済み」と表示され、さらに progressRatio が非nullになることで
+ * 呼び出し側のhaversineフォールバックまで塞いでしまうため。
+ * フォールバックの選択は呼び出し側に委ねる。
  */
 export function computeSegmentProgress(
   trackPositionMeters: number,
   startOffsetMeters: number,
   segmentLengthMeters: number,
   isDown: boolean
-): SegmentProgress {
+): SegmentProgress | null {
   if (!Number.isFinite(segmentLengthMeters) || segmentLengthMeters <= 0) {
-    return { distanceToNextStationMeters: 0, progressRatio: 1 };
+    return null;
   }
 
   const offsetWithinSegment = Math.min(
@@ -229,8 +235,13 @@ export class JourneyStateEstimator {
           segLength,
           isDown
         );
-        distanceToNextStationMeters = progress.distanceToNextStationMeters;
-        progressRatio = progress.progressRatio;
+        // セグメント長が使えない場合は両方ともnullのまま残し、「不明」として
+        // 駅フォールバック / haversineフォールバック / UI側の判断に委ねる。
+        // 片方だけ埋めると距離と進捗が矛盾するため、必ず両方まとめて代入する。
+        if (progress) {
+          distanceToNextStationMeters = progress.distanceToNextStationMeters;
+          progressRatio = progress.progressRatio;
+        }
       }
     }
 

--- a/tests/railway/journey-state-estimator.test.ts
+++ b/tests/railway/journey-state-estimator.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
-import { JourneyStateEstimator } from '../../src/domain/railway/journey-state-estimator';
+import {
+  computeSegmentProgress,
+  isDownDirection,
+  isUpDirection,
+  JourneyStateEstimator,
+} from '../../src/domain/railway/journey-state-estimator';
 import { RailwayCoverageResult, RailwayDataRepository, RailwayDataState } from '../../src/domain/railway/repository';
 import { RailwayLine, RailwayRoute, RouteMatch, Station, TrackSegment } from '../../src/domain/models/railway';
-import { LocationSample, FullSpeedState, SpeedEstimate } from '../../src/domain/models/location';
+import {
+  LocationSample,
+  FullSpeedState,
+  SpeedEstimate,
+  TrackNavigationState,
+} from '../../src/domain/models/location';
 
 class MockStationDatabase implements RailwayDataRepository {
   private stations: Station[] = [
@@ -197,6 +207,267 @@ describe('JourneyStateEstimator', () => {
     expect(state.previousStation?.name).toBe('座間');
     expect(state.nextStation?.name).toBe('海老名');
     expect(state.distanceToNextStationMeters).toBe(1500);
+    expect(state.progressRatio).toBe(1700 / 3200);
     expect(state.status).toBe('TRACKING');
+  });
+});
+
+// 上り: st-1(海老名) -> st-2(座間) -> st-3(相武台前)
+// 下り: st-3 -> st-2 -> st-1
+// トラックオフセットは常に上り方向で単調増加する。
+const SEG_1_LENGTH = 3200;
+const SEG_2_LENGTH = 2400;
+
+const SEG_1: TrackSegment = {
+  id: 'seg-1',
+  lineId: 'line-1',
+  fromStationId: 'st-1',
+  toStationId: 'st-2',
+  coordinates: [
+    [35.4526, 139.3900],
+    [35.4806, 139.4005],
+  ],
+  lengthMeters: SEG_1_LENGTH,
+  startOffsetMeters: 0,
+};
+
+const SEG_2: TrackSegment = {
+  id: 'seg-2',
+  lineId: 'line-1',
+  fromStationId: 'st-2',
+  toStationId: 'st-3',
+  coordinates: [
+    [35.4806, 139.4005],
+    [35.4988, 139.4144],
+  ],
+  lengthMeters: SEG_2_LENGTH,
+  startOffsetMeters: SEG_1_LENGTH,
+};
+
+function buildNavState(
+  direction: 'UP' | 'DOWN',
+  trackPositionMeters: number,
+  segmentId: string
+): TrackNavigationState {
+  return {
+    lineId: 'line-1',
+    routeId: null,
+    segmentId,
+    direction,
+    trackPositionMeters,
+    velocityMps: 25,
+    accelerationMps2: 0,
+    accelerationBiasMps2: 0,
+    lastObservationTimestampMs: 10000,
+    lastPredictionTimestampMs: 10000,
+    mode: 'gps-locked',
+    confidence: 0.9,
+  };
+}
+
+const DUMMY_SPEED_STATE = {
+  smoothedSpeedKmh: 90,
+  isStopped: false,
+  isValid: true,
+} as unknown as FullSpeedState;
+
+/**
+ * GPSサンプル/RouteMatchを与えず、navStateの方向とセグメントだけで状態を評価する。
+ * 進行方向がheading推定で上書きされないため、方向別の距離計算だけを検証できる。
+ */
+async function estimateAt(
+  estimator: JourneyStateEstimator,
+  direction: 'UP' | 'DOWN',
+  trackPositionMeters: number,
+  segment: TrackSegment
+) {
+  const navState = buildNavState(direction, trackPositionMeters, segment.id);
+  return estimator.update(null, null, DUMMY_SPEED_STATE, navState, segment);
+}
+
+describe('JourneyStateEstimator - direction aware distance and progress', () => {
+  const cases = [
+    // 上りはセグメント終点(座間)へ向かうので、オフセットが進むほど残距離が減る。
+    { direction: 'UP' as const, label: 'segment start', trackPosition: 0, distance: 3200, progress: 0, next: '座間' },
+    { direction: 'UP' as const, label: 'segment middle', trackPosition: 1600, distance: 1600, progress: 0.5, next: '座間' },
+    { direction: 'UP' as const, label: 'segment end', trackPosition: 3200, distance: 0, progress: 1, next: '座間' },
+    // 下りはセグメント始点(海老名)へ向かうので、オフセットが進むほど残距離が増える。
+    { direction: 'DOWN' as const, label: 'segment start', trackPosition: 0, distance: 0, progress: 1, next: '海老名' },
+    { direction: 'DOWN' as const, label: 'segment middle', trackPosition: 1600, distance: 1600, progress: 0.5, next: '海老名' },
+    { direction: 'DOWN' as const, label: 'segment end', trackPosition: 3200, distance: 3200, progress: 0, next: '海老名' },
+  ];
+
+  for (const testCase of cases) {
+    it(`computes exact distance and progress for ${testCase.direction} at ${testCase.label}`, async () => {
+      const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+      const state = await estimateAt(estimator, testCase.direction, testCase.trackPosition, SEG_1);
+
+      expect(state.direction).toBe(testCase.direction);
+      expect(state.nextStation?.name).toBe(testCase.next);
+      expect(state.distanceToNextStationMeters).toBe(testCase.distance);
+      expect(state.progressRatio).toBe(testCase.progress);
+    });
+  }
+
+  it('produces mirrored distance and progress for UP and DOWN at the same track position', async () => {
+    const upEstimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+    const downEstimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+    const up = await estimateAt(upEstimator, 'UP', 1500, SEG_1);
+    const down = await estimateAt(downEstimator, 'DOWN', 1500, SEG_1);
+
+    expect(up.previousStation?.name).toBe('海老名');
+    expect(up.nextStation?.name).toBe('座間');
+    expect(up.distanceToNextStationMeters).toBe(1700);
+    expect(up.progressRatio).toBe(0.46875);
+    expect(up.directionName).toBe('上り');
+
+    expect(down.previousStation?.name).toBe('座間');
+    expect(down.nextStation?.name).toBe('海老名');
+    expect(down.distanceToNextStationMeters).toBe(1500);
+    expect(down.progressRatio).toBe(0.53125);
+    expect(down.directionName).toBe('下り');
+
+    // 残距離の合計はセグメント長、進捗率の合計は1になる(方向が逆転していない証拠)。
+    expect(up.distanceToNextStationMeters! + down.distanceToNextStationMeters!).toBe(SEG_1_LENGTH);
+    expect(up.progressRatio! + down.progressRatio!).toBe(1);
+  });
+
+  it('clamps distance and progress into segment bounds when the track position is outside the segment', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+    const upOvershoot = await estimateAt(estimator, 'UP', 5000, SEG_1);
+    expect(upOvershoot.distanceToNextStationMeters).toBe(0);
+    expect(upOvershoot.progressRatio).toBe(1);
+
+    const upUndershoot = await estimateAt(estimator, 'UP', -500, SEG_1);
+    expect(upUndershoot.distanceToNextStationMeters).toBe(SEG_1_LENGTH);
+    expect(upUndershoot.progressRatio).toBe(0);
+
+    const downOvershoot = await estimateAt(estimator, 'DOWN', 5000, SEG_1);
+    expect(downOvershoot.distanceToNextStationMeters).toBe(SEG_1_LENGTH);
+    expect(downOvershoot.progressRatio).toBe(0);
+
+    const downUndershoot = await estimateAt(estimator, 'DOWN', -500, SEG_1);
+    expect(downUndershoot.distanceToNextStationMeters).toBe(0);
+    expect(downUndershoot.progressRatio).toBe(1);
+  });
+
+  it('keeps UP distance continuous across a segment boundary', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+    const beforeBoundary = await estimateAt(estimator, 'UP', 3000, SEG_1);
+    expect(beforeBoundary.nextStation?.name).toBe('座間');
+    expect(beforeBoundary.distanceToNextStationMeters).toBe(200);
+    expect(beforeBoundary.progressRatio).toBe(0.9375);
+
+    const atBoundary = await estimateAt(estimator, 'UP', 3200, SEG_1);
+    expect(atBoundary.distanceToNextStationMeters).toBe(0);
+    expect(atBoundary.progressRatio).toBe(1);
+
+    // セグメント遷移直後は次駅が相武台前へ切り替わり、残距離はセグメント長から連続して減っていく。
+    const afterBoundary = await estimateAt(estimator, 'UP', 3200, SEG_2);
+    expect(afterBoundary.previousStation?.name).toBe('座間');
+    expect(afterBoundary.nextStation?.name).toBe('相武台前');
+    expect(afterBoundary.distanceToNextStationMeters).toBe(SEG_2_LENGTH);
+    expect(afterBoundary.progressRatio).toBe(0);
+
+    const advanced = await estimateAt(estimator, 'UP', 3800, SEG_2);
+    expect(advanced.distanceToNextStationMeters).toBe(1800);
+    expect(advanced.progressRatio).toBe(0.25);
+
+    const advancedFurther = await estimateAt(estimator, 'UP', 4400, SEG_2);
+    expect(advancedFurther.distanceToNextStationMeters).toBe(1200);
+    expect(advancedFurther.progressRatio).toBe(0.5);
+  });
+
+  it('keeps DOWN distance continuous across a segment boundary', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+    const beforeBoundary = await estimateAt(estimator, 'DOWN', 4400, SEG_2);
+    expect(beforeBoundary.previousStation?.name).toBe('相武台前');
+    expect(beforeBoundary.nextStation?.name).toBe('座間');
+    expect(beforeBoundary.distanceToNextStationMeters).toBe(1200);
+    expect(beforeBoundary.progressRatio).toBe(0.5);
+
+    const nearBoundary = await estimateAt(estimator, 'DOWN', 3800, SEG_2);
+    expect(nearBoundary.distanceToNextStationMeters).toBe(600);
+    expect(nearBoundary.progressRatio).toBe(0.75);
+
+    const atBoundary = await estimateAt(estimator, 'DOWN', 3200, SEG_2);
+    expect(atBoundary.distanceToNextStationMeters).toBe(0);
+    expect(atBoundary.progressRatio).toBe(1);
+
+    // セグメント遷移直後は次駅が海老名へ切り替わり、残距離はセグメント長から連続して減っていく。
+    const afterBoundary = await estimateAt(estimator, 'DOWN', 3200, SEG_1);
+    expect(afterBoundary.previousStation?.name).toBe('座間');
+    expect(afterBoundary.nextStation?.name).toBe('海老名');
+    expect(afterBoundary.distanceToNextStationMeters).toBe(SEG_1_LENGTH);
+    expect(afterBoundary.progressRatio).toBe(0);
+
+    const advanced = await estimateAt(estimator, 'DOWN', 1600, SEG_1);
+    expect(advanced.distanceToNextStationMeters).toBe(1600);
+    expect(advanced.progressRatio).toBe(0.5);
+  });
+});
+
+describe('computeSegmentProgress', () => {
+  it('returns direction specific remaining distance within the segment', () => {
+    expect(computeSegmentProgress(1500, 0, 3200, false)).toEqual({
+      distanceToNextStationMeters: 1700,
+      progressRatio: 0.46875,
+    });
+    expect(computeSegmentProgress(1500, 0, 3200, true)).toEqual({
+      distanceToNextStationMeters: 1500,
+      progressRatio: 0.53125,
+    });
+  });
+
+  it('honours a non-zero segment start offset', () => {
+    expect(computeSegmentProgress(4400, 3200, 2400, false)).toEqual({
+      distanceToNextStationMeters: 1200,
+      progressRatio: 0.5,
+    });
+    expect(computeSegmentProgress(4400, 3200, 2400, true)).toEqual({
+      distanceToNextStationMeters: 1200,
+      progressRatio: 0.5,
+    });
+  });
+
+  it('rounds the distance while keeping the progress ratio unrounded', () => {
+    expect(computeSegmentProgress(1024.5, 0, 4096, false)).toEqual({
+      distanceToNextStationMeters: 3072,
+      progressRatio: 0.2501220703125,
+    });
+  });
+
+  it('degrades safely when the segment length is not usable', () => {
+    expect(computeSegmentProgress(100, 0, 0, false)).toEqual({
+      distanceToNextStationMeters: 0,
+      progressRatio: 1,
+    });
+    expect(computeSegmentProgress(100, 0, Number.NaN, true)).toEqual({
+      distanceToNextStationMeters: 0,
+      progressRatio: 1,
+    });
+  });
+});
+
+describe('direction normalization', () => {
+  it('treats DOWN and its DIRECTION_B alias as the down direction', () => {
+    expect(isDownDirection('DOWN')).toBe(true);
+    expect(isDownDirection('DIRECTION_B')).toBe(true);
+    expect(isDownDirection('UP')).toBe(false);
+    expect(isDownDirection('DIRECTION_A')).toBe(false);
+    expect(isDownDirection('UNKNOWN')).toBe(false);
+  });
+
+  it('treats UP and its DIRECTION_A alias as the up direction', () => {
+    expect(isUpDirection('UP')).toBe(true);
+    expect(isUpDirection('DIRECTION_A')).toBe(true);
+    expect(isUpDirection('DOWN')).toBe(false);
+    expect(isUpDirection('DIRECTION_B')).toBe(false);
+    expect(isUpDirection('UNKNOWN')).toBe(false);
   });
 });

--- a/tests/railway/journey-state-estimator.test.ts
+++ b/tests/railway/journey-state-estimator.test.ts
@@ -6,6 +6,7 @@ import {
   isUpDirection,
   JourneyStateEstimator,
 } from '../../src/domain/railway/journey-state-estimator';
+import { haversineDistance } from '../../src/domain/geo/distance';
 import { RailwayCoverageResult, RailwayDataRepository, RailwayDataState } from '../../src/domain/railway/repository';
 import { RailwayLine, RailwayRoute, RouteMatch, Station, TrackSegment } from '../../src/domain/models/railway';
 import {
@@ -412,6 +413,61 @@ describe('JourneyStateEstimator - direction aware distance and progress', () => 
   });
 });
 
+describe('JourneyStateEstimator - unusable segment length', () => {
+  // 前駅・次駅は特定できるがセグメント長が壊れているケース。
+  // 「残り0m / 進捗100%」= 到着済み、と誤って断定してはいけない。
+  it('reports unknown distance and progress instead of a bogus arrived state', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+    const brokenSegment: TrackSegment = { ...SEG_1, lengthMeters: 0 };
+
+    const state = await estimateAt(estimator, 'UP', 1500, brokenSegment);
+
+    expect(state.previousStation?.name).toBe('海老名');
+    expect(state.nextStation?.name).toBe('座間');
+    expect(state.distanceToNextStationMeters).toBeNull();
+    expect(state.progressRatio).toBeNull();
+  });
+
+  it('reports unknown distance and progress for DOWN as well', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+    const brokenSegment: TrackSegment = { ...SEG_1, lengthMeters: Number.NaN };
+
+    const state = await estimateAt(estimator, 'DOWN', 1500, brokenSegment);
+
+    expect(state.previousStation?.name).toBe('座間');
+    expect(state.nextStation?.name).toBe('海老名');
+    expect(state.distanceToNextStationMeters).toBeNull();
+    expect(state.progressRatio).toBeNull();
+  });
+
+  // セグメント長が壊れていて、かつセグメントの駅IDが路線の駅一覧に見つからない場合は
+  // 駅フォールバックが距離を埋める。このとき progressRatio がセグメント側の値で
+  // 埋まっていると haversine フォールバックが動かず、距離500mなのに進捗100%という
+  // 矛盾した状態になる。progressRatio は null のまま残す必要がある。
+  it('keeps the haversine fallback reachable when the segment length is unusable', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+    const brokenSegment: TrackSegment = {
+      ...SEG_1,
+      fromStationId: 'st-not-in-line',
+      toStationId: 'st-also-not-in-line',
+      lengthMeters: 0,
+    };
+
+    const state = await estimateAt(estimator, 'UP', 1500, brokenSegment);
+
+    expect(state.previousStation?.name).toBe('海老名');
+    expect(state.nextStation?.name).toBe('座間');
+    // 駅フォールバックが埋めた残距離 (次駅オフセット 2000m - 現在位置 1500m)。
+    expect(state.distanceToNextStationMeters).toBe(500);
+
+    // 進捗率は駅間の直線距離ベースで再計算される(「到着済み」の1.0ではない)。
+    const straightLineMeters = haversineDistance(35.4526, 139.3900, 35.4806, 139.4005);
+    const expectedRatio = (straightLineMeters - 500) / straightLineMeters;
+    expect(state.progressRatio).toBeCloseTo(expectedRatio, 10);
+    expect(state.progressRatio).toBeLessThan(1);
+  });
+});
+
 describe('computeSegmentProgress', () => {
   it('returns direction specific remaining distance within the segment', () => {
     expect(computeSegmentProgress(1500, 0, 3200, false)).toEqual({
@@ -442,15 +498,14 @@ describe('computeSegmentProgress', () => {
     });
   });
 
-  it('degrades safely when the segment length is not usable', () => {
-    expect(computeSegmentProgress(100, 0, 0, false)).toEqual({
-      distanceToNextStationMeters: 0,
-      progressRatio: 1,
-    });
-    expect(computeSegmentProgress(100, 0, Number.NaN, true)).toEqual({
-      distanceToNextStationMeters: 0,
-      progressRatio: 1,
-    });
+  // セグメント長が壊れているだけなのに 0m / 進捗1.0 を返すと「到着済み」と誤表示され、
+  // さらに progressRatio が非nullになることで呼び出し側のフォールバックも塞いでしまう。
+  it('returns null instead of a bogus arrived state when the segment length is not usable', () => {
+    expect(computeSegmentProgress(100, 0, 0, false)).toBeNull();
+    expect(computeSegmentProgress(100, 0, 0, true)).toBeNull();
+    expect(computeSegmentProgress(100, 0, Number.NaN, true)).toBeNull();
+    expect(computeSegmentProgress(100, 0, -1200, false)).toBeNull();
+    expect(computeSegmentProgress(100, 0, Number.POSITIVE_INFINITY, false)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #18

## 調査結果

issue本文にある「距離を常に `segmentEnd - trackPosition` で計算している」箇所は、すでに 56fc682 (Address Copilot review feedback) で方向別 (`trackPosition - segmentStart`) に修正済み、clampも入っていた。したがって完了条件のうち2つは main 時点で満たされている。

残っていた本質的な不整合は **progressRatio の分母** だった:

- `distanceToNextStationMeters` … トラックオフセット基準 (`segment.lengthMeters`)
- `progressRatio` … 前駅・次駅の**直線距離** (haversine) 基準

分母が違うため距離と進捗が食い違い、しかもUP/DOWNで非対称にずれる。例: `segLength=3200` / haversine≒3255 / `trackPos=1500` のとき UP の progress は 0.4778 (正しくは 0.46875)。曲線区間 (segLength 3200 / 直線 2000) では UP 0.15 対 正解 0.469 と大きく破綻する。

## 変更内容

- `computeSegmentProgress()` を切り出し、距離と進捗率を**同じセグメント長**から導出。trackPosition をセグメント境界内へclampするので、距離は `[0, segLength]`、進捗率は `[0, 1]` に収まる。
- haversine による近似はセグメント長が得られない駅フォールバック経路専用に降格 (`progressRatio === null` のときのみ)。
- `isDownDirection()` / `isUpDirection()` で方向を一箇所に正規化し、駅の割り当て・距離計算・方向名が同じ判定を使うようにした。
  - 補足: `TrackNavigationState.direction` は `'UP' | 'DOWN' | 'UNKNOWN'` なので `DIRECTION_A` / `DIRECTION_B` は現状 `update()` からは到達しない。ただし `TravelDirection` 型は許容しており、3箇所の扱いがバラバラだった (DIRECTION_B は下り表記なのに上りの距離、DIRECTION_A/B は駅フォールバックのどちらの分岐にも入らない) ため、実バグ修正ではなく防御的な正規化として入れている。
  - これに伴い駅フォールバックの `else if (direction === 'DOWN')` を `else` に変更している (意図的)。方向名は方向が未確定の場合 `null` のまま。

## テスト

`tests/railway/journey-state-estimator.test.ts` に数値検証を追加:

- UP / DOWN それぞれ セグメント開始 (0) / 中間 (1600) / 終了 (3200) の distance と progressRatio を `toBe` で厳密検証 (UP: 3200/1600/0 と 0/0.5/1、DOWN: 0/1600/3200 と 1/0.5/0)
- 同一 trackPosition (1500) での UP/DOWN 対称性: 距離の合計 = セグメント長、進捗率の合計 = 1 (UP 1700/0.46875、DOWN 1500/0.53125)
- セグメント外 (`trackPos = 5000` / `-500`) のclamp
- セグメント跨ぎの連続性を UP / DOWN 双方で検証 (seg-1 3200m → seg-2 2400m、次駅の切り替わりと残距離が連続して更新されること)
- `computeSegmentProgress` / `isDownDirection` / `isUpDirection` の単体テスト

## 検証

```
pnpm test          Test Files 19 passed (19) / Tests 80 passed (80)   (main: 64 passed)
npx tsc --noEmit   exit 0
pnpm lint          exit 0 (eslint --max-warnings=0)
```

## Copilot レビュー対応

commit 0510155。指摘2件 (+ suppressed 1件) はいずれも同じ根本原因で、内容も妥当だったため受け入れて修正した。

**問題**: `computeSegmentProgress()` は `segmentLengthMeters` が有限の正数でないとき `{ distanceToNextStationMeters: 0, progressRatio: 1 }` を返していた。これは (1) 入力が壊れているだけなのに HUD 上「次駅に到着済み」と表示され、(2) `progressRatio` が非nullになるため `update()` の haversine フォールバック (`progressRatio === null` のときだけ動く) を塞ぐ、という2つの実害があった。

(2) はセグメントの `fromStationId` / `toStationId` が路線の駅一覧に解決できないケースで顕在化する。駅フォールバックが `distanceToNextStationMeters` を上書きする一方 `progressRatio` は 1 のまま残るため、同一フレームで「残り500m」かつ「進捗100%」という矛盾した状態になる。

**修正**:

- `computeSegmentProgress()` の戻り値を `SegmentProgress | null` に変更。セグメント長が使えない場合は「算出不能」を意味する `null` を返し、フォールバックの選択は呼び出し側に委ねる。
- 呼び出し側 (`update()`) を `if (progress)` でガードし、算出できた場合のみ距離と進捗を**まとめて**代入する。片方だけ埋めると逆方向から同じ矛盾が再発するため。
- 算出不能時は両フィールドが `null` のまま残るので、駅フォールバック / haversine フォールバック / UI (`hud-renderer.ts:79`、`canvas-hud-renderer.ts`) が「不明」として扱える。「不明」と「到着済み」を明確に分離した。

**契約の変更**: セグメント長が壊れている場合の出力は `0m / 100%` ではなく `null` (不明) になる。

**追加テスト**:

- `computeSegmentProgress` が `0` / `NaN` / 負値 / `Infinity` で `null` を返すこと (既存テストの `0m/1.0` 期待値を差し替え)
- `describe('JourneyStateEstimator - unusable segment length')` を新設
  - 駅は特定できるがセグメント長が壊れている場合、UP/DOWN とも距離・進捗が `null`
  - セグメント長が壊れていて駅IDも解決できない場合、駅フォールバックが距離500mを埋めた上で haversine フォールバックが進捗を再計算する (期待値は `haversineDistance()` を実際に呼んで算出、`toBeLessThan(1)` も検証)
- 非空振り確認: src 側の変更のみ stash した状態で上記4テストが失敗することを確認済み

**再検証**:

```
pnpm test          Test Files 19 passed (19) / Tests 83 passed (83)
npx tsc --noEmit   exit 0
pnpm lint          exit 0 (eslint --max-warnings=0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk
