### PR TITLE
滞留したページ復旧を積んだ時点のセッションに束縛する (#32)

### DIFF
--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -90,6 +90,16 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
   private disconnectWaiters: Array<() => void> = [];
 
+  /**
+   * Incremented every time a new native page session is established.
+   *
+   * `isConnected` is a plain boolean, so it cannot distinguish "still the
+   * session I was queued for" from "a different session that happens to be
+   * connected now" (ABA). Bridge operations that sit in bridgeQueue capture
+   * this at enqueue time and re-check it before touching the page.
+   */
+  private sessionEpoch = 0;
+
   private readonly bridgeReadyTimeoutMs: number;
 
   constructor(
@@ -190,6 +200,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         this.flushedGeneration = 0;
         this.pageReady = true;
         this.isConnected = true;
+        this.sessionEpoch += 1;
         this.subscribeToLifecycleEvents();
 
         // Initial image after page is ready (must stay on bridgeQueue). Failures must not block text/GPS.
@@ -506,16 +517,25 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     // Once disconnected, the reconnect loop owns recovery: never resurrect the
     // session from a stale foreground event.
     if (!this.bridge || !this.isConnected) return;
+    // Bind this recovery to the session that is live right now. A slow BLE op can
+    // hold bridgeQueue long enough for this session to die and the reconnect loop
+    // to build a replacement, and createStartUpPageContainer does not go through
+    // the queue — so by the time we run, `isConnected` may be true for a session
+    // that was never ours.
+    const epoch = this.sessionEpoch;
     console.log('[EvenG2Adapter] FOREGROUND_ENTER — rebuilding page containers');
+
+    let rebuiltThisSession = false;
     try {
       await this.enqueueBridgeOperation(async () => {
-        // A disconnect may have landed while this rebuild waited in the queue.
-        if (!this.isConnected) throw new Error('bridge disconnected before rebuild');
+        // A disconnect — or a whole disconnect/reconnect cycle — may have landed
+        // while this rebuild waited in the queue.
+        if (!this.isConnected || this.sessionEpoch !== epoch) return;
         const rebuilt = await this.bridge.rebuildPageContainer(
           new RebuildPageContainer({ containerTotalNum: 4, ...this.createPageDefinition() })
         );
         if (!rebuilt) throw new Error('rebuildPageContainer failed');
-        if (!this.isConnected) throw new Error('bridge disconnected during rebuild');
+        if (!this.isConnected || this.sessionEpoch !== epoch) return;
         this.lastHeaderContent = '';
         this.lastSegmentContent = '';
         this.lastFooterContent = '';
@@ -524,12 +544,23 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         this.flushedGeneration = 0;
         this.pageReady = true;
         this.isConnected = true;
+        rebuiltThisSession = true;
       });
     } catch (error) {
       console.warn('[EvenG2Adapter] Page recovery failed:', error);
-      // A failed rebuild leaves no usable page: transition to the disconnected
-      // state so waitUntilDisconnected() resolves and AppController reconnects.
-      this.markDisconnected('page recovery failed');
+      // Only our own session's failure means "no usable page". If a newer session
+      // already owns the bridge, tearing it down here would resolve its disconnect
+      // waiter and cost a spurious reconnect cycle for a page we never built.
+      if (this.sessionEpoch === epoch) {
+        // A failed rebuild leaves no usable page: transition to the disconnected
+        // state so waitUntilDisconnected() resolves and AppController reconnects.
+        this.markDisconnected('page recovery failed');
+      }
+      return;
+    }
+
+    if (!rebuiltThisSession) {
+      console.log('[EvenG2Adapter] Skipped stale page recovery (session already replaced)');
       return;
     }
 

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -560,7 +560,9 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
 
     if (!rebuiltThisSession) {
-      console.log('[EvenG2Adapter] Skipped stale page recovery (session already replaced)');
+      // Either the session was torn down outright, or it was torn down and a new
+      // one took its place; both leave this recovery with no page of its own.
+      console.log('[EvenG2Adapter] Skipped page recovery (its session is no longer current)');
       return;
     }
 

--- a/tests/even-g2/even-g2-adapter-session-epoch.test.ts
+++ b/tests/even-g2/even-g2-adapter-session-epoch.test.ts
@@ -166,6 +166,74 @@ describe('HybridEvenG2Adapter stale recovery across a reconnect', () => {
     expect(disconnected).toBe(false);
   });
 
+  /**
+   * Parks the rebuild IN FLIGHT rather than behind another op, so the pre-check
+   * has already passed and the epoch only changes while rebuildPageContainer is
+   * awaiting. This is the path that reaches the catch-side epoch guard.
+   */
+  async function rebuildInFlightAcrossReconnect(): Promise<{
+    adapter: HybridEvenG2Adapter;
+    finishRebuild: (result: boolean) => void;
+    secondConnect: Promise<boolean>;
+  }> {
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true); // session A
+    // Populate lastModel so an adopted rebuild would force a HUD re-flush.
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    let finishRebuild!: (result: boolean) => void;
+    sdk.bridge.rebuildPageContainer.mockImplementationOnce(
+      () => new Promise((resolve) => { finishRebuild = resolve; })
+    );
+
+    // Queue is free, so the rebuild starts immediately and passes its pre-check.
+    hubEvent?.({ sysEvent: { eventType: 5 } }); // FOREGROUND_EXIT
+    hubEvent?.({ sysEvent: { eventType: 4 } }); // FOREGROUND_ENTER
+    await flushBridge();
+    expect(sdk.bridge.rebuildPageContainer).toHaveBeenCalledTimes(1);
+
+    // Session A dies and is replaced while the native rebuild is still awaiting.
+    hubEvent?.({ sysEvent: { eventType: 6 } }); // ABNORMAL_EXIT
+    const secondConnect = adapter.connect(); // session B
+    await flushBridge();
+    expect(adapter.isBridgeConnected()).toBe(true);
+
+    return { adapter, finishRebuild, secondConnect };
+  }
+
+  it('does not tear down the reconnected session when an in-flight rebuild then fails', async () => {
+    const { adapter, finishRebuild, secondConnect } = await rebuildInFlightAcrossReconnect();
+
+    let disconnected = false;
+    void adapter.waitUntilDisconnected!().then(() => { disconnected = true; });
+
+    // The failure belongs to session A, which is already gone.
+    finishRebuild(false);
+    await flushBridge();
+    expect(await secondConnect).toBe(true);
+
+    expect(adapter.isBridgeConnected()).toBe(true);
+    expect(disconnected).toBe(false);
+  });
+
+  it('does not adopt an in-flight rebuild that succeeded for a dead session', async () => {
+    const { adapter, finishRebuild, secondConnect } = await rebuildInFlightAcrossReconnect();
+
+    const textCallsBefore = sdk.bridge.textContainerUpgrade.mock.calls.length;
+
+    // Even a successful rebuild belonged to session A. Adopting it would clear
+    // session B's container caches and push a fresh HUD flush on its behalf;
+    // skipping leaves session B's page untouched.
+    finishRebuild(true);
+    await flushBridge();
+    expect(await secondConnect).toBe(true);
+
+    expect(sdk.bridge.textContainerUpgrade.mock.calls.length).toBe(textCallsBefore);
+    expect(adapter.isBridgeConnected()).toBe(true);
+    expect(sdk.bridge.rebuildPageContainer).toHaveBeenCalledTimes(1);
+  });
+
   it('still recovers normally when no reconnect happened in between', async () => {
     const adapter = new HybridEvenG2Adapter();
     expect(await adapter.connect()).toBe(true);

--- a/tests/even-g2/even-g2-adapter-session-epoch.test.ts
+++ b/tests/even-g2/even-g2-adapter-session-epoch.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HudViewModel } from '../../src/domain/models/hud';
+
+const sdk = vi.hoisted(() => ({
+  bridge: {
+    createStartUpPageContainer: vi.fn(),
+    rebuildPageContainer: vi.fn(),
+    updateImageRawData: vi.fn(),
+    textContainerUpgrade: vi.fn(),
+    shutDownPageContainer: vi.fn(),
+    onEvenHubEvent: vi.fn(),
+  },
+  waitForEvenAppBridge: vi.fn(),
+}));
+
+vi.mock('@evenrealities/even_hub_sdk', () => {
+  class Model {
+    constructor(data: Record<string, unknown>) { Object.assign(this, data); }
+  }
+  return {
+    waitForEvenAppBridge: sdk.waitForEvenAppBridge,
+    ImageContainerProperty: Model,
+    ImageRawDataUpdate: Model,
+    TextContainerProperty: Model,
+    TextContainerUpgrade: Model,
+    CreateStartUpPageContainer: Model,
+    RebuildPageContainer: Model,
+    StartUpPageCreateResult: { success: 'success' },
+    ImageRawDataUpdateResult: { isSuccess: (value: string) => value === 'success' },
+    OsEventTypeList: {
+      FOREGROUND_ENTER_EVENT: 4,
+      FOREGROUND_EXIT_EVENT: 5,
+      ABNORMAL_EXIT_EVENT: 6,
+      SYSTEM_EXIT_EVENT: 7,
+    },
+  };
+});
+
+vi.mock('../../src/infrastructure/even-g2/speed-png-generator', () => ({
+  createSpeedPng: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+}));
+
+import { HybridEvenG2Adapter } from '../../src/infrastructure/even-g2/even-g2-adapter';
+
+function viewModel(speed: string): HudViewModel {
+  return {
+    header: { lineName: '小田急線', serviceOrDirection: '上り' },
+    speed: { displaySpeedKmhText: speed, unitText: 'km/h', isEstimated: false },
+    segment: {
+      previousStationName: '海老名',
+      nextStationName: '座間',
+      progressRatio: 0.5,
+      distanceToNextText: '次まで 1km',
+    },
+    footer: { leftInfo: '上り', statusRight: 'GPS' },
+    statusMode: 'GPS',
+    rawFormattedText: speed,
+    timestampMs: 1000,
+  };
+}
+
+/** Drain microtasks + any queued bridge flushes. */
+async function flushBridge(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/**
+ * A stale rebuild is one that was queued for session A but only reaches the
+ * front of bridgeQueue after session A died and the reconnect loop established
+ * session B. `isConnected` is true in both cases, so it cannot tell them apart.
+ */
+describe('HybridEvenG2Adapter stale recovery across a reconnect', () => {
+  let hubEvent: ((event: any) => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(true);
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
+    sdk.bridge.shutDownPageContainer.mockResolvedValue(true);
+    sdk.bridge.onEvenHubEvent.mockImplementation((callback) => {
+      hubEvent = callback;
+      return vi.fn();
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Drives the adapter into the exact interleaving from issue #32 and leaves the
+   * stale rebuild parked behind a slow BLE text update.
+   *
+   * Returns a `releaseSlowOp` that lets the queue drain, at which point the
+   * stale rebuild reaches the front.
+   */
+  async function parkStaleRebuildBehindSlowOp(): Promise<{
+    adapter: HybridEvenG2Adapter;
+    releaseSlowOp: () => void;
+    secondConnect: Promise<boolean>;
+  }> {
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true); // session A
+
+    // A slow BLE text update takes the queue and stays in flight.
+    let releaseSlowOp!: () => void;
+    sdk.bridge.textContainerUpgrade.mockImplementationOnce(
+      () => new Promise((resolve) => { releaseSlowOp = () => resolve(true); })
+    );
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    // Foreground bounce queues a rebuild BEHIND the in-flight slow op.
+    hubEvent?.({ sysEvent: { eventType: 5 } }); // FOREGROUND_EXIT
+    hubEvent?.({ sysEvent: { eventType: 4 } }); // FOREGROUND_ENTER
+    await flushBridge();
+    expect(sdk.bridge.rebuildPageContainer).not.toHaveBeenCalled(); // still queued
+
+    // Session A dies and the reconnect loop immediately establishes session B.
+    // createStartUpPageContainer does NOT go through bridgeQueue, so session B
+    // is live (isConnected === true) while connect()'s initial image push is
+    // still queued behind the slow op — and behind the stale rebuild.
+    hubEvent?.({ sysEvent: { eventType: 6 } }); // ABNORMAL_EXIT
+    expect(adapter.isBridgeConnected()).toBe(false);
+    const secondConnect = adapter.connect(); // session B — do not await yet
+    await flushBridge();
+    expect(adapter.isBridgeConnected()).toBe(true);
+    expect(sdk.bridge.createStartUpPageContainer).toHaveBeenCalledTimes(2);
+
+    return { adapter, releaseSlowOp, secondConnect };
+  }
+
+  it('does not rebuild the page of a session it was not queued for', async () => {
+    const { adapter, releaseSlowOp, secondConnect } = await parkStaleRebuildBehindSlowOp();
+
+    releaseSlowOp();
+    await flushBridge();
+    expect(await secondConnect).toBe(true);
+
+    // The rebuild belonged to session A, which no longer exists.
+    expect(sdk.bridge.rebuildPageContainer).not.toHaveBeenCalled();
+    expect(adapter.isBridgeConnected()).toBe(true);
+  });
+
+  it('does not tear down the reconnected session when the stale rebuild fails', async () => {
+    const { adapter, releaseSlowOp, secondConnect } = await parkStaleRebuildBehindSlowOp();
+
+    // Even if the native call would fail, session B must survive: a failure that
+    // belongs to a dead session must not resolve session B's disconnect waiter.
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(false);
+    let disconnected = false;
+    void adapter.waitUntilDisconnected!().then(() => { disconnected = true; });
+
+    releaseSlowOp();
+    await flushBridge();
+    expect(await secondConnect).toBe(true);
+
+    expect(adapter.isBridgeConnected()).toBe(true);
+    expect(disconnected).toBe(false);
+  });
+
+  it('still recovers normally when no reconnect happened in between', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true);
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    hubEvent?.({ sysEvent: { eventType: 5 } }); // FOREGROUND_EXIT
+    hubEvent?.({ sysEvent: { eventType: 4 } }); // FOREGROUND_ENTER
+    await flushBridge();
+
+    // Same session throughout, so the rebuild must actually run.
+    expect(sdk.bridge.rebuildPageContainer).toHaveBeenCalledTimes(1);
+    expect(adapter.isBridgeConnected()).toBe(true);
+  });
+
+  it('still disconnects when a rebuild fails within its own session', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    expect(await adapter.connect()).toBe(true);
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(false);
+
+    let disconnected = false;
+    void adapter.waitUntilDisconnected!().then(() => { disconnected = true; });
+
+    hubEvent?.({ sysEvent: { eventType: 5 } });
+    hubEvent?.({ sysEvent: { eventType: 4 } });
+    await flushBridge();
+
+    expect(adapter.isBridgeConnected()).toBe(false);
+    expect(disconnected).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

`recoverPage()` がキューに積む rebuild を、積んだ時点のセッションに束縛する。滞留した rebuild が別セッションのページを触る ABA 問題を解消する。

Closes #32

## 問題

`isConnected` は単なる boolean で、「自分が積まれたセッションがまだ生きている」のか「別のセッションがたまたま今つながっている」のかを区別できない。

`createStartUpPageContainer` は `bridgeQueue` を経由しないため、遅い BLE 転送がキューを塞いでいる間に次のセッションが確立され得る。

## 再現シーケンス（テストで再現済み）

1. セッションA が確立
2. 遅い `textContainerUpgrade` がキューを占有（実行中）
3. `FOREGROUND_EXIT` → `FOREGROUND_ENTER` で rebuild がその後ろに積まれる
4. `ABNORMAL_EXIT` でセッションA が死ぬ
5. 再接続ループが `connect()` を呼び、`createStartUpPageContainer` はキュー外なので**即座にセッションB が live になる**（`isConnected = true`）。connect() 自身は初期画像送信がキューに詰まるためまだ返っていない
6. 遅い操作が完了し、**滞留していた rebuild が走る**。`isConnected === true` を見て通過し、セッションB のページを rebuild する
7. `rebuildPageContainer` が失敗すると catch が `markDisconnected()` を呼び、**セッションB の disconnect waiter を解決**して余分な再接続サイクルを発生させる

## 変更内容

- セッション確立ごとに単調増加する `sessionEpoch` を追加（`connect()` 成功時に加算）
- `recoverPage()` はエントリ時点の epoch を捕捉し、キュー実行時に照合する
  - rebuild 実行前と、状態を書き戻す前の2箇所でチェック
  - 不一致なら**静かにスキップ**（例外を投げないので `markDisconnected` に落ちない）
- catch 側も epoch を照合し、**自分のセッションの失敗のときだけ** `markDisconnected()` する
- rebuild が実際に自セッションで完了したかを `rebuiltThisSession` で持ち、スキップ時は後段の HUD 再送も行わない

## テスト

`tests/even-g2/even-g2-adapter-session-epoch.test.ts`（新規4件）。ヘルパーが上記シーケンス1〜5を組み立て、滞留 rebuild をキューに残したまま返す。

- 滞留 rebuild が別セッションのページを rebuild しないこと
- 滞留 rebuild が失敗しても再接続済みセッションを破棄しないこと（disconnect waiter が解決されない）
- **対照群1**: 間に再接続がなければ rebuild は通常どおり実行されること
- **対照群2**: 自セッション内での rebuild 失敗では従来どおり切断へ遷移すること（#17 の修正を守る）

**非空虚性確認:** src の変更のみ stash すると新規2件が失敗（`rebuildPageContainer` が1回呼ばれる / `isBridgeConnected()` が false）。対照群2件は修正の有無に関わらず通過し、既存動作を守っていることを示す。

## 検証

```
pnpm test          Test Files 23 passed (23) / Tests 119 passed (119)   ← main 115 から +4
npx tsc --noEmit   exit 0
pnpm lint          exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk
