### PR TITLE
Even G2 ブリッジ待機にタイムアウトを設けて無音の停止をなくす

### DIFF
--- a/src/infrastructure/even-app/bridge-ready.ts
+++ b/src/infrastructure/even-app/bridge-ready.ts
@@ -1,0 +1,94 @@
+import { waitForEvenAppBridge } from '@evenrealities/even_hub_sdk';
+import type { EvenAppBridge } from '@evenrealities/even_hub_sdk';
+
+/**
+ * Upper bound for the SDK bridge handshake.
+ *
+ * The WebView pushes the bridge once page loading completes, so this only needs
+ * to be generous enough to cover a slow start-up. Paired with AppController's
+ * backoff (max 10s) it retries roughly every 20s while the bridge is absent.
+ */
+export const DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000;
+
+/**
+ * Largest delay `setTimeout` can actually hold (2^31 - 1 ms, ~24.9 days).
+ *
+ * Anything above it overflows the 32-bit timer and fires after ~1ms instead,
+ * so a caller asking for a very long wait would silently get an instant one.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Resolves a caller-supplied handshake bound to a delay `setTimeout` can honour.
+ *
+ * `setTimeout` never rejects a bad delay, it quietly substitutes 1ms:
+ * `Infinity`, `NaN` and negatives all fire on the next tick. Passing one
+ * through would not restore the unbounded wait this bound exists to prevent —
+ * it causes the opposite failure, a handshake that expires before the bridge
+ * can ever answer, leaving the caller permanently unable to connect. Values
+ * over {@link MAX_TIMER_DELAY_MS} overflow into the same instant-fire
+ * behaviour, so they are clamped rather than rejected.
+ *
+ * @param logPrefix Owner tag for the warning, e.g. `[EvenG2Adapter]`.
+ */
+export function resolveBridgeReadyTimeoutMs(
+  value: number | undefined,
+  logPrefix: string
+): number {
+  if (value === undefined) return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    console.warn(
+      `${logPrefix} Ignoring invalid bridgeReadyTimeoutMs (${value}); ` +
+        `falling back to ${DEFAULT_BRIDGE_READY_TIMEOUT_MS}ms.`
+    );
+    return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
+  }
+
+  if (value > MAX_TIMER_DELAY_MS) {
+    console.warn(
+      `${logPrefix} Clamping bridgeReadyTimeoutMs (${value}) to ` +
+        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+
+  return value;
+}
+
+/**
+ * Bounded wrapper around the SDK handshake.
+ *
+ * `waitForEvenAppBridge()` resolves on an `evenAppBridgeReady` event and the SDK
+ * exposes no timeout, so a bridge that never initializes parks the caller
+ * forever: retry loops never iterate again and `await`ed start-up paths never
+ * settle, leaving no log and no error. Bounding it turns that silent stall into
+ * an ordinary failure that backoff can retry and error reporting can observe.
+ *
+ * The losing side of the race is abandoned rather than cancelled — the SDK has
+ * no cancellation — so a bridge that shows up late is dropped instead of being
+ * wired up behind whatever fallback has since taken over.
+ *
+ * @param timeoutMs Must already be a delay `setTimeout` can honour; run
+ *   caller-supplied values through {@link resolveBridgeReadyTimeoutMs} first.
+ */
+export async function waitForEvenAppBridgeWithin(timeoutMs: number): Promise<EvenAppBridge> {
+  const pending = waitForEvenAppBridge();
+  // Promise.race already handles a late settle, but keep this explicit so the
+  // abandoned SDK promise can never surface as an unhandled rejection.
+  void pending.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`waitForEvenAppBridge() timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+  });
+
+  try {
+    return await Promise.race([pending, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -13,6 +13,20 @@ import {
 import { HudViewModel } from '../../domain/models/hud';
 import { createSpeedPng } from './speed-png-generator';
 
+/**
+ * Upper bound for the SDK bridge handshake.
+ *
+ * The WebView pushes the bridge once page loading completes, so this only needs
+ * to be generous enough to cover a slow start-up. Paired with AppController's
+ * backoff (max 10s) it retries roughly every 20s while the bridge is absent.
+ */
+export const DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000;
+
+export interface HybridEvenG2AdapterOptions {
+  /** Overrides {@link DEFAULT_BRIDGE_READY_TIMEOUT_MS}. */
+  bridgeReadyTimeoutMs?: number;
+}
+
 export interface EvenG2Adapter {
   connect(): Promise<boolean>;
   render(model: HudViewModel): Promise<void>;
@@ -71,8 +85,14 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
   private disconnectWaiters: Array<() => void> = [];
 
-  constructor(onRender?: (formattedText: string, model: HudViewModel) => void) {
+  private readonly bridgeReadyTimeoutMs: number;
+
+  constructor(
+    onRender?: (formattedText: string, model: HudViewModel) => void,
+    options: HybridEvenG2AdapterOptions = {}
+  ) {
     this.onRenderCallback = onRender;
+    this.bridgeReadyTimeoutMs = options.bridgeReadyTimeoutMs ?? DEFAULT_BRIDGE_READY_TIMEOUT_MS;
   }
 
   public getLastImageResult(): string {
@@ -122,10 +142,43 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
   }
 
+  /**
+   * Bounded wrapper around the SDK handshake.
+   *
+   * `waitForEvenAppBridge()` resolves on an `evenAppBridgeReady` event and the SDK
+   * exposes no timeout, so a bridge that never initializes parks connect() forever:
+   * AppController's reconnect loop awaits it and never iterates again, leaving no
+   * log and no error. Bounding it turns that silent stall into a normal connect
+   * failure that backoff retries — and that error reporting can observe.
+   */
+  private async waitForBridgeReady(): Promise<any> {
+    const pending = waitForEvenAppBridge();
+    // Promise.race already handles a late settle, but keep this explicit so the
+    // abandoned SDK promise can never surface as an unhandled rejection.
+    void pending.catch(() => {});
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new Error(`waitForEvenAppBridge() timed out after ${this.bridgeReadyTimeoutMs}ms`)
+          ),
+        this.bridgeReadyTimeoutMs
+      );
+    });
+
+    try {
+      return await Promise.race([pending, expiry]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   public async connect(): Promise<boolean> {
     try {
       if (!this.bridge) {
-        this.bridge = await waitForEvenAppBridge();
+        this.bridge = await this.waitForBridgeReady();
         console.log('[EvenG2Adapter] waitForEvenAppBridge() resolved!');
       }
 

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -22,8 +22,54 @@ import { createSpeedPng } from './speed-png-generator';
  */
 export const DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000;
 
+/**
+ * Largest delay `setTimeout` can actually hold (2^31 - 1 ms, ~24.9 days).
+ *
+ * Anything above it overflows the 32-bit timer and fires after ~1ms instead,
+ * so a caller asking for a very long wait would silently get an instant one.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Resolves the configured handshake bound to a delay `setTimeout` can honour.
+ *
+ * `setTimeout` never rejects a bad delay, it quietly substitutes 1ms:
+ * `Infinity`, `NaN` and negatives all fire on the next tick. Passing one
+ * through would not restore the unbounded wait this bound exists to prevent —
+ * it causes the opposite failure, a handshake that expires before the bridge
+ * can ever answer, leaving the adapter permanently unable to connect. Values
+ * over {@link MAX_TIMER_DELAY_MS} overflow into the same instant-fire
+ * behaviour, so they are clamped rather than rejected.
+ */
+function resolveBridgeReadyTimeoutMs(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    console.warn(
+      `[EvenG2Adapter] Ignoring invalid bridgeReadyTimeoutMs (${value}); ` +
+        `falling back to ${DEFAULT_BRIDGE_READY_TIMEOUT_MS}ms.`
+    );
+    return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
+  }
+
+  if (value > MAX_TIMER_DELAY_MS) {
+    console.warn(
+      `[EvenG2Adapter] Clamping bridgeReadyTimeoutMs (${value}) to ` +
+        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+
+  return value;
+}
+
 export interface HybridEvenG2AdapterOptions {
-  /** Overrides {@link DEFAULT_BRIDGE_READY_TIMEOUT_MS}. */
+  /**
+   * Overrides {@link DEFAULT_BRIDGE_READY_TIMEOUT_MS}.
+   *
+   * Must be a finite, positive number of milliseconds. Anything else falls
+   * back to the default; values beyond {@link MAX_TIMER_DELAY_MS} are clamped.
+   */
   bridgeReadyTimeoutMs?: number;
 }
 
@@ -92,7 +138,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     options: HybridEvenG2AdapterOptions = {}
   ) {
     this.onRenderCallback = onRender;
-    this.bridgeReadyTimeoutMs = options.bridgeReadyTimeoutMs ?? DEFAULT_BRIDGE_READY_TIMEOUT_MS;
+    this.bridgeReadyTimeoutMs = resolveBridgeReadyTimeoutMs(options.bridgeReadyTimeoutMs);
   }
 
   public getLastImageResult(): string {
@@ -151,7 +197,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
    * log and no error. Bounding it turns that silent stall into a normal connect
    * failure that backoff retries — and that error reporting can observe.
    */
-  private async waitForBridgeReady(): Promise<any> {
+  private async waitForBridgeReady(): Promise<Awaited<ReturnType<typeof waitForEvenAppBridge>>> {
     const pending = waitForEvenAppBridge();
     // Promise.race already handles a late settle, but keep this explicit so the
     // abandoned SDK promise can never surface as an unhandled rejection.

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -1,5 +1,4 @@
 import {
-  waitForEvenAppBridge,
   ImageContainerProperty,
   ImageRawDataUpdate,
   TextContainerProperty,
@@ -11,64 +10,24 @@ import {
   OsEventTypeList,
 } from '@evenrealities/even_hub_sdk';
 import { HudViewModel } from '../../domain/models/hud';
+import {
+  DEFAULT_BRIDGE_READY_TIMEOUT_MS,
+  resolveBridgeReadyTimeoutMs,
+  waitForEvenAppBridgeWithin,
+} from '../even-app/bridge-ready';
 import { createSpeedPng } from './speed-png-generator';
 
-/**
- * Upper bound for the SDK bridge handshake.
- *
- * The WebView pushes the bridge once page loading completes, so this only needs
- * to be generous enough to cover a slow start-up. Paired with AppController's
- * backoff (max 10s) it retries roughly every 20s while the bridge is absent.
- */
-export const DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000;
+export { DEFAULT_BRIDGE_READY_TIMEOUT_MS };
 
-/**
- * Largest delay `setTimeout` can actually hold (2^31 - 1 ms, ~24.9 days).
- *
- * Anything above it overflows the 32-bit timer and fires after ~1ms instead,
- * so a caller asking for a very long wait would silently get an instant one.
- */
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
-
-/**
- * Resolves the configured handshake bound to a delay `setTimeout` can honour.
- *
- * `setTimeout` never rejects a bad delay, it quietly substitutes 1ms:
- * `Infinity`, `NaN` and negatives all fire on the next tick. Passing one
- * through would not restore the unbounded wait this bound exists to prevent —
- * it causes the opposite failure, a handshake that expires before the bridge
- * can ever answer, leaving the adapter permanently unable to connect. Values
- * over {@link MAX_TIMER_DELAY_MS} overflow into the same instant-fire
- * behaviour, so they are clamped rather than rejected.
- */
-function resolveBridgeReadyTimeoutMs(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
-
-  if (!Number.isFinite(value) || value <= 0) {
-    console.warn(
-      `[EvenG2Adapter] Ignoring invalid bridgeReadyTimeoutMs (${value}); ` +
-        `falling back to ${DEFAULT_BRIDGE_READY_TIMEOUT_MS}ms.`
-    );
-    return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
-  }
-
-  if (value > MAX_TIMER_DELAY_MS) {
-    console.warn(
-      `[EvenG2Adapter] Clamping bridgeReadyTimeoutMs (${value}) to ` +
-        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
-    );
-    return MAX_TIMER_DELAY_MS;
-  }
-
-  return value;
-}
+const BRIDGE_TIMEOUT_LOG_PREFIX = '[EvenG2Adapter]';
 
 export interface HybridEvenG2AdapterOptions {
   /**
    * Overrides {@link DEFAULT_BRIDGE_READY_TIMEOUT_MS}.
    *
    * Must be a finite, positive number of milliseconds. Anything else falls
-   * back to the default; values beyond {@link MAX_TIMER_DELAY_MS} are clamped.
+   * back to the default; values beyond the largest delay `setTimeout` can hold
+   * are clamped.
    */
   bridgeReadyTimeoutMs?: number;
 }
@@ -138,7 +97,10 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     options: HybridEvenG2AdapterOptions = {}
   ) {
     this.onRenderCallback = onRender;
-    this.bridgeReadyTimeoutMs = resolveBridgeReadyTimeoutMs(options.bridgeReadyTimeoutMs);
+    this.bridgeReadyTimeoutMs = resolveBridgeReadyTimeoutMs(
+      options.bridgeReadyTimeoutMs,
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
   }
 
   public getLastImageResult(): string {
@@ -188,43 +150,12 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
   }
 
-  /**
-   * Bounded wrapper around the SDK handshake.
-   *
-   * `waitForEvenAppBridge()` resolves on an `evenAppBridgeReady` event and the SDK
-   * exposes no timeout, so a bridge that never initializes parks connect() forever:
-   * AppController's reconnect loop awaits it and never iterates again, leaving no
-   * log and no error. Bounding it turns that silent stall into a normal connect
-   * failure that backoff retries — and that error reporting can observe.
-   */
-  private async waitForBridgeReady(): Promise<Awaited<ReturnType<typeof waitForEvenAppBridge>>> {
-    const pending = waitForEvenAppBridge();
-    // Promise.race already handles a late settle, but keep this explicit so the
-    // abandoned SDK promise can never surface as an unhandled rejection.
-    void pending.catch(() => {});
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const expiry = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(
-        () =>
-          reject(
-            new Error(`waitForEvenAppBridge() timed out after ${this.bridgeReadyTimeoutMs}ms`)
-          ),
-        this.bridgeReadyTimeoutMs
-      );
-    });
-
-    try {
-      return await Promise.race([pending, expiry]);
-    } finally {
-      clearTimeout(timer);
-    }
-  }
-
   public async connect(): Promise<boolean> {
     try {
       if (!this.bridge) {
-        this.bridge = await this.waitForBridgeReady();
+        // Bounded: an unbounded handshake parks this reconnect loop forever,
+        // with no log and no error. See ../even-app/bridge-ready.
+        this.bridge = await waitForEvenAppBridgeWithin(this.bridgeReadyTimeoutMs);
         console.log('[EvenG2Adapter] waitForEvenAppBridge() resolved!');
       }
 

--- a/src/infrastructure/geolocation/even-app-location-provider.ts
+++ b/src/infrastructure/geolocation/even-app-location-provider.ts
@@ -2,10 +2,26 @@ import {
   AppLocation,
   AppLocationAccuracy,
   EvenAppBridge,
-  waitForEvenAppBridge,
 } from '@evenrealities/even_hub_sdk';
 import { LocationSample } from '../../domain/models/location';
+import {
+  resolveBridgeReadyTimeoutMs,
+  waitForEvenAppBridgeWithin,
+} from '../even-app/bridge-ready';
 import { BrowserLocationProvider, LocationProvider, LocationProviderError } from './browser-location-provider';
+
+const BRIDGE_TIMEOUT_LOG_PREFIX = '[EvenAppLocationProvider]';
+
+export interface EvenAppLocationProviderOptions {
+  /**
+   * Overrides `DEFAULT_BRIDGE_READY_TIMEOUT_MS` from `../even-app/bridge-ready`.
+   *
+   * Must be a finite, positive number of milliseconds. Anything else falls
+   * back to the default; values beyond the largest delay `setTimeout` can hold
+   * are clamped.
+   */
+  bridgeReadyTimeoutMs?: number;
+}
 
 export class EvenAppUnavailableError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -18,6 +34,14 @@ export class EvenAppLocationProvider implements LocationProvider {
   private bridge: EvenAppBridge | null = null;
   private unsubscribe: (() => void) | null = null;
   private started = false;
+  private readonly bridgeReadyTimeoutMs: number;
+
+  constructor(options: EvenAppLocationProviderOptions = {}) {
+    this.bridgeReadyTimeoutMs = resolveBridgeReadyTimeoutMs(
+      options.bridgeReadyTimeoutMs,
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+  }
 
   public async start(
     onLocation: (sample: LocationSample) => void,
@@ -26,7 +50,10 @@ export class EvenAppLocationProvider implements LocationProvider {
     if (this.started) return;
 
     try {
-      this.bridge = await waitForEvenAppBridge();
+      // Bounded: an unbounded handshake leaves start() pending forever, so GPS
+      // never begins, onError never fires, and AdaptiveLocationProvider never
+      // sees the EvenAppUnavailableError it needs to reach browser geolocation.
+      this.bridge = await waitForEvenAppBridgeWithin(this.bridgeReadyTimeoutMs);
       this.unsubscribe = this.bridge.onAppLocationChanged((location) => {
         onLocation(this.toSample(location));
       });

--- a/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
+++ b/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
@@ -151,3 +151,92 @@ describe('HybridEvenG2Adapter bridge-ready timeout', () => {
     expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 });
+
+/**
+ * `setTimeout` never rejects a bad delay — it silently substitutes ~1ms, so
+ * `Infinity`, `NaN`, `0` and negatives all fire on the next tick. An
+ * unvalidated option therefore does not reinstate the unbounded wait; it does
+ * the reverse, expiring the handshake before the bridge can ever answer and
+ * leaving the adapter permanently unable to connect. These assert the delay
+ * actually handed to the timer, which costs no wall-clock time and leaves no
+ * live timer behind.
+ */
+describe('HybridEvenG2Adapter bridgeReadyTimeoutMs validation', () => {
+  /**
+   * Counts only the option-validation warnings; unrelated bridge chatter (e.g. a
+   * background speed-image flush) also lands on console.warn during connect().
+   */
+  function boundWarnings(warn: { mock: { calls: unknown[][] } }): unknown[][] {
+    return warn.mock.calls.filter((args) => String(args[0]).includes('bridgeReadyTimeoutMs'));
+  }
+
+  const invalidBounds: Array<[string, number]> = [
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
+    ['NaN', Number.NaN],
+    ['zero', 0],
+    ['a negative value', -1],
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
+    sdk.bridge.onEvenHubEvent.mockImplementation(() => vi.fn());
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(invalidBounds)('falls back to the default bound when given %s', async (_label, value) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: value });
+    expect(await adapter.connect()).toBe(true);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      DEFAULT_BRIDGE_READY_TIMEOUT_MS
+    );
+    // An overridden option is silently dropped otherwise; say so.
+    expect(boundWarnings(warn)).toHaveLength(1);
+  });
+
+  it('clamps a bound past the 32-bit timer limit instead of overflowing to ~1ms', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    // Finite and positive, so a Number.isFinite-only guard would let it through,
+    // yet setTimeout fires it after ~1ms.
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 2 ** 31 });
+    expect(await adapter.connect()).toBe(true);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2_147_483_647);
+    expect(boundWarnings(warn)).toHaveLength(1);
+  });
+
+  it('passes a valid bound through untouched', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 1234 });
+    expect(await adapter.connect()).toBe(true);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1234);
+    expect(boundWarnings(warn)).toHaveLength(0);
+  });
+
+  it('uses the default when no bound is supplied', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      DEFAULT_BRIDGE_READY_TIMEOUT_MS
+    );
+  });
+});

--- a/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
+++ b/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sdk = vi.hoisted(() => ({
+  bridge: {
+    createStartUpPageContainer: vi.fn(),
+    rebuildPageContainer: vi.fn(),
+    updateImageRawData: vi.fn(),
+    textContainerUpgrade: vi.fn(),
+    shutDownPageContainer: vi.fn(),
+    onEvenHubEvent: vi.fn(),
+  },
+  waitForEvenAppBridge: vi.fn(),
+}));
+
+vi.mock('@evenrealities/even_hub_sdk', () => {
+  class Model {
+    constructor(data: Record<string, unknown>) { Object.assign(this, data); }
+  }
+  return {
+    waitForEvenAppBridge: sdk.waitForEvenAppBridge,
+    ImageContainerProperty: Model,
+    ImageRawDataUpdate: Model,
+    TextContainerProperty: Model,
+    TextContainerUpgrade: Model,
+    CreateStartUpPageContainer: Model,
+    RebuildPageContainer: Model,
+    StartUpPageCreateResult: { success: 'success' },
+    ImageRawDataUpdateResult: { isSuccess: (value: string) => value === 'success' },
+    OsEventTypeList: {
+      FOREGROUND_ENTER_EVENT: 4,
+      FOREGROUND_EXIT_EVENT: 5,
+      ABNORMAL_EXIT_EVENT: 6,
+      SYSTEM_EXIT_EVENT: 7,
+    },
+  };
+});
+
+vi.mock('../../src/infrastructure/even-g2/speed-png-generator', () => ({
+  createSpeedPng: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+}));
+
+import {
+  DEFAULT_BRIDGE_READY_TIMEOUT_MS,
+  HybridEvenG2Adapter,
+} from '../../src/infrastructure/even-g2/even-g2-adapter';
+
+/** Let pending timers and the microtask queue settle. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('HybridEvenG2Adapter bridge-ready timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
+    sdk.bridge.onEvenHubEvent.mockImplementation(() => vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to a bounded wait rather than an unlimited one', () => {
+    expect(DEFAULT_BRIDGE_READY_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(DEFAULT_BRIDGE_READY_TIMEOUT_MS)).toBe(true);
+  });
+
+  it('gives up when the bridge never becomes ready, instead of hanging forever', async () => {
+    // The SDK waits for an `evenAppBridgeReady` event that never arrives.
+    sdk.waitForEvenAppBridge.mockReturnValue(new Promise(() => {}));
+
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+
+    // Without a timeout this await never settles and the test times out.
+    await expect(adapter.connect()).resolves.toBe(false);
+
+    expect(adapter.isBridgeConnected()).toBe(false);
+    // The page must not be attempted when we never got a bridge.
+    expect(sdk.bridge.createStartUpPageContainer).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the timeout as an error so telemetry in connect() can capture it', async () => {
+    sdk.waitForEvenAppBridge.mockReturnValue(new Promise(() => {}));
+    const logged: unknown[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args);
+    });
+
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+    await adapter.connect();
+
+    const notice = logged.find(
+      (args) =>
+        Array.isArray(args) &&
+        typeof args[0] === 'string' &&
+        args[0].includes('Bridge connection notice')
+    ) as unknown[] | undefined;
+    expect(notice).toBeDefined();
+    expect(notice?.[1]).toBeInstanceOf(Error);
+    expect((notice?.[1] as Error).message).toMatch(/20 ?ms|timed out/i);
+  });
+
+  it('reconnects on a later attempt once the bridge becomes available', async () => {
+    sdk.waitForEvenAppBridge.mockReturnValueOnce(new Promise(() => {}));
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+
+    expect(await adapter.connect()).toBe(false);
+
+    // Bridge shows up before the AppController's next backoff attempt.
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    expect(await adapter.connect()).toBe(true);
+    expect(adapter.isBridgeConnected()).toBe(true);
+    expect(sdk.bridge.createStartUpPageContainer).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not raise an unhandled rejection when the abandoned wait rejects later', async () => {
+    let rejectBridge!: (reason: Error) => void;
+    sdk.waitForEvenAppBridge.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectBridge = reject;
+      })
+    );
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+      expect(await adapter.connect()).toBe(false);
+
+      // The orphaned SDK promise settles well after we stopped waiting on it.
+      rejectBridge(new Error('bridge channel torn down'));
+      await wait(20);
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('clears the timeout timer once the bridge resolves normally', async () => {
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 60_000 });
+    expect(await adapter.connect()).toBe(true);
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/geolocation/even-app-location-provider.test.ts
+++ b/tests/geolocation/even-app-location-provider.test.ts
@@ -21,6 +21,7 @@ import {
   EvenAppLocationProvider,
 } from '../../src/infrastructure/geolocation/even-app-location-provider';
 import { LocationProvider } from '../../src/infrastructure/geolocation/browser-location-provider';
+import { DEFAULT_BRIDGE_READY_TIMEOUT_MS } from '../../src/infrastructure/even-app/bridge-ready';
 
 describe('EvenAppLocationProvider', () => {
   beforeEach(() => {
@@ -107,4 +108,128 @@ describe('EvenAppLocationProvider', () => {
     await expect(provider.start(vi.fn())).rejects.toThrow(/permission denied/);
     expect(fallback.start).not.toHaveBeenCalled();
   });
+});
+
+/**
+ * Same failure mode as the Even G2 adapter handshake: `waitForEvenAppBridge()`
+ * resolves on an `evenAppBridgeReady` event the SDK never times out, so inside a
+ * WebView where the bridge never materializes `start()` simply never settles.
+ * GPS never begins, `onError` never fires, AppController's `.catch` never runs,
+ * and — because the browser fallback is gated on `EvenAppUnavailableError` — the
+ * designed fallback can never engage. Bounding the wait converts that silent
+ * stall into the ordinary unavailability the fallback already handles.
+ *
+ * Each case carries a short per-test timeout so an unbounded regression fails in
+ * about a second rather than waiting out vitest's default.
+ */
+describe('EvenAppLocationProvider bridge-ready timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('window', { flutter_inappwebview: { callHandler: vi.fn() } });
+    // The SDK waits on an `evenAppBridgeReady` event that never arrives.
+    sdk.waitForEvenAppBridge.mockReturnValue(new Promise(() => {}));
+    sdk.bridge.onAppLocationChanged.mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it(
+    'reports the stalled handshake instead of waiting on it forever',
+    async () => {
+      const provider = new EvenAppLocationProvider({ bridgeReadyTimeoutMs: 20 });
+      const onLocation = vi.fn();
+      const onError = vi.fn();
+
+      // Without a bound this await never settles and the test times out.
+      await expect(provider.start(onLocation, onError)).rejects.toBeInstanceOf(
+        EvenAppUnavailableError
+      );
+
+      // The configured bound must actually reach the timer, not just the default.
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('20ms') })
+      );
+      expect(onLocation).not.toHaveBeenCalled();
+      // No bridge means no subscription and no location request was attempted.
+      expect(sdk.bridge.onAppLocationChanged).not.toHaveBeenCalled();
+      expect(sdk.bridge.getAppLocation).not.toHaveBeenCalled();
+    },
+    1000
+  );
+
+  it(
+    'lets browser geolocation take over when the bridge never becomes ready',
+    async () => {
+      const primary = new EvenAppLocationProvider({ bridgeReadyTimeoutMs: 20 });
+      const fallback: LocationProvider = { start: vi.fn(), stop: vi.fn() };
+      const provider = new AdaptiveLocationProvider(primary, fallback);
+      const onLocation = vi.fn();
+
+      await provider.start(onLocation);
+
+      expect(fallback.start).toHaveBeenCalledOnce();
+
+      await provider.stop();
+      expect(fallback.stop).toHaveBeenCalledOnce();
+    },
+    1000
+  );
+
+  it(
+    'still starts normally when the bridge arrives before the bound expires',
+    async () => {
+      sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+      sdk.bridge.getAppLocation.mockResolvedValue({
+        latitude: 35.6812,
+        longitude: 139.7671,
+        accuracy: 4,
+        speed: 12,
+        heading: 30,
+        timestamp: 1234,
+      });
+      sdk.bridge.startAppLocationUpdates.mockResolvedValue(true);
+
+      const provider = new EvenAppLocationProvider({ bridgeReadyTimeoutMs: 20 });
+      const onLocation = vi.fn();
+
+      await provider.start(onLocation);
+
+      expect(onLocation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: 35.6812, timestampMs: 1234 })
+      );
+    },
+    1000
+  );
+
+  it(
+    'falls back to the default bound rather than an instant-firing one',
+    async () => {
+      // Resolve the handshake so the assertion inspects the delay handed to the
+      // timer without leaving a live 10s timer behind.
+      sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+      sdk.bridge.getAppLocation.mockResolvedValue(null);
+      sdk.bridge.startAppLocationUpdates.mockResolvedValue(true);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      // setTimeout silently substitutes ~1ms for Infinity, so an unvalidated
+      // option would expire the handshake before the bridge could ever answer.
+      const provider = new EvenAppLocationProvider({
+        bridgeReadyTimeoutMs: Number.POSITIVE_INFINITY,
+      });
+      await provider.start(vi.fn());
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        DEFAULT_BRIDGE_READY_TIMEOUT_MS
+      );
+      expect(
+        warn.mock.calls.filter((args) => String(args[0]).includes('bridgeReadyTimeoutMs'))
+      ).toHaveLength(1);
+    },
+    1000
+  );
 });


### PR DESCRIPTION
## 概要

`waitForEvenAppBridge()` の無期限待機に上限を設け、ブリッジが ready にならない環境で発生する**無音の恒久停止**を、backoff 再接続へ進む通常の接続失敗に変える。

Closes #29

## 問題

SDK の `waitForEvenAppBridge()` は `evenAppBridgeReady` イベントで解決し、タイムアウト機構を持たない（型定義 `waitForEvenAppBridge(): Promise<EvenAppBridge>` は引数を取らない）。イベントが来なければ無期限に待つ。

`connect()` がこれをそのまま await していたため、ブリッジが初期化されない環境では:

1. `connect()` が返らない
2. `AppController.connectEvenG2InBackground()` が `app-controller.ts:115` で停止し、`while (this.isRunning)` ループが二度と回らない
3. backoff 再接続が発生せず、エラーログも一切出ない

回復不能な停止でありながら可観測性がゼロという状態だった。

## 変更内容

`waitForBridgeReady()` を追加し、`connect()` はこれを経由する。

- `DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000`。WebView はページロード完了後にブリッジを push するため、遅い起動を吸収できれば十分。AppController の backoff（最大10秒）と合わせ、ブリッジ不在時はおよそ20秒間隔で再試行する
- コンストラクタ第2引数 `{ bridgeReadyTimeoutMs }` で上書き可能（テストおよび調整用）
- タイムアウト時は throw し、`connect()` の既存 catch を通って `false` を返す
- 放棄した SDK Promise に明示的に catch を張り、遅延して解決／棄却しても unhandled rejection にしない（`Promise.race` が既にハンドラを張るため二重の防御）
- 正常・異常どちらの経路でも `finally` でタイマーを解放する

`this.bridge` は失敗時 null のままなので、次回 `connect()` が再度 SDK を呼ぶ。SDK 側はまず既存ブリッジの ready を確認して即返すため、再試行は安価。

## 診断上の効果

PR #26 は `connect()` の catch に `captureRuntimeError(err, 'even-g2-connect')` を置く。従来ハング分岐は例外を投げないためこの経路に到達せず、breadcrumb もイベント添付でしか送信されないため、**Sentry 側は完全に無音**だった。「何も来ない」がハングなのか Sentry 未初期化なのか区別できない状態。

本 PR で待機失敗が例外になるため、**新規の計装コードを足さずに** #26 の既存経路がハングを捕捉できる。

## テスト

`tests/even-g2/even-g2-adapter-bridge-timeout.test.ts`（新規6件）

- デフォルト値が有限であること
- ブリッジが永久に解決しないとき `connect()` が `false` を返し、`createStartUpPageContainer` を呼ばないこと
- タイムアウトが `Error` として catch に届くこと（#26 の捕捉経路の前提）
- 初回タイムアウト後、ブリッジ復帰で次回 `connect()` が成功すること
- 放棄した Promise が後から reject しても unhandled rejection が出ないこと
- 正常解決時にタイマーが解放されること

**非空虚性確認:** 実装前に6件すべて失敗。うちハング系2件は vitest 自身の5秒タイムアウトで落ちており、これがバグの再現そのもの。

## 検証

```
pnpm test          Test Files 20 passed (20) / Tests 70 passed (70)   ← baseline 64 から +6
npx tsc --noEmit   exit 0
pnpm lint          exit 0
```

## マージ順

本 PR は `main` 起点。#24（`fix/issue-17-g2-recovery-reconnect`）との試験マージは**競合なし**で、マージ後も 74 tests / tsc 通過を確認済み。

なお #24 と #26 は本 PR とは独立に `even-g2-adapter.ts` で相互に競合する（`connect()` catch と `recoverPage()` catch の2箇所）。#24 → #26 の順で、#26 側を rebase して `captureRuntimeError` を #24 の構造へ載せ直すのが素直。

## 補足

`docs/EVEN_G2_VERIFICATION.md` の「ローカル timeout で Promise だけを打ち切る実装は禁止する」は、キャンセル API を持たない native BLE **画像転送**（`updateImageRawData`）に対する制約であり、ブリッジ待機には該当しない。本 PR は画像転送の待機には一切手を入れていない。

## Copilot レビュー対応

`dc125a2` で2件の指摘に対応した。

### 1. `bridgeReadyTimeoutMs` の検証（挙動変更あり）

指摘は「`Infinity` を渡すと無期限待機に戻る」だったが、**実際の失敗モードは逆**だった。`setTimeout` は不正な delay を拒否せず 1ms に置き換えるため、Node 26.3.0 実測で `Infinity` / `-Infinity` / `NaN` / `0` / `-1` はいずれも約 1〜2ms で発火する（ブラウザでも WebIDL `long` 変換により ±Infinity・NaN は 0 になる）。つまり無期限待機ではなく、**ハンドシェイクがブリッジの応答前に即座に期限切れになり、アダプタが恒久的に接続できなくなる**。

検証してデフォルトへフォールバックするという指摘自体は妥当なので実装した。

- `resolveBridgeReadyTimeoutMs()` を追加し、コンストラクタで一度だけ解決
- 非有限値・0・負値は `console.warn` のうえ `DEFAULT_BRIDGE_READY_TIMEOUT_MS` へフォールバック
- 加えて 2^31-1 超の値をクランプ（`2**31` は有限かつ正で `Number.isFinite` ガードを通過するが、32bit タイマーをオーバーフローして同じく 1ms で発火するため）
- `HybridEvenG2AdapterOptions` の許容範囲を JSDoc に明記

**`HybridEvenG2AdapterOptions.bridgeReadyTimeoutMs` は不正値を渡すと警告のうえ上書きされるようになった**（従来はそのまま `setTimeout` へ渡していた）。

### 2. `waitForBridgeReady()` の戻り値型

`Promise<any>` → `Promise<Awaited<ReturnType<typeof waitForEvenAppBridge>>>`（= `EvenAppBridge`）。クラスフィールド `private bridge: any` は本 PR 以前からのものなので変更していない。型のみの変更につき実行時テストは追加せず、担保は `tsc --noEmit`。

### テスト

`tests/even-g2/even-g2-adapter-bridge-timeout.test.ts` に8件追加（計14件）。`setTimeout` に実際に渡された delay を spy で検証する方式とし、実時間を消費せずタイマーも残さない。fake timer は「不正な delay の扱い」自体が検証対象でありシムの挙動を測ることになるため採用しなかった。

**非空虚性確認:** src の変更のみを戻すと8件中6件（不正値5件＋クランプ1件）が失敗。残り2件は対照用。

```
pnpm test          Test Files 20 passed (20) / Tests 78 passed (78)   ← 70 から +8
npx tsc --noEmit   exit 0
pnpm lint          exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk

