### PR TITLE
ブリッジ待機のリトライでSDKハンドシェイクを共有する (#34)

### DIFF
--- a/src/infrastructure/even-app/bridge-ready.ts
+++ b/src/infrastructure/even-app/bridge-ready.ts
@@ -56,6 +56,45 @@ export function resolveBridgeReadyTimeoutMs(
   return value;
 }
 
+let pendingHandshake: Promise<EvenAppBridge> | null = null;
+
+/**
+ * One shared handshake for all attempts.
+ *
+ * `waitForEvenAppBridge()` registers a one-shot `evenAppBridgeReady` listener per
+ * call and the SDK offers no cancellation, so a timed-out attempt cannot take its
+ * listener back. Calling the SDK again per retry would strand one listener — plus
+ * its closure and pending promise — on `window` every time, growing without bound
+ * for as long as the bridge stays absent.
+ *
+ * Sharing one handshake also makes a late bridge usable: the listener from the
+ * first attempt is still armed, so whichever attempt is waiting when the bridge
+ * finally arrives resolves with it.
+ */
+function sharedHandshake(): Promise<EvenAppBridge> {
+  const existing = pendingHandshake;
+  if (existing) return existing;
+
+  const started = waitForEvenAppBridge();
+  // A rejected handshake must not stay cached, or every later attempt would
+  // replay the same failure without ever asking the SDK again.
+  void started.catch(() => {
+    if (pendingHandshake === started) pendingHandshake = null;
+  });
+  pendingHandshake = started;
+  return started;
+}
+
+/**
+ * Drops the shared handshake.
+ *
+ * Only for tests: production code has a single bridge per page, so the cache is
+ * meant to live for the lifetime of the document.
+ */
+export function resetBridgeHandshakeForTests(): void {
+  pendingHandshake = null;
+}
+
 /**
  * Bounded wrapper around the SDK handshake.
  *
@@ -65,18 +104,17 @@ export function resolveBridgeReadyTimeoutMs(
  * settle, leaving no log and no error. Bounding it turns that silent stall into
  * an ordinary failure that backoff can retry and error reporting can observe.
  *
- * The losing side of the race is abandoned rather than cancelled — the SDK has
- * no cancellation — so a bridge that shows up late is dropped instead of being
- * wired up behind whatever fallback has since taken over.
+ * A timed-out attempt abandons the race but not the handshake: the SDK has no
+ * cancellation, so the underlying wait is kept and reused (see
+ * {@link sharedHandshake}) rather than restarted. A bridge that shows up late is
+ * therefore picked up by the next attempt instead of being lost.
  *
  * @param timeoutMs Must already be a delay `setTimeout` can honour; run
  *   caller-supplied values through {@link resolveBridgeReadyTimeoutMs} first.
  */
 export async function waitForEvenAppBridgeWithin(timeoutMs: number): Promise<EvenAppBridge> {
-  const pending = waitForEvenAppBridge();
-  // Promise.race already handles a late settle, but keep this explicit so the
-  // abandoned SDK promise can never surface as an unhandled rejection.
-  void pending.catch(() => {});
+  // Shared across attempts so retrying cannot accumulate SDK listeners.
+  const pending = sharedHandshake();
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   const expiry = new Promise<never>((_resolve, reject) => {

--- a/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
+++ b/tests/even-g2/even-g2-adapter-bridge-timeout.test.ts
@@ -43,6 +43,7 @@ import {
   DEFAULT_BRIDGE_READY_TIMEOUT_MS,
   HybridEvenG2Adapter,
 } from '../../src/infrastructure/even-g2/even-g2-adapter';
+import { resetBridgeHandshakeForTests } from '../../src/infrastructure/even-app/bridge-ready';
 
 /** Let pending timers and the microtask queue settle. */
 function wait(ms: number): Promise<void> {
@@ -52,6 +53,7 @@ function wait(ms: number): Promise<void> {
 describe('HybridEvenG2Adapter bridge-ready timeout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetBridgeHandshakeForTests();
     sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
     sdk.bridge.updateImageRawData.mockResolvedValue('success');
     sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
@@ -103,16 +105,45 @@ describe('HybridEvenG2Adapter bridge-ready timeout', () => {
   });
 
   it('reconnects on a later attempt once the bridge becomes available', async () => {
-    sdk.waitForEvenAppBridge.mockReturnValueOnce(new Promise(() => {}));
+    // The handshake outlives the attempt that timed out, so a bridge arriving
+    // during backoff resolves it and the next attempt picks it up.
+    let deliverBridge!: (bridge: unknown) => void;
+    sdk.waitForEvenAppBridge.mockReturnValue(
+      new Promise((resolve) => { deliverBridge = resolve; })
+    );
     const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
 
     expect(await adapter.connect()).toBe(false);
 
-    // Bridge shows up before the AppController's next backoff attempt.
-    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    deliverBridge(sdk.bridge);
     expect(await adapter.connect()).toBe(true);
     expect(adapter.isBridgeConnected()).toBe(true);
     expect(sdk.bridge.createStartUpPageContainer).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses one SDK handshake across retries instead of stranding a listener', async () => {
+    sdk.waitForEvenAppBridge.mockReturnValue(new Promise(() => {}));
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+
+    expect(await adapter.connect()).toBe(false);
+    expect(await adapter.connect()).toBe(false);
+    expect(await adapter.connect()).toBe(false);
+
+    // Each SDK call registers a one-shot `evenAppBridgeReady` listener that it
+    // cannot take back, so one call must cover all three attempts.
+    expect(sdk.waitForEvenAppBridge).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a handshake that rejected', async () => {
+    sdk.waitForEvenAppBridge.mockRejectedValueOnce(new Error('bridge init failed'));
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 20 });
+
+    expect(await adapter.connect()).toBe(false);
+
+    // A failed handshake must not be replayed forever: ask the SDK again.
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    expect(await adapter.connect()).toBe(true);
+    expect(sdk.waitForEvenAppBridge).toHaveBeenCalledTimes(2);
   });
 
   it('does not raise an unhandled rejection when the abandoned wait rejects later', async () => {
@@ -143,12 +174,25 @@ describe('HybridEvenG2Adapter bridge-ready timeout', () => {
 
   it('clears the timeout timer once the bridge resolves normally', async () => {
     sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    const timeoutMs = 60_000;
+
+    // Track the handle of the timer armed for THIS bound. Asserting only that
+    // clearTimeout was called would pass even if the handle were lost, since
+    // `finally { clearTimeout(timer) }` runs either way.
+    const armed: Array<ReturnType<typeof setTimeout>> = [];
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: any, delay?: number, ...rest: any[]) => {
+      const handle = realSetTimeout(fn, delay as any, ...rest);
+      if (delay === timeoutMs) armed.push(handle);
+      return handle;
+    }) as typeof globalThis.setTimeout);
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
-    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: 60_000 });
+    const adapter = new HybridEvenG2Adapter(undefined, { bridgeReadyTimeoutMs: timeoutMs });
     expect(await adapter.connect()).toBe(true);
 
-    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(armed).toHaveLength(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(armed[0]);
   });
 });
 
@@ -180,6 +224,7 @@ describe('HybridEvenG2Adapter bridgeReadyTimeoutMs validation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetBridgeHandshakeForTests();
     sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
     sdk.bridge.onEvenHubEvent.mockImplementation(() => vi.fn());
     sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);

--- a/tests/geolocation/even-app-location-provider.test.ts
+++ b/tests/geolocation/even-app-location-provider.test.ts
@@ -21,10 +21,14 @@ import {
   EvenAppLocationProvider,
 } from '../../src/infrastructure/geolocation/even-app-location-provider';
 import { LocationProvider } from '../../src/infrastructure/geolocation/browser-location-provider';
-import { DEFAULT_BRIDGE_READY_TIMEOUT_MS } from '../../src/infrastructure/even-app/bridge-ready';
+import {
+  DEFAULT_BRIDGE_READY_TIMEOUT_MS,
+  resetBridgeHandshakeForTests,
+} from '../../src/infrastructure/even-app/bridge-ready';
 
 describe('EvenAppLocationProvider', () => {
   beforeEach(() => {
+    resetBridgeHandshakeForTests();
     vi.clearAllMocks();
     vi.stubGlobal('window', { flutter_inappwebview: { callHandler: vi.fn() } });
     sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
@@ -124,6 +128,7 @@ describe('EvenAppLocationProvider', () => {
  */
 describe('EvenAppLocationProvider bridge-ready timeout', () => {
   beforeEach(() => {
+    resetBridgeHandshakeForTests();
     vi.clearAllMocks();
     vi.stubGlobal('window', { flutter_inappwebview: { callHandler: vi.fn() } });
     // The SDK waits on an `evenAppBridgeReady` event that never arrives.


### PR DESCRIPTION
## 概要

ブリッジ待機のリトライで SDK ハンドシェイクを共有し、`evenAppBridgeReady` リスナの無制限な蓄積をなくす。

Closes #34

## 問題

SDK の `waitForEvenAppBridge()` は呼び出しごとに `{once: true}` の `evenAppBridgeReady` リスナを登録し、**キャンセル経路を持たない**。タイムアウトした試行はリスナを回収できない。

PR #30 以前はハンドシェイクが一度しか呼ばれなかったため問題にならなかったが、リトライ導入後は試行のたびに SDK を呼び直していた。結果、ブリッジが不在の間、リスナ（＋クロージャと未解決 Promise）が `window` に1つずつ蓄積し続ける。タイムアウト10秒 + backoff 最大10秒なので、**約20秒に1個**のペースで増える。

## 変更内容

`src/infrastructure/even-app/bridge-ready.ts` に `sharedHandshake()` を追加し、進行中のハンドシェイクをモジュールスコープでキャッシュして全試行で共有する。

- **reject されたハンドシェイクはキャッシュから追い出す** — 一度の失敗を永久に再生し続け、SDK に二度と問い合わせなくなるのを防ぐ
- 共有は副次的な利点もある。最初の試行のリスナが生きたままなので、**遅れて到着したブリッジをその時点で待っている試行が拾える**。従来は放棄した待機のリスナが解決しても誰も受け取れなかった
- テスト用に `resetBridgeHandshakeForTests()` を公開（本番ではドキュメント寿命だけキャッシュが生きる想定）

## テスト

`tests/even-g2/even-g2-adapter-bridge-timeout.test.ts` に2件追加:

- 3回タイムアウトしても SDK 呼び出しは1回であること（リスナ蓄積の直接検証）
- reject されたハンドシェイクはキャッシュされず、次の試行が SDK を呼び直すこと

既存の「遅れて到着したブリッジを次の試行が拾う」テストは、旧実装の「試行ごとに SDK を呼び直す」前提をモックで表現していたため、**共有ハンドシェイクが解決する**形へ更新した（挙動の意図は同じ）。

`tests/geolocation/even-app-location-provider.test.ts` の `beforeEach` にもリセットを追加（ハンドシェイクがプロセス共有になったため、テスト間の持ち越しを断つ）。

### レビュー指摘の nit も併せて対応

タイマー解放テストが `clearTimeout` の**呼び出し有無しか見ていない**問題を修正。無条件の `finally { clearTimeout(timer) }` はハンドルを失っていても呼び出し自体は成立するため、旧アサーションでは検出できなかった。当該 bound で armed されたハンドルを追跡し、`toHaveBeenCalledWith(armed[0])` で検証する形に変更。

## 非空虚性確認

テスト用フックごと消えてしまう stash では検証にならないため、**キャッシュ動作だけを無効化**して確認した。

- リスナ共有テスト: `expected "spy" to be called 1 times, but got 3 times` で失敗
- 強化したタイマーテスト: 実装がハンドルを失う状態を作ると `expected "clearTimeout" to be called with arguments: [ …(1) ]` で失敗（旧アサーションでは通っていたケース）

いずれも復帰後 16/16 通過。

## 検証

```
pnpm test          Test Files 22 passed (22) / Tests 117 passed (117)   ← main 115 から +2
npx tsc --noEmit   exit 0
pnpm lint          exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbZYqTkjFay9zMZcDjSttk
