### PR TITLE
Add Even Hub beta package workflow

### DIFF
--- a/.github/workflows/build-evenhub-package.yml
+++ b/.github/workflows/build-evenhub-package.yml
@@ -26,7 +26,6 @@ jobs:
       VITE_EVEN_SDK_VERSION: ${{ vars.VITE_EVEN_SDK_VERSION }}
       SENTRY_ORG: ${{ vars.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - name: Require main branch
         shell: bash
@@ -50,6 +49,8 @@ jobs:
 
       - name: Validate beta configuration
         shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           required=(
@@ -94,6 +95,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build package and upload source maps
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm ehpack
 
       - name: Verify packaged network permissions and source maps
@@ -110,7 +113,7 @@ jobs:
             process.env.VITE_RAILWAY_DATA_BASE_URL,
             process.env.VITE_SENTRY_DSN,
             process.env.VITE_TELEMETRY_ENDPOINT,
-          ].map((value) => new URL(value).origin);
+          ].map((value) => new URL(value.trim()).origin);
           const missing = expected.filter((origin) => !actual.has(origin));
           if (missing.length > 0) {
             throw new Error(`dist/app.json is missing network origins: ${missing.join(', ')}`);

--- a/.github/workflows/build-evenhub-package.yml
+++ b/.github/workflows/build-evenhub-package.yml
@@ -1,0 +1,146 @@
+name: Build Even Hub Beta Package
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: evenhub-beta-package
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Package .ehpk
+    runs-on: ubuntu-latest
+    environment:
+      name: evenhub-beta
+    env:
+      VITE_RAILWAY_DATA_BASE_URL: ${{ vars.VITE_RAILWAY_DATA_BASE_URL }}
+      VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+      VITE_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}
+      VITE_APP_RELEASE: ${{ vars.VITE_APP_RELEASE }}
+      VITE_APP_ENVIRONMENT: ${{ vars.VITE_APP_ENVIRONMENT }}
+      VITE_TELEMETRY_ENDPOINT: ${{ vars.VITE_TELEMETRY_ENDPOINT }}
+      VITE_EVEN_SDK_VERSION: ${{ vars.VITE_EVEN_SDK_VERSION }}
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Even Hub beta packages must be built from main, received: $GITHUB_REF" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.29.3
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Validate beta configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(
+            VITE_RAILWAY_DATA_BASE_URL
+            VITE_SENTRY_DSN
+            VITE_SENTRY_TRACES_SAMPLE_RATE
+            VITE_APP_RELEASE
+            VITE_APP_ENVIRONMENT
+            VITE_TELEMETRY_ENDPOINT
+            VITE_EVEN_SDK_VERSION
+            SENTRY_ORG
+            SENTRY_PROJECT
+            SENTRY_AUTH_TOKEN
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing evenhub-beta configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          package_version=$(node -p "require('./package.json').version")
+          manifest_version=$(node -p "require('./app.json').version")
+          expected_release="railglance@${package_version}"
+          if [[ "$manifest_version" != "$package_version" ]]; then
+            echo "app.json version must match package.json version" >&2
+            exit 1
+          fi
+          if [[ "$VITE_APP_RELEASE" != "$expected_release" ]]; then
+            echo "VITE_APP_RELEASE must be $expected_release" >&2
+            exit 1
+          fi
+          if [[ "$VITE_APP_ENVIRONMENT" != "beta" ]]; then
+            echo "VITE_APP_ENVIRONMENT must be beta for this workflow" >&2
+            exit 1
+          fi
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build package and upload source maps
+        run: pnpm ehpack
+
+      - name: Verify packaged network permissions and source maps
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import { readFileSync } from 'node:fs';
+
+          const manifest = JSON.parse(readFileSync('dist/app.json', 'utf8'));
+          const networkPermission = manifest.permissions?.find((permission) => permission.name === 'network');
+          const actual = new Set(networkPermission?.whitelist ?? []);
+          const expected = [
+            process.env.VITE_RAILWAY_DATA_BASE_URL,
+            process.env.VITE_SENTRY_DSN,
+            process.env.VITE_TELEMETRY_ENDPOINT,
+          ].map((value) => new URL(value).origin);
+          const missing = expected.filter((origin) => !actual.has(origin));
+          if (missing.length > 0) {
+            throw new Error(`dist/app.json is missing network origins: ${missing.join(', ')}`);
+          }
+          NODE
+
+          if find dist -type f -name '*.map' -print -quit | grep -q .; then
+            echo "Source maps remain in dist after Sentry upload" >&2
+            exit 1
+          fi
+          test -s out.ehpk
+
+      - name: Upload out.ehpk
+        id: artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: out.ehpk
+          archive: false
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Write package summary
+        env:
+          ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
+        run: |
+          {
+            echo '## Even Hub Beta package'
+            echo
+            echo "- Release: \`$VITE_APP_RELEASE\`"
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Artifact: [out.ehpk]($ARTIFACT_URL)"
+            echo '- Retention: 14 days'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -186,6 +186,19 @@ GitHubの `Settings` → `Environments` → `New environment` で `evenhub-beta`
 | --- | --- | --- |
 | `SENTRY_AUTH_TOKEN` | `org:ci`権限のSentry Organization Auth Token | source mapとrelease情報のupload専用。アプリへは組み込まれない |
 
+`SENTRY_AUTH_TOKEN` は次の手順で発行・登録する。
+
+1. Sentryの `Settings` を開き、左メニューを下までスクロールして
+   `Developer Settings` → `Organization Tokens` を開く。micosys Organizationでは
+   `https://micosys.sentry.io/settings/auth-tokens/` へ直接アクセスしてもよい。
+   `Organization` → `Auth` はGoogle/GitHubなどのSSO設定画面であり、token発行には使用しない。
+2. `Create New Token` を押し、識別名（例: `railglance-github-actions`）を入力して作成する。
+   Organization Tokenのscopeは画面上で `org:ci`（Source Map Upload、Release Creation、
+   Code Mappings）と表示される。発行直後に一度だけ表示されるtokenをコピーする。
+3. GitHubリポジトリの `Settings` → `Environments` → `evenhub-beta` →
+   `Environment secrets` → `Add environment secret` を開き、名前を `SENTRY_AUTH_TOKEN`、
+   値を手順2でコピーしたtokenとして保存する。
+
 `VITE_SENTRY_DSN`、`SENTRY_ORG`、`SENTRY_PROJECT` は秘密情報ではないためVariableへ置く。
 `SENTRY_AUTH_TOKEN`だけをSecretへ置き、Repository Variable、`.env`、ログ、`.ehpk`には保存しない。
 

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -159,6 +159,43 @@ Sentry Breadcrumbにはroute、segment、navigation mode、次駅、Even G2接�
 
 source map upload用の `SENTRY_AUTH_TOKEN` はCI/build環境だけに保存し、`.ehpk`へ含めない。
 
+### Even Hub Beta 配布設定
+
+`.github/workflows/build-evenhub-package.yml` は、GitHub Actionsの `evenhub-beta` Environmentを使って
+Beta Testing用の単一成果物 `out.ehpk` を生成する。`evenhub-beta` はEven Hubが提供する画面や予約語ではなく、
+このリポジトリで作成するGitHub Actions Environmentの名前である。
+
+GitHubの `Settings` → `Environments` → `New environment` で `evenhub-beta` を作成する。そのEnvironmentの
+`Environment variables` に次を設定する。
+
+| 名前 | 設定値 | 取得元・用途 |
+| --- | --- | --- |
+| `VITE_RAILWAY_DATA_BASE_URL` | Datasetの公開base URL | R2の公開URL。`/datasets/...`を付けないorigin/base URL |
+| `VITE_SENTRY_DSN` | Sentry projectのDSN | SentryのProject Settings → Client Keys (DSN) |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | `0.1` | performance traceの送信率 |
+| `SENTRY_ORG` | Sentry organization slug | Sentry Project Settings URLのorganization部分 |
+| `SENTRY_PROJECT` | Sentry project slug | Sentry Project Settings URLのproject部分 |
+| `VITE_APP_RELEASE` | `railglance@0.1.0`など | `railglance@` + `package.json`のversion。Workerの許可releaseとも完全一致させる |
+| `VITE_APP_ENVIRONMENT` | `beta` | SentryとTelemetry上の環境名 |
+| `VITE_TELEMETRY_ENDPOINT` | Telemetry WorkerのHTTPS URL | 独自ドメイン導入前はデプロイ結果の`workers.dev` URL |
+| `VITE_EVEN_SDK_VERSION` | `0.0.12`など | 使用中のEven Hub SDK version |
+
+同じEnvironmentの `Environment secrets` に次を設定する。
+
+| 名前 | 設定値 | 取得元・用途 |
+| --- | --- | --- |
+| `SENTRY_AUTH_TOKEN` | `org:ci`権限のSentry Organization Auth Token | source mapとrelease情報のupload専用。アプリへは組み込まれない |
+
+`VITE_SENTRY_DSN`、`SENTRY_ORG`、`SENTRY_PROJECT` は秘密情報ではないためVariableへ置く。
+`SENTRY_AUTH_TOKEN`だけをSecretへ置き、Repository Variable、`.env`、ログ、`.ehpk`には保存しない。
+
+workflowは手動実行専用で、`main`以外からの配布、必須設定の不足、`app.json`と`package.json`のversion不一致、
+`VITE_APP_RELEASE`の不一致、Sentry upload後にsource mapが`dist`へ残っている状態を拒否する。Node.js 26で
+`pnpm ehpack`を実行し、成功時はWorkflow SummaryとArtifactsに未圧縮の`out.ehpk`を14日間保存する。
+
+実行はGitHubの `Actions` → `Build Even Hub Beta Package` → `Run workflow` からbranchに`main`を選ぶ。
+取得した`out.ehpk`をEven HubのPrivate Testingへ先に登録し、下記の実機ゲートを通過後にBeta Testingへ進める。
+
 ## Even G2 実機ゲート
 
 ブラウザ上のIndexedDB再生成テストだけでは、Even Appコンテナのlock・強制終了・package更新時の永続性を


### PR DESCRIPTION
## 概要

Even Hub Beta Testing向けの配布成果物を、個別マシンの`.env`や手作業に依存せずGitHub Actionsで生成できるようにします。

## 変更内容

- 手動実行専用の`Build Even Hub Beta Package` workflowを追加
- GitHub Actions Environment `evenhub-beta`からVariables/Secretを受け取る
- Node.js 26とpnpm 10.29.3で`pnpm ehpack`を実行
- Sentry Vite pluginによるrelease/source map uploadを必須化
- main以外、必須設定不足、version/release不一致、source map残存をfail closed
- Even Hub network whitelistへDataset、Sentry、Telemetry Workerのoriginが入ったことを検証
- `out.ehpk`を`actions/upload-artifact@v7`で未圧縮のまま14日保存
- GitHub/Sentryの設定先と値の取得元を`docs/TELEMETRY_AND_SENTRY.md`へ追記

## GitHub側の準備状況

`evenhub-beta` Environmentは作成済みです。必要なEnvironment Variablesもすべて設定済みです。

- `VITE_RAILWAY_DATA_BASE_URL`
- `VITE_SENTRY_DSN`
- `VITE_SENTRY_TRACES_SAMPLE_RATE`
- `VITE_APP_RELEASE`
- `VITE_APP_ENVIRONMENT=beta`
- `VITE_TELEMETRY_ENDPOINT`
- `VITE_EVEN_SDK_VERSION`
- `SENTRY_ORG=micosys`
- `SENTRY_PROJECT=railglance`

workflow実行前に、Environment Secret `SENTRY_AUTH_TOKEN`（Sentry Organization Auth Token、`org:ci`）の設定だけが必要です。

## 検証

- `actionlint .github/workflows/build-evenhub-package.yml`
- `pnpm lint`
- `pnpm test`（28 files / 180 tests）
- `pnpm ehpack`（`out.ehpk`生成成功）

実際のSentry source map uploadとGitHub Artifact生成は、`SENTRY_AUTH_TOKEN`を追加して本PRをmainへマージした後、workflow_dispatchで検証します。
