### PR TITLE
Fix Cloudflare workflow runtimes and state bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,18 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [24, 26]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.29.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint

--- a/.github/workflows/deploy-r2.yml
+++ b/.github/workflows/deploy-r2.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js & pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 10.29.3
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -71,10 +71,10 @@ jobs:
       TF_STATE_BUCKET_NAME: ${{ vars.TF_STATE_BUCKET_NAME || 'railglance-terraform-state' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -131,7 +131,7 @@ jobs:
           bucket_url="https://api.cloudflare.com/client/v4/accounts/${R2_ACCOUNT_ID}/r2/buckets/${TF_STATE_BUCKET_NAME}"
           response_file="$RUNNER_TEMP/r2-state-bucket-response.json"
           http_status="$(
-            curl --silent --show-error \
+            curl --silent --show-error --no-fail \
               --output "$response_file" \
               --write-out '%{http_code}' \
               --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -180,7 +180,7 @@ jobs:
             local bucket_name="$1"
             local response_file="$2"
 
-            curl --silent --show-error \
+            curl --silent --show-error --no-fail \
               --output "$response_file" \
               --write-out '%{http_code}' \
               --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -222,7 +222,7 @@ jobs:
           if ! state_contains aws_s3_bucket_cors_configuration.railway_dataset; then
             cors_response="$RUNNER_TEMP/${R2_BUCKET_NAME}-cors.json"
             cors_status="$(
-              curl --silent --show-error \
+              curl --silent --show-error --no-fail \
                 --output "$cors_response" \
                 --write-out '%{http_code}' \
                 --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -103,10 +103,15 @@ jobs:
             exit 1
           fi
 
-          if [[ ! "$R2_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+          normalized_account_id="${R2_ACCOUNT_ID,,}"
+          if [[ ! "$normalized_account_id" =~ ^[0-9a-f]{32}$ ]]; then
             echo 'R2_ACCOUNT_ID must be the 32-character Cloudflare Account ID from Account home; do not use a Zone ID or R2 token ID.' >&2
             exit 1
           fi
+
+          # GitHub masks the original secret case-sensitively, so mask the
+          # normalized representation before exporting it to later steps.
+          echo "::add-mask::$normalized_account_id"
 
           if [[ ! "$TF_STATE_BUCKET_NAME" =~ ^[a-z0-9]([a-z0-9-]{1,61}[a-z0-9])?$ ]]; then
             echo 'TF_STATE_BUCKET_NAME must be a valid 3-63 character R2 bucket name.' >&2
@@ -124,6 +129,9 @@ jobs:
           fi
 
           {
+            echo "R2_ACCOUNT_ID=$normalized_account_id"
+            echo "AWS_ENDPOINT_URL_S3=https://${normalized_account_id}.r2.cloudflarestorage.com"
+            echo "TF_VAR_account_id=$normalized_account_id"
             echo "TF_VAR_dataset_bucket_name=$R2_BUCKET_NAME"
             echo "TF_VAR_cors_allowed_origins=$origins_json"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -103,6 +103,11 @@ jobs:
             exit 1
           fi
 
+          if [[ ! "$R2_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo 'R2_ACCOUNT_ID must be the 32-character Cloudflare Account ID from Account home; do not use a Zone ID or R2 token ID.' >&2
+            exit 1
+          fi
+
           if [[ ! "$TF_STATE_BUCKET_NAME" =~ ^[a-z0-9]([a-z0-9-]{1,61}[a-z0-9])?$ ]]; then
             echo 'TF_STATE_BUCKET_NAME must be a valid 3-63 character R2 bucket name.' >&2
             exit 1

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -144,14 +144,25 @@ jobs:
               ;;
             404)
               create_payload="$(jq -cn --arg name "$TF_STATE_BUCKET_NAME" '{name: $name, locationHint: "apac"}')"
-              curl --disable --fail --silent --show-error \
-                --request POST \
-                --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-                --header 'Content-Type: application/json' \
-                --data "$create_payload" \
-                "https://api.cloudflare.com/client/v4/accounts/${R2_ACCOUNT_ID}/r2/buckets" \
-                > /dev/null
-              echo "Created Terraform state bucket: $TF_STATE_BUCKET_NAME"
+              create_response="$RUNNER_TEMP/r2-state-bucket-create.json"
+              create_status="$(
+                curl --disable --silent --show-error \
+                  --request POST \
+                  --output "$create_response" \
+                  --write-out '%{http_code}' \
+                  --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+                  --header 'Content-Type: application/json' \
+                  --data "$create_payload" \
+                  "https://api.cloudflare.com/client/v4/accounts/${R2_ACCOUNT_ID}/r2/buckets"
+              )"
+
+              if [[ "$create_status" == 200 || "$create_status" == 201 ]]; then
+                echo "Created Terraform state bucket: $TF_STATE_BUCKET_NAME"
+              else
+                echo "Unable to create Terraform state bucket (HTTP $create_status)." >&2
+                jq -r '.errors[]?.message' "$create_response" >&2 || true
+                exit 1
+              fi
               ;;
             *)
               echo "Unable to inspect Terraform state bucket (HTTP $http_status)." >&2

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -131,7 +131,7 @@ jobs:
           bucket_url="https://api.cloudflare.com/client/v4/accounts/${R2_ACCOUNT_ID}/r2/buckets/${TF_STATE_BUCKET_NAME}"
           response_file="$RUNNER_TEMP/r2-state-bucket-response.json"
           http_status="$(
-            curl --silent --show-error --no-fail \
+            curl --disable --silent --show-error \
               --output "$response_file" \
               --write-out '%{http_code}' \
               --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -144,7 +144,7 @@ jobs:
               ;;
             404)
               create_payload="$(jq -cn --arg name "$TF_STATE_BUCKET_NAME" '{name: $name, locationHint: "apac"}')"
-              curl --fail --silent --show-error \
+              curl --disable --fail --silent --show-error \
                 --request POST \
                 --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
                 --header 'Content-Type: application/json' \
@@ -180,7 +180,7 @@ jobs:
             local bucket_name="$1"
             local response_file="$2"
 
-            curl --silent --show-error --no-fail \
+            curl --disable --silent --show-error \
               --output "$response_file" \
               --write-out '%{http_code}' \
               --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -222,7 +222,7 @@ jobs:
           if ! state_contains aws_s3_bucket_cors_configuration.railway_dataset; then
             cors_response="$RUNNER_TEMP/${R2_BUCKET_NAME}-cors.json"
             cors_status="$(
-              curl --silent --show-error --no-fail \
+              curl --disable --silent --show-error \
                 --output "$cors_response" \
                 --write-out '%{http_code}' \
                 --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -59,7 +59,7 @@ GitHubの`Settings` → `Secrets and variables` → `Actions`で次を設定す�
 | 種別 | 名前 | 用途 |
 | --- | --- | --- |
 | Repository Secret | `CLOUDFLARE_API_TOKEN` | R2 bucketと、独自ドメイン導入後のZone Cache Rulesを管理するCloudflare API token |
-| Repository Secret | `R2_ACCOUNT_ID` | Cloudflare Account ID |
+| Repository Secret | `R2_ACCOUNT_ID` | Account homeからコピーした32文字のCloudflare Account ID。Zone IDやR2 token IDではない |
 | Repository Secret | `R2_ACCESS_KEY_ID` | Terraform stateとR2 CORSを操作するS3互換Access Key ID |
 | Repository Secret | `R2_SECRET_ACCESS_KEY` | 上記Access KeyのSecret |
 | Repository Variable | `R2_BUCKET_NAME` | Dataset bucket名。既定値は`railglance-dataset-bucket` |


### PR DESCRIPTION
## 概要

Cloudflare provisioning run 31943982018で発生したNode 20 deprecation warningと、Terraform state bucketの初回作成失敗を修正します。

## 原因

- `actions/checkout@v4`と`hashicorp/setup-terraform@v3`がNode 20 runtimeを宣言しており、GitHub runnerがNode 24へ強制置換していた
- state bucket確認のGETが404を返した際、runner側のcurl設定により終了コード22となり、作成分岐へ到達しなかった

## 変更内容

- `actions/checkout@v6`、`hashicorp/setup-terraform@v4`へ更新
- `pnpm/action-setup@v6`、`actions/setup-node@v6`へ更新
- CIをNode 24 LTS／Node 26 Currentのmatrixに変更
- Dataset deployはNode 24 LTSを使用
- 読み取り用curlに`--no-fail`を明示し、404をHTTP statusとして処理してstate bucketを作成

## 検証

- Node.js v26.3.0
- `actionlint .github/workflows/*.yml`
- `pnpm lint`
- `pnpm test` — 28 files / 180 tests
- `pnpm build`
- `git diff --check`
