### PR TITLE
Reduce route misclassification with lock recovery and manual reacquire

### DIFF
--- a/docs/ROUTE_MATCHING_RELIABILITY_SPEC.md
+++ b/docs/ROUTE_MATCHING_RELIABILITY_SPEC.md
@@ -1,0 +1,1229 @@
+# 路線マッチング信頼性仕様
+
+作成日: 2026-08-16
+
+本書は、RailGlanceにおける路線誤検知の低減、誤検知後の自動再取得、手動再検出・手動ロックの仕様と実装方針を定める。
+
+関連ドキュメント:
+
+- `docs/GPS_LOSS_SPEED_STATE_SPEC.md` — GPS劣化・消失時の速度状態と再取得
+- `docs/TELEMETRY_AND_SENTRY.md` — 実走ログ、候補スコア、Route Health、切替理由の収集
+- `docs/HUD_UI_UX_REQUIREMENTS.md` — 路線判定中・再取得中のHUD表示
+
+対象リポジトリ:
+
+```text
+https://github.com/TakuroFukamizu/railglance
+```
+
+---
+
+# 1. 背景
+
+Even G2実機テスト中、JR中央・総武線各駅停車の浅草橋駅付近にいるにもかかわらず、RailGlanceが「東北新幹線 東京〜上野間」と判定する事象が確認された。
+
+さらに、浅草橋から秋葉原まで実際に中央・総武線で移動しても誤判定が解消せず、東北新幹線判定が継続した。
+
+本件について、以下の3観点から改善を行う。
+
+- A. 初回の誤検知を減らす
+- B. 誤検知後に自動で異常を検知し、再判定・訂正できるようにする
+- C. ユーザーが手動で路線再検出を実行できるようにする
+
+ただし、A/Bの自動補正を強くしすぎると、正常な路線判定まで頻繁に揺れるリスクがある。
+
+そのため、今回の実装では以下を最優先する。
+
+> 「誤判定を無理に即時訂正する」よりも、  
+> 「正常判定を不用意に壊さない」「確信が弱い場合は未確定状態を維持する」ことを優先する。
+
+---
+
+# 2. 現行実装で特に確認すべき問題
+
+現行`MapMatcher`、`candidate-scorer`、`TrackingConfig`を確認した上で作業すること。
+
+現状コードでは特に以下の点に注意する。
+
+## 2.1 初回候補を即時確定している
+
+`currentMatch === null`の場合、最高スコア候補をその場で採用している。
+
+これにより、起動直後の単発GPS誤差や都市部の並走路線によって誤った路線が確定しやすい。
+
+---
+
+## 2.2 現在保持中のroute候補が、現在GPS fixで再評価されていない可能性
+
+路線切替判定では、新しいGPS fixから得た`topCandidate`と、過去に保持した`currentMatch`を比較している。
+
+`currentMatch.totalScore`や`currentMatch.distanceMeters`が過去fix時点の値であれば、
+
+```text
+新候補 = 現在位置での評価
+現在候補 = 過去位置での評価
+```
+
+という不適切な比較になる。
+
+これは今回の誤判定固着の主要原因になり得る。
+
+**最優先で確認・修正すること。**
+
+---
+
+## 2.3 continuity bonusが誤判定の固定化を招く可能性
+
+現在路線・現在segmentへ最大20点のcontinuity bonusが付与される。
+
+一度誤ったrouteを選ぶと、その誤routeが継続的に有利になる可能性がある。
+
+continuity自体は路線判定の安定化に必要なため削除しない。
+
+ただし、
+
+- 現在routeが矛盾している
+- challengerが継続的に優勢
+- route進行が不自然
+
+といった状況ではcontinuity biasを弱める仕組みを導入する。
+
+---
+
+## 2.4 検索範囲とGPS精度許容値
+
+現状の設定値が以下である場合は、都市部の高密度鉄道路線では候補が多くなる。
+
+```text
+routeSearchRadiusMeters = 1000m
+maxGpsAccuracyMeters = 500m
+```
+
+これらを即座に単純縮小して解決してはならない。
+
+地下、ビル街、駅周辺ではGPS精度が悪化するため、単純な閾値縮小は真の路線を除外する恐れがある。
+
+距離閾値だけでなく、accuracy、heading、trajectory、route continuityを組み合わせること。
+
+---
+
+# 3. 全体設計方針
+
+MapMatcherを以下の状態モデルへ発展させる。
+
+```ts
+export type RouteLockState =
+  | 'UNRESOLVED'
+  | 'LOCKED'
+  | 'SUSPICIOUS'
+  | 'REACQUIRING'
+  | 'MANUAL_LOCK';
+```
+
+基本遷移:
+
+```text
+UNRESOLVED
+   ↓
+LOCKED
+   ↓
+SUSPICIOUS
+   ↓
+REACQUIRING
+   ↓
+LOCKED
+```
+
+手動選択時:
+
+```text
+REACQUIRING
+   ↓
+MANUAL_LOCK
+```
+
+手動解除:
+
+```text
+MANUAL_LOCK
+   ↓
+UNRESOLVED
+```
+
+---
+
+# 4. A. 初回誤検知を減らす
+
+## 4.1 現在候補を毎GPS fixで必ず再スコアする
+
+最優先修正。
+
+現在保持しているroute / segmentについて、毎GPS fixで現在位置から再評価する。
+
+例:
+
+```ts
+const rescoredCurrent = candidateScores.find(
+  candidate =>
+    candidate.segment.id === this.currentMatch?.segment.id
+);
+```
+
+存在しない場合は、現在routeが現在検索範囲から外れたものとして扱う。
+
+比較は必ず以下とする。
+
+```text
+top challenger at current fix
+vs
+current route rescored at current fix
+```
+
+過去fix時点の`currentMatch.totalScore`を現在の切替判定に使用してはならない。
+
+---
+
+## 4.2 初回確定を即決しない
+
+`UNRESOLVED`状態を導入する。
+
+初回GPS fixだけでは路線を確定しない。
+
+候補履歴を蓄積し、以下の複数条件を満たした場合のみ`LOCKED`へ移行する。
+
+候補条件例:
+
+```text
+最低3〜5 GPS fix
+AND
+一定時間継続
+AND
+top candidateが複数回優勢
+AND
+topとsecondのscore marginが十分
+```
+
+ただし、ユーザーが停車中の場合は移動距離条件を必須にしない。
+
+停止中に無理にrouteを確定する必要もない。
+
+HUD上は速度を表示しつつ、
+
+```text
+路線判定中
+```
+
+と表示できるようにする。
+
+---
+
+## 4.3 1位と2位のscore marginを明示的に使う
+
+次を計算する。
+
+```ts
+const scoreMargin =
+  topCandidate.totalScore -
+  (secondCandidate?.totalScore ?? 0);
+```
+
+単にtop candidateの絶対スコアだけで判断しない。
+
+例:
+
+```text
+A = 78
+B = 77
+```
+
+は確信度が低い。
+
+```text
+A = 91
+B = 52
+```
+
+は強い。
+
+閾値は設定値として管理する。
+
+例:
+
+```ts
+routeInitialLockMinScore
+routeInitialLockMinMargin
+routeInitialLockConsecutiveCount
+routeInitialLockMinimumMs
+```
+
+値は実走ログに基づき調整可能にする。
+
+---
+
+## 4.4 continuity判定をトポロジーベースへ変更する
+
+ID文字列のprefixなどによる「同一路線っぽい」判定は避ける。
+
+continuity bonusは以下の順で付与する。
+
+```text
+同一segment
+> 隣接segment
+> 同一route上で到達可能なsegment
+> 同一路線だが非連続
+> 無関係route
+```
+
+例:
+
+```text
+same segment: +20
+adjacent segment: +15
+reachable same route: +8
+same line but disconnected: +2
+different route: 0
+```
+
+数値は設定可能にする。
+
+---
+
+## 4.5 trajectory headingを導入する
+
+単発の`sample.headingDegrees`だけに依存しない。
+
+直近GPS履歴から、移動方向を求める。
+
+例:
+
+```text
+5〜15秒
+または
+最低30〜50m移動
+```
+
+から代表headingを計算する。
+
+優先順位:
+
+```text
+移動ベクトルから得たtrajectory heading
+>
+GPS提供heading
+>
+heading不明
+```
+
+低速時はtrajectory headingも信頼しすぎない。
+
+---
+
+## 4.6 線路距離をGPS accuracyと組み合わせる
+
+単純な線路までの距離だけでなく、
+
+```ts
+normalizedDistance =
+  distanceMeters /
+  Math.max(accuracyMeters, minimumAccuracyMeters);
+```
+
+を補助評価に使う。
+
+ただし、これをハード除外条件にしない。
+
+都市部のmultipathや地下出口ではaccuracy値自体も不安定なため、penalty / confidence補正として使う。
+
+---
+
+## 4.7 駅順序は補助証拠として使う
+
+駅付近・駅通過時に、
+
+```text
+previousStation
+nextStation
+trajectory
+route progression
+```
+
+の整合性を評価する。
+
+例:
+
+```text
+浅草橋付近
+↓
+西方向移動
+↓
+秋葉原付近
+```
+
+という動きが中央・総武線route上で自然に説明できるなら、そのrouteを強く支持できる。
+
+ただし、大規模駅・並走区間では駅近接だけでrouteを確定しない。
+
+---
+
+## 4.8 速度情報は非対称に利用する
+
+以下のようなルールは禁止。
+
+```text
+低速だから新幹線ではない
+```
+
+新幹線も駅付近では低速・停止するため。
+
+一方、
+
+```text
+250km/hだから一般在来線ではない
+```
+
+は強い証拠として使える。
+
+したがって速度は、
+
+```text
+物理的に不可能な高速 → 強いpenalty
+低速 → 基本的にroute否定材料にしない
+```
+
+とする。
+
+---
+
+# 5. B. 誤検知を自動発見・訂正する
+
+## 5.1 Route Healthを導入する
+
+現在選択中routeが、現在の観測列をどの程度説明できているかを継続評価する。
+
+例:
+
+```ts
+export type RouteHealth = {
+  distanceConsistency: number;
+  headingConsistency: number;
+  trajectoryConsistency: number;
+  stationSequenceConsistency: number;
+  topologyConsistency: number;
+  progressConsistency: number;
+  challengerDominance: number;
+
+  total: number;
+};
+```
+
+各項目は0〜1など正規化した値とする。
+
+---
+
+## 5.2 route progress monotonicityを評価する
+
+現在routeへ各GPS点を投影し、
+
+```text
+distanceFromRouteStartMeters
+```
+
+の時系列を見る。
+
+正常例:
+
+```text
+12.30km
+12.45km
+12.62km
+12.81km
+```
+
+誤routeの可能性が高い例:
+
+```text
+2.10km
+1.82km
+2.25km
+1.91km
+```
+
+進行方向が一定なのにroute positionが大きく前後する場合、current route healthを低下させる。
+
+ただし、以下を考慮する。
+
+- 停車
+- GPS jitter
+- 方向転換
+- 折返し運転
+- route分岐
+
+単一サンプルで異常判定しない。
+
+---
+
+## 5.3 SUSPICIOUS状態
+
+route healthが悪化しても即座にrouteを変更しない。
+
+以下のような条件で`SUSPICIOUS`へ遷移する。
+
+```text
+current route health < threshold
+AND
+一定時間継続
+```
+
+または、
+
+```text
+challengerがcurrentより一定margin以上優勢
+AND
+複数fix継続
+```
+
+`SUSPICIOUS`状態では現在routeを一応維持する。
+
+HUDで必要なら、
+
+```text
+路線確認中
+```
+
+程度を表示する。
+
+---
+
+## 5.4 continuity bonusを状態に応じて弱める
+
+例:
+
+```text
+LOCKED:
+通常continuity
+
+SUSPICIOUS:
+continuityを25〜50%へ低下
+
+REACQUIRING:
+continuityを0〜最小値へ低下
+```
+
+これにより、通常時の安定性は維持しつつ、誤route固着時のみ再探索しやすくする。
+
+---
+
+## 5.5 Challenger方式
+
+現在route以外の有力候補を`challenger`として追跡する。
+
+例:
+
+```ts
+export type RouteChallengerState = {
+  segmentId: string;
+  routeId: string | null;
+
+  consecutiveWins: number;
+  firstSeenAtMs: number;
+  lastSeenAtMs: number;
+
+  latestScore: number;
+  latestMargin: number;
+};
+```
+
+切替条件は最低でも以下を満たす。
+
+```text
+1. current route healthが低い
+2. challengerがcurrentより明確に高い
+3. それが時間的に継続している
+```
+
+どれか1つだけで自動切替してはならない。
+
+---
+
+## 5.6 REACQUIRING状態
+
+SUSPICIOUSが一定時間続いた場合のみ`REACQUIRING`へ遷移する。
+
+この状態では、
+
+- current continuity biasをほぼ無効化
+- 直近GPS履歴を再評価
+- candidate Top Nを比較
+- trajectory整合性を重視
+
+する。
+
+1fixでrouteを切り替えない。
+
+---
+
+## 5.7 Sliding Window Map Matching
+
+直近10〜20秒程度のGPSサンプル履歴を保持する。
+
+候補routeごとに履歴全体を投影し、以下を評価する。
+
+```text
+平均線路距離
+最大線路距離
+trajectory heading整合
+route position単調性
+速度一貫性
+駅順序整合
+topology continuity
+```
+
+例:
+
+```ts
+export type WindowRouteScore = {
+  routeId: string;
+
+  meanDistanceScore: number;
+  headingConsistencyScore: number;
+  progressMonotonicityScore: number;
+  stationSequenceScore: number;
+  topologyScore: number;
+
+  totalScore: number;
+};
+```
+
+初回実装ではHMM/Viterbiなどの複雑な確率モデルは必須にしない。
+
+まずwindow scoring方式を導入する。
+
+---
+
+## 5.8 自動訂正条件は保守的にする
+
+自動切替は以下の三重条件とする。
+
+```text
+A. current route contradiction
+AND
+B. challenger superiority
+AND
+C. temporal persistence
+```
+
+さらに必要なら、
+
+```text
+GPS accuracyが一定以上良好
+OR
+trajectory distanceが十分
+```
+
+を追加する。
+
+自動訂正後も新routeを即完全LOCKEDにせず、
+
+```text
+REACQUIRING
+↓
+数fix安定
+↓
+LOCKED
+```
+
+とする。
+
+---
+
+# 6. C. 手動再検出
+
+スマートフォン画面に以下を追加する。
+
+```text
+路線を再検出
+```
+
+Even G2上に操作UIを追加する必要はない。
+
+---
+
+## 6.1 resetだけで終わらせない
+
+単純な、
+
+```ts
+mapMatcher.reset();
+```
+
+だけでは不十分。
+
+同じGPS点で同じ誤判定を再度選ぶ可能性がある。
+
+---
+
+## 6.2 Manual Reacquire
+
+ボタン押下時は以下を行う。
+
+```text
+1. current route lock解除
+2. continuity biasを0
+3. 状態をREACQUIRINGへ変更
+4. 直近10〜20秒のGPS履歴を利用
+5. Top N候補をwindow scoring
+6. 数fix観測
+7. 新routeを確定
+```
+
+手動再検出中でも速度表示は継続する。
+
+---
+
+## 6.3 候補選択UI
+
+再検出後、候補が拮抗している場合はユーザーが選択できるようにする。
+
+例:
+
+```text
+路線候補
+
+1. JR中央・総武線各駅停車  88%
+2. JR山手線                  54%
+3. 東北新幹線                31%
+```
+
+ユーザーが候補をタップした場合は`MANUAL_LOCK`とする。
+
+---
+
+## 6.4 MANUAL_LOCK
+
+手動選択されたrouteを一定期間優先する。
+
+設定例:
+
+```text
+session中
+または
+30分
+または
+ユーザーが解除するまで
+```
+
+ただし、現在位置が選択routeから明らかに離れた場合は、
+
+```text
+選択した路線から離れています
+```
+
+と警告する。
+
+自動で即解除しない。
+
+---
+
+## 6.5 手動ロック解除
+
+以下を用意する。
+
+```text
+自動判定に戻す
+```
+
+押下後:
+
+```text
+MANUAL_LOCK
+↓
+UNRESOLVED
+↓
+通常の初回確定処理
+```
+
+とする。
+
+---
+
+# 7. 新規設定項目
+
+閾値をハードコードしない。
+
+例:
+
+```ts
+export type RouteMatchingConfig = {
+  initialLockMinScore: number;
+  initialLockMinMargin: number;
+  initialLockConsecutiveCount: number;
+  initialLockMinimumMs: number;
+
+  suspiciousHealthThreshold: number;
+  suspiciousMinimumMs: number;
+
+  reacquireMinimumMs: number;
+
+  challengerMinMargin: number;
+  challengerConsecutiveCount: number;
+  challengerMinimumMs: number;
+
+  trajectoryWindowMs: number;
+  trajectoryMinDistanceMeters: number;
+
+  manualLockMaxDistanceMeters: number;
+};
+```
+
+既存`TrackingConfig`へ統合してもよい。
+
+---
+
+# 8. Telemetry / Debugログ
+
+今回の改善は実走ログによる調整を前提とする。
+
+既存のTelemetry実装がある場合は必ず連携する。
+
+最低限以下を記録する。
+
+## 毎fix
+
+```text
+GPS lat/lon
+GPS accuracy
+GPS speed
+GPS heading
+trajectory heading
+
+current route
+current segment
+current score
+current rescored score
+
+top candidate
+second candidate
+score margin
+
+candidate Top5:
+  distance
+  distanceScore
+  headingScore
+  continuityScore
+  historyScore
+  totalScore
+
+route health各要素
+route health total
+
+challenger
+challenger wins
+challenger duration
+
+RouteLockState
+
+switch reason
+```
+
+---
+
+## 状態遷移イベント
+
+以下は個別イベントとして保存する。
+
+```text
+route-lock
+route-suspicious
+route-reacquire-start
+route-switch
+manual-reacquire
+manual-route-lock
+manual-route-unlock
+route-lost
+```
+
+`route-switch`には必ず理由を記録する。
+
+例:
+
+```ts
+type RouteSwitchReason =
+  | 'initial-lock'
+  | 'challenger-dominant'
+  | 'route-health-low'
+  | 'manual-selection'
+  | 'manual-reacquire'
+  | 'current-route-lost';
+```
+
+---
+
+# 9. デバッグ画面
+
+スマートフォンDebugPanelへ追加する。
+
+```text
+Route State
+Current Route
+Current Segment
+Current Score
+Current Score (rescored)
+Top Candidate
+Second Candidate
+Score Margin
+
+Route Health
+Distance Consistency
+Heading Consistency
+Trajectory Consistency
+Progress Consistency
+Station Sequence Consistency
+
+Challenger
+Challenger Score
+Consecutive Wins
+Duration
+
+Trajectory Heading
+Trajectory Window
+
+Manual Lock State
+```
+
+開発中は候補Top5を展開表示できるようにする。
+
+---
+
+# 10. テスト
+
+## 10.1 Initial Lock
+
+- 1fixだけで確定しない
+- 同一候補が継続するとLOCKEDになる
+- top/secondが僅差ならUNRESOLVEDを維持
+- 停止中でも誤ったrouteを即確定しない
+
+---
+
+## 10.2 Current Rescore
+
+- current routeが毎fix再評価される
+- 過去fixのscoreを切替比較に使わない
+- current routeが検索範囲から消えた場合を処理できる
+
+---
+
+## 10.3 Continuity
+
+- 同一segmentが最も高いbonus
+- 隣接segmentは適度なbonus
+- 非連続の同一路線segmentへ高bonusを付けない
+- SUSPICIOUSでbonusが下がる
+- REACQUIRINGでbiasがほぼ消える
+
+---
+
+## 10.4 Route Health
+
+- route positionが滑らかなら高health
+- route positionが前後ジャンプするとhealth低下
+- heading不一致が継続するとhealth低下
+- 単発GPS外れ値だけではSUSPICIOUSにならない
+
+---
+
+## 10.5 Challenger
+
+- 一瞬だけ高scoreのcandidateでは切替しない
+- 複数fix継続したcandidateを追跡する
+- current healthが正常ならchallengerだけで切替しない
+- current health低下 + challenger優勢 + 継続で切替する
+
+---
+
+## 10.6 Manual Reacquire
+
+- ボタン押下でcontinuity biasが解除される
+- 過去GPS windowを使って再評価する
+- 速度表示は停止しない
+- 候補が拮抗する場合は候補選択できる
+
+---
+
+## 10.7 Manual Lock
+
+- ユーザー選択routeが優先される
+- 近傍の別routeへ勝手に切替しない
+- 大きく離れた場合に警告する
+- 自動判定へ戻せる
+
+---
+
+# 11. 実走再現テスト
+
+今回の浅草橋ケースをfixture化する。
+
+最低限以下のログを再生できるテストデータを作る。
+
+```text
+浅草橋駅付近で開始
+↓
+中央・総武線各駅停車に乗車
+↓
+浅草橋 → 秋葉原
+```
+
+検証項目:
+
+```text
+東北新幹線が一時Top candidateになっても即LOCKしない
+
+誤って東北新幹線LOCK状態から開始した場合:
+  route healthが低下
+  SUSPICIOUS
+  REACQUIRING
+  中央・総武線へ訂正
+
+正常な中央・総武線LOCK後:
+  並走候補が出ても不必要に揺れない
+```
+
+可能なら以下も追加する。
+
+```text
+東京〜上野の新幹線実走
+```
+
+これにより、浅草橋対策によって本当の東北新幹線判定を壊していないことを確認する。
+
+---
+
+# 12. 回帰テスト対象
+
+誤判定対策により、以下を壊してはならない。
+
+- 同一路線segment間の滑らかな遷移
+- 新幹線高速走行判定
+- GPS精度劣化時のDR
+- トンネル出口のreacquire
+- 駅停車
+- 並走区間
+- Cloudflareから取得したrouteデータ
+- Cached routeデータ
+- Even G2速度表示
+- HUD更新レート
+- Telemetry送信
+
+---
+
+# 13. 実装順序
+
+一度に全機能を混ぜない。
+
+以下の順でコミットする。
+
+## Step 1
+
+current route再スコア修正。
+
+```text
+fix: rescore current route on every gps observation
+```
+
+## Step 2
+
+初回即決廃止 + score margin。
+
+```text
+feat: add unresolved state and stable initial route locking
+```
+
+## Step 3
+
+トポロジーベースcontinuity。
+
+```text
+refactor: score route continuity using track topology
+```
+
+## Step 4
+
+trajectory heading。
+
+```text
+feat: add trajectory-based route heading evidence
+```
+
+## Step 5
+
+Route Health。
+
+```text
+feat: monitor current route health
+```
+
+## Step 6
+
+SUSPICIOUS / challenger / REACQUIRING。
+
+```text
+feat: add conservative automatic route reacquisition
+```
+
+## Step 7
+
+手動再検出。
+
+```text
+feat: add manual route reacquire control
+```
+
+## Step 8
+
+候補選択 / manual lock。
+
+```text
+feat: allow manual route selection and lock
+```
+
+## Step 9
+
+Telemetry / DebugPanel / fixture。
+
+```text
+test: add Asakusabashi route misclassification regression scenario
+```
+
+---
+
+# 14. 特に禁止する実装
+
+以下のような単純修正は禁止する。
+
+```text
+新幹線は低速なら除外
+```
+
+```text
+検索半径を一律200mへ縮小
+```
+
+```text
+GPS accuracyが50m超なら路線判定しない
+```
+
+```text
+別candidateが1回勝ったら即切替
+```
+
+```text
+continuity bonusを完全削除
+```
+
+```text
+毎fix完全resetして再判定
+```
+
+これらはいずれも特定ケースだけ改善して、別ケースの誤検知を増やす可能性が高い。
+
+---
+
+# 15. 完了条件
+
+以下をすべて満たすこと。
+
+## A. 誤検知低減
+
+- current routeが毎fix再評価される
+- 初回1fixでrouteを確定しない
+- score marginを評価する
+- trajectory evidenceを利用できる
+- topologyベースcontinuityを利用する
+- uncertain時にUNRESOLVEDを維持できる
+
+## B. 自動訂正
+
+- Route Healthを継続評価する
+- 単発異常ではrouteを変更しない
+- SUSPICIOUS状態を持つ
+- challengerを時間的に追跡する
+- current contradiction + challenger superiority + persistenceの三重条件で切替する
+- 誤routeから自動復帰できる
+- 正常routeが不用意に揺れない
+
+## C. 手動訂正
+
+- 「路線を再検出」がある
+- 過去GPS windowを利用する
+- continuity biasなしで再評価する
+- 候補一覧から手動選択できる
+- MANUAL_LOCKできる
+- 自動判定へ戻せる
+
+## Telemetry
+
+- 候補Top5を記録する
+- current routeの再スコアを記録する
+- score marginを記録する
+- Route Healthを記録する
+- challenger状態を記録する
+- route switch reasonを記録する
+
+## テスト
+
+- 浅草橋→秋葉原fixtureがある
+- 誤った東北新幹線初期LOCKから中央・総武線へ復帰できる
+- 本当の東北新幹線走行を壊していない
+- 既存テストが成功する
+- buildが成功する
+
+---
+
+# 16. 作業報告
+
+完了時は以下を報告する。
+
+```text
+原因分析:
+- ...
+
+実装したA対策:
+- ...
+
+実装したB対策:
+- ...
+
+実装したC対策:
+- ...
+
+Route Healthの判定内容:
+- ...
+
+自動切替条件:
+- ...
+
+手動再検出仕様:
+- ...
+
+追加Telemetry:
+- ...
+
+追加テスト:
+- ...
+
+浅草橋fixture結果:
+- ...
+
+既存ケースへの回帰結果:
+- ...
+
+実機未確認事項:
+- ...
+
+今後調整が必要な閾値:
+- ...
+```
+
+閾値の値は、推測だけで最適値と断定しない。
+
+実走Telemetryを用いて今後調整できる状態を維持すること。

--- a/index.html
+++ b/index.html
@@ -54,6 +54,20 @@
           </div>
         </section>
 
+        <section class="route-control-section" aria-labelledby="route-control-title">
+          <h2 id="route-control-title">路線再検出</h2>
+          <p>誤った路線が表示されている場合は再検出できます。速度表示は止まりません。</p>
+          <div class="route-control-actions">
+            <button id="btn-reacquire-route" class="btn btn-secondary">路線を再検出</button>
+            <button id="btn-unlock-route" class="btn" hidden>自動判定に戻す</button>
+          </div>
+          <p id="route-lock-warning" class="route-lock-warning" hidden>選択した路線から離れています</p>
+          <div id="route-candidates" class="route-candidates" hidden>
+            <h3>路線候補</h3>
+            <ul id="route-candidate-list"></ul>
+          </div>
+        </section>
+
         <section class="diagnostic-section" aria-labelledby="diagnostic-title">
           <h2 id="diagnostic-title">テスター向け診断記録</h2>
           <p>

--- a/infra/cloudflare/telemetry-worker/src/index.ts
+++ b/infra/cloudflare/telemetry-worker/src/index.ts
@@ -194,6 +194,18 @@ function object(value: unknown): JsonObject | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : null;
 }
 
+function optionalNumberField(source: JsonObject, key: string): JsonObject {
+  if (!(key in source)) return {};
+  const value = nullableNumber(source[key]);
+  return value === undefined ? {} : { [key]: value };
+}
+
+function optionalStringField(source: JsonObject, key: string): JsonObject {
+  if (!(key in source)) return {};
+  const value = nullableString(source[key], 80);
+  return value === undefined ? {} : { [key]: value };
+}
+
 function sanitizeBase(value: JsonObject): JsonObject | null {
   const timestampMs = finiteNumber(value.timestampMs);
   const datasetVersion = value.datasetVersion === undefined ? null : nullableString(value.datasetVersion);
@@ -286,7 +298,15 @@ function sanitizeEstimation(value: JsonObject, base: JsonObject): JsonObject | n
     const scores = numericFields(candidateObject, [
       'distanceMeters', 'distanceScore', 'headingScore', 'continuityScore', 'totalScore',
     ]);
-    return scores ? { lineId: candidateObject.lineId, segmentId: candidateObject.segmentId, ...scores } : null;
+    const historyScore = nullableNumber(candidateObject.historyScore);
+    return scores
+      ? {
+          lineId: candidateObject.lineId,
+          segmentId: candidateObject.segmentId,
+          ...scores,
+          ...(historyScore !== undefined ? { historyScore } : {}),
+        }
+      : null;
   });
   if (candidates.some((candidate) => candidate === null)) return null;
 
@@ -307,6 +327,15 @@ function sanitizeEstimation(value: JsonObject, base: JsonObject): JsonObject | n
       selectedSegmentId,
       confidence: matchConfidence,
       candidates,
+      ...optionalStringField(match, 'lockState'),
+      ...optionalNumberField(match, 'currentScore'),
+      ...optionalNumberField(match, 'rescoredCurrentScore'),
+      ...optionalNumberField(match, 'scoreMargin'),
+      ...optionalNumberField(match, 'trajectoryHeadingDegrees'),
+      ...optionalNumberField(match, 'routeHealthTotal'),
+      ...optionalStringField(match, 'challengerLineId'),
+      ...optionalNumberField(match, 'challengerWins'),
+      ...optionalStringField(match, 'switchReason'),
     },
     journey: { previousStationId, nextStationId, ...journeyNumbers },
     bridge: { connected: bridge.connected, lastImageResult: bridge.lastImageResult.slice(0, 500) },

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -172,7 +172,9 @@ export class AppController {
   }
 
   public async startManualReacquire(): Promise<void> {
-    this.mapMatcher.startManualReacquire(Date.now());
+    const nowMs = Date.now();
+    this.mapMatcher.startManualReacquire(nowMs);
+    this.flushRouteLockEvents(nowMs);
     this.journeyEstimator.invalidateRoute();
     this.speedEstimator.getNavStateEstimator().clearRoute();
     if (this.latestSample) {
@@ -181,8 +183,10 @@ export class AppController {
   }
 
   public async lockSelectedRoute(segmentId: string): Promise<boolean> {
-    const locked = this.mapMatcher.lockSelectedRoute(segmentId, Date.now());
+    const nowMs = Date.now();
+    const locked = this.mapMatcher.lockSelectedRoute(segmentId, nowMs);
     if (!locked) return false;
+    this.flushRouteLockEvents(nowMs);
     if (this.latestSample) {
       await this.onLocationUpdate(this.latestSample);
     }
@@ -190,13 +194,20 @@ export class AppController {
   }
 
   public async unlockManualRoute(): Promise<void> {
-    this.mapMatcher.unlockManualRoute(Date.now());
+    const nowMs = Date.now();
+    this.mapMatcher.unlockManualRoute(nowMs);
+    this.flushRouteLockEvents(nowMs);
     this.journeyEstimator.invalidateRoute();
     this.speedEstimator.getNavStateEstimator().clearRoute();
     this.currentMatch = null;
     if (this.latestSample) {
       await this.onLocationUpdate(this.latestSample);
     }
+  }
+
+  private flushRouteLockEvents(timestampMs: number): void {
+    if (typeof this.mapMatcher.takeLockEvents !== 'function') return;
+    this.logger.logRouteEvents(this.mapMatcher.takeLockEvents(), timestampMs);
   }
 
   public getCurrentRouteMatch(): RouteMatch | null {
@@ -468,6 +479,7 @@ export class AppController {
     // The provider was switched/stopped while matching: drop the sample before it can
     // mutate the (already reset) speed estimator.
     if (generation !== this.locationGeneration) return;
+    this.flushRouteLockEvents(sample.timestampMs);
     this.logger.logRouteObservation(sample, match);
 
     // 3. Compute track distance progress if match is valid

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -1,6 +1,6 @@
 import { TrackingConfig } from '../config/tracking-config';
 import { LocationSample, FullSpeedState, SpeedEstimate } from '../domain/models/location';
-import { JourneyState, RouteMatch } from '../domain/models/railway';
+import { JourneyState, RouteMatch, shouldDisplaySelectedRoute } from '../domain/models/railway';
 import { HudViewModel } from '../domain/models/hud';
 import { SpeedEstimator } from '../domain/speed/speed-estimator';
 import { MapMatcher } from '../domain/railway/map-matcher';
@@ -169,6 +169,38 @@ export class AppController {
       status: 'INITIALIZING',
     };
     this.currentViewModel = this.hudRenderer.createViewModel(this.currentFullSpeedState, this.currentJourney, now);
+  }
+
+  public async startManualReacquire(): Promise<void> {
+    this.mapMatcher.startManualReacquire(Date.now());
+    this.journeyEstimator.invalidateRoute();
+    this.speedEstimator.getNavStateEstimator().clearRoute();
+    if (this.latestSample) {
+      await this.onLocationUpdate(this.latestSample);
+    }
+  }
+
+  public async lockSelectedRoute(segmentId: string): Promise<boolean> {
+    const locked = this.mapMatcher.lockSelectedRoute(segmentId, Date.now());
+    if (!locked) return false;
+    if (this.latestSample) {
+      await this.onLocationUpdate(this.latestSample);
+    }
+    return true;
+  }
+
+  public async unlockManualRoute(): Promise<void> {
+    this.mapMatcher.unlockManualRoute(Date.now());
+    this.journeyEstimator.invalidateRoute();
+    this.speedEstimator.getNavStateEstimator().clearRoute();
+    this.currentMatch = null;
+    if (this.latestSample) {
+      await this.onLocationUpdate(this.latestSample);
+    }
+  }
+
+  public getCurrentRouteMatch(): RouteMatch | null {
+    return this.currentMatch;
   }
 
   public async start(): Promise<void> {
@@ -436,10 +468,11 @@ export class AppController {
     // The provider was switched/stopped while matching: drop the sample before it can
     // mutate the (already reset) speed estimator.
     if (generation !== this.locationGeneration) return;
+    this.logger.logRouteObservation(sample, match);
 
     // 3. Compute track distance progress if match is valid
     let trackProgress: { distanceAlongPolylineMeters: number; timestampMs: number } | undefined;
-    if (match) {
+    if (match && shouldDisplaySelectedRoute(match)) {
       const closest = findClosestPointOnPolyline(
         sample.latitude,
         sample.longitude,

--- a/src/config/tracking-config.ts
+++ b/src/config/tracking-config.ts
@@ -35,6 +35,42 @@ export type TrackingConfig = {
   confidenceHigh: number;
   confidenceMedium: number;
   confidenceLow: number;
+
+  routeInitialLockMinScore: number;
+  routeInitialLockMinMargin: number;
+  routeInitialLockConsecutiveCount: number;
+  routeInitialLockMinimumMs: number;
+
+  routeSuspiciousHealthThreshold: number;
+  routeSuspiciousMinimumMs: number;
+  routeReacquireMinimumMs: number;
+
+  routeChallengerMinMargin: number;
+  routeChallengerConsecutiveCount: number;
+  routeChallengerMinimumMs: number;
+
+  routeTrajectoryWindowMs: number;
+  routeTrajectoryMinDistanceMeters: number;
+
+  routeManualLockMaxDistanceMeters: number;
+  routeManualLockDurationMs: number;
+
+  continuitySameSegment: number;
+  continuityAdjacentSegment: number;
+  continuityReachableSameRoute: number;
+  continuitySameLineDisconnected: number;
+  continuitySuspiciousScale: number;
+  continuityReacquiringScale: number;
+
+  routeWindowMs: number;
+  routeWindowMinSamples: number;
+  routeMinimumAccuracyMeters: number;
+  routeConventionalMaxSpeedKmh: number;
+  routeImpossibleSpeedPenalty: number;
+  routeRelockConsecutiveCount: number;
+  routeRelockMinimumMs: number;
+  routeCandidateTieMargin: number;
+  routeProgressJitterMeters: number;
 };
 
 export const DEFAULT_TRACKING_CONFIG: TrackingConfig = {
@@ -55,4 +91,40 @@ export const DEFAULT_TRACKING_CONFIG: TrackingConfig = {
   confidenceHigh: 0.85,
   confidenceMedium: 0.6,
   confidenceLow: 0.4,
+
+  routeInitialLockMinScore: 55,
+  routeInitialLockMinMargin: 12,
+  routeInitialLockConsecutiveCount: 3,
+  routeInitialLockMinimumMs: 3000,
+
+  routeSuspiciousHealthThreshold: 0.45,
+  routeSuspiciousMinimumMs: 4000,
+  routeReacquireMinimumMs: 4000,
+
+  routeChallengerMinMargin: 12,
+  routeChallengerConsecutiveCount: 3,
+  routeChallengerMinimumMs: 4000,
+
+  routeTrajectoryWindowMs: 12000,
+  routeTrajectoryMinDistanceMeters: 40,
+
+  routeManualLockMaxDistanceMeters: 250,
+  routeManualLockDurationMs: 30 * 60 * 1000,
+
+  continuitySameSegment: 20,
+  continuityAdjacentSegment: 15,
+  continuityReachableSameRoute: 8,
+  continuitySameLineDisconnected: 2,
+  continuitySuspiciousScale: 0.4,
+  continuityReacquiringScale: 0.05,
+
+  routeWindowMs: 15000,
+  routeWindowMinSamples: 4,
+  routeMinimumAccuracyMeters: 15,
+  routeConventionalMaxSpeedKmh: 160,
+  routeImpossibleSpeedPenalty: 25,
+  routeRelockConsecutiveCount: 3,
+  routeRelockMinimumMs: 3000,
+  routeCandidateTieMargin: 15,
+  routeProgressJitterMeters: 15,
 };

--- a/src/domain/geo/trajectory.ts
+++ b/src/domain/geo/trajectory.ts
@@ -1,0 +1,82 @@
+import { TrackingConfig } from '../../config/tracking-config';
+import { LocationSample } from '../models/location';
+import { haversineDistance } from './distance';
+import { calculateBearing } from './heading';
+
+export type TrajectoryEstimate = {
+  headingDegrees: number | null;
+  distanceMeters: number;
+  durationMs: number;
+  sampleCount: number;
+  reliable: boolean;
+};
+
+/**
+ * Representative heading from recent GPS movement, preferred over a single-fix
+ * device heading. Low-speed / short-distance windows are marked unreliable.
+ */
+export function computeTrajectory(
+  history: LocationSample[],
+  nowMs: number,
+  config: TrackingConfig,
+  stopped: boolean
+): TrajectoryEstimate {
+  const window = history.filter(
+    (sample) => nowMs - sample.timestampMs >= 0 && nowMs - sample.timestampMs <= config.routeTrajectoryWindowMs
+  );
+
+  if (window.length < 2) {
+    return { headingDegrees: null, distanceMeters: 0, durationMs: 0, sampleCount: window.length, reliable: false };
+  }
+
+  const oldest = window[0];
+  const newest = window[window.length - 1];
+  const distanceMeters = haversineDistance(oldest.latitude, oldest.longitude, newest.latitude, newest.longitude);
+  const durationMs = Math.max(0, newest.timestampMs - oldest.timestampMs);
+
+  let accumulated = 0;
+  for (let i = 1; i < window.length; i++) {
+    accumulated += haversineDistance(
+      window[i - 1].latitude,
+      window[i - 1].longitude,
+      window[i].latitude,
+      window[i].longitude
+    );
+  }
+
+  const headingDegrees =
+    distanceMeters >= 5
+      ? calculateBearing(oldest.latitude, oldest.longitude, newest.latitude, newest.longitude)
+      : newest.headingDegrees;
+
+  const reliable =
+    !stopped &&
+    distanceMeters >= config.routeTrajectoryMinDistanceMeters &&
+    accumulated >= config.routeTrajectoryMinDistanceMeters * 0.6;
+
+  return {
+    headingDegrees,
+    distanceMeters: Math.round(distanceMeters * 10) / 10,
+    durationMs,
+    sampleCount: window.length,
+    reliable,
+  };
+}
+
+export function resolveEffectiveHeading(
+  trajectory: TrajectoryEstimate,
+  sample: LocationSample
+): number | null {
+  if (trajectory.reliable && trajectory.headingDegrees !== null) {
+    return trajectory.headingDegrees;
+  }
+  return sample.headingDegrees;
+}
+
+export function trimLocationHistory(
+  history: LocationSample[],
+  nowMs: number,
+  retainMs: number
+): LocationSample[] {
+  return history.filter((sample) => nowMs - sample.timestampMs >= 0 && nowMs - sample.timestampMs <= retainMs);
+}

--- a/src/domain/geo/trajectory.ts
+++ b/src/domain/geo/trajectory.ts
@@ -12,14 +12,22 @@ export type TrajectoryEstimate = {
 };
 
 /**
+ * True when OS speed says the train is stopped. Null when the device did not
+ * provide a speed — that is not treated as 0 km/h.
+ */
+export function osSpeedStopped(sample: LocationSample, config: TrackingConfig): boolean | null {
+  if (sample.speedMps === null) return null;
+  return sample.speedMps * 3.6 <= config.stopSpeedThresholdKmh;
+}
+
+/**
  * Representative heading from recent GPS movement, preferred over a single-fix
- * device heading. Low-speed / short-distance windows are marked unreliable.
+ * device heading. Reliability is based only on displacement, not OS speed.
  */
 export function computeTrajectory(
   history: LocationSample[],
   nowMs: number,
-  config: TrackingConfig,
-  stopped: boolean
+  config: TrackingConfig
 ): TrajectoryEstimate {
   const window = history.filter(
     (sample) => nowMs - sample.timestampMs >= 0 && nowMs - sample.timestampMs <= config.routeTrajectoryWindowMs
@@ -50,7 +58,6 @@ export function computeTrajectory(
       : newest.headingDegrees;
 
   const reliable =
-    !stopped &&
     distanceMeters >= config.routeTrajectoryMinDistanceMeters &&
     accumulated >= config.routeTrajectoryMinDistanceMeters * 0.6;
 
@@ -65,8 +72,10 @@ export function computeTrajectory(
 
 export function resolveEffectiveHeading(
   trajectory: TrajectoryEstimate,
-  sample: LocationSample
+  sample: LocationSample,
+  osStopped: boolean | null
 ): number | null {
+  if (osStopped === true) return sample.headingDegrees;
   if (trajectory.reliable && trajectory.headingDegrees !== null) {
     return trajectory.headingDegrees;
   }

--- a/src/domain/models/railway.ts
+++ b/src/domain/models/railway.ts
@@ -63,6 +63,10 @@ export type DatasetMetadata = {
 
 export type TravelDirection = 'UP' | 'DOWN' | 'DIRECTION_A' | 'DIRECTION_B' | 'UNKNOWN';
 
+export function routeIdentityKey(segment: TrackSegment): string {
+  return segment.routeId ?? `line:${segment.lineId}`;
+}
+
 export type RouteLockState =
   | 'UNRESOLVED'
   | 'LOCKED'

--- a/src/domain/models/railway.ts
+++ b/src/domain/models/railway.ts
@@ -63,6 +63,78 @@ export type DatasetMetadata = {
 
 export type TravelDirection = 'UP' | 'DOWN' | 'DIRECTION_A' | 'DIRECTION_B' | 'UNKNOWN';
 
+export type RouteLockState =
+  | 'UNRESOLVED'
+  | 'LOCKED'
+  | 'SUSPICIOUS'
+  | 'REACQUIRING'
+  | 'MANUAL_LOCK';
+
+export type RouteSwitchReason =
+  | 'initial-lock'
+  | 'challenger-dominant'
+  | 'route-health-low'
+  | 'manual-selection'
+  | 'manual-reacquire'
+  | 'current-route-lost';
+
+export type RouteLockEventType =
+  | 'route-lock'
+  | 'route-suspicious'
+  | 'route-reacquire-start'
+  | 'route-switch'
+  | 'manual-reacquire'
+  | 'manual-route-lock'
+  | 'manual-route-unlock'
+  | 'route-lost';
+
+export type ContinuityKind =
+  | 'same-segment'
+  | 'adjacent-segment'
+  | 'reachable-same-route'
+  | 'same-line-disconnected'
+  | 'unrelated';
+
+export type RouteHealth = {
+  distanceConsistency: number;
+  headingConsistency: number;
+  trajectoryConsistency: number;
+  stationSequenceConsistency: number;
+  topologyConsistency: number;
+  progressConsistency: number;
+  challengerDominance: number;
+  total: number;
+};
+
+export type RouteChallengerState = {
+  segmentId: string;
+  routeId: string | null;
+  lineId: string;
+  consecutiveWins: number;
+  firstSeenAtMs: number;
+  lastSeenAtMs: number;
+  latestScore: number;
+  latestMargin: number;
+};
+
+export type WindowRouteScore = {
+  routeId: string;
+  lineId: string;
+  lineName: string;
+  meanDistanceScore: number;
+  headingConsistencyScore: number;
+  progressMonotonicityScore: number;
+  stationSequenceScore: number;
+  topologyScore: number;
+  totalScore: number;
+};
+
+export type RouteLockEvent = {
+  type: RouteLockEventType;
+  reason?: RouteSwitchReason;
+  data: Record<string, string | number | boolean | null>;
+};
+
 export type RouteCandidateScore = {
   segment: TrackSegment;
   line: RailwayLine;
@@ -74,6 +146,10 @@ export type RouteCandidateScore = {
   totalScore: number;
   projectedPoint: [number, number]; // [latitude, longitude]
   bearingDegrees: number;
+  normalizedDistance?: number;
+  continuityKind?: ContinuityKind;
+  effectiveHeadingDegrees?: number | null;
+  trackPositionMeters?: number;
 };
 
 export type RouteMatch = {
@@ -82,6 +158,18 @@ export type RouteMatch = {
   confidence: number; // 0.0 to 1.0
   candidates: RouteCandidateScore[];
   timestampMs: number;
+  lockState?: RouteLockState;
+  routeHealth?: RouteHealth | null;
+  challenger?: RouteChallengerState | null;
+  scoreMargin?: number;
+  currentScore?: number | null;
+  rescoredCurrentScore?: number | null;
+  trajectoryHeadingDegrees?: number | null;
+  switchReason?: RouteSwitchReason | null;
+  manualLockAway?: boolean;
+  showSelectedRoute?: boolean;
+  windowScores?: WindowRouteScore[];
+  lockEvents?: RouteLockEvent[];
 };
 
 export type JourneyState = {
@@ -94,4 +182,17 @@ export type JourneyState = {
   progressRatio: number | null; // 0.0 to 1.0
   confidence: number;
   status: 'INITIALIZING' | 'WAITING_FOR_GPS' | 'MATCHING_ROUTE' | 'TRACKING' | 'GPS_UNAVAILABLE' | 'ROUTE_UNCERTAIN' | 'GPS_LOW_ACCURACY';
+  lockState?: RouteLockState;
+  manualLockAway?: boolean;
 };
+
+export function isCommittedRouteLock(state: RouteLockState | undefined): boolean {
+  return state === undefined || state === 'LOCKED' || state === 'SUSPICIOUS' || state === 'MANUAL_LOCK';
+}
+
+export function shouldDisplaySelectedRoute(match: RouteMatch | null | undefined): boolean {
+  if (!match) return false;
+  if (match.showSelectedRoute === false) return false;
+  if (match.showSelectedRoute === true) return true;
+  return isCommittedRouteLock(match.lockState);
+}

--- a/src/domain/railway/candidate-scorer.ts
+++ b/src/domain/railway/candidate-scorer.ts
@@ -1,25 +1,53 @@
 import { TrackingConfig } from '../../config/tracking-config';
 import { LocationSample } from '../models/location';
-import { RailwayLine, RouteCandidateScore, TrackSegment } from '../models/railway';
+import {
+  ContinuityKind,
+  RailwayLine,
+  RouteCandidateScore,
+  RouteLockState,
+  TrackSegment,
+} from '../models/railway';
 import { findClosestPointOnPolyline } from '../geo/polyline';
 import { calculateBearing, calculateHeadingDifference } from '../geo/heading';
+import { classifyContinuity, continuityBonus } from './continuity';
 
-export function scoreCandidate(
-  sample: LocationSample,
-  segment: TrackSegment,
-  line: RailwayLine,
-  previousMatchSegmentId: string | null,
-  config: TrackingConfig
-): RouteCandidateScore {
+export type ScoreCandidateInput = {
+  sample: LocationSample;
+  segment: TrackSegment;
+  line: RailwayLine;
+  previousSegment: TrackSegment | null;
+  nearbySegments: TrackSegment[];
+  lockState: RouteLockState;
+  effectiveHeadingDegrees: number | null;
+  config: TrackingConfig;
+};
+
+export function looksLikeShinkansen(line: RailwayLine): boolean {
+  const name = `${line.name} ${line.shortName ?? ''}`;
+  return name.includes('新幹線');
+}
+
+export function scoreCandidate(input: ScoreCandidateInput): RouteCandidateScore {
+  const { sample, segment, line, previousSegment, nearbySegments, lockState, effectiveHeadingDegrees, config } =
+    input;
+
   const closest = findClosestPointOnPolyline(sample.latitude, sample.longitude, segment.coordinates);
   const distance = closest.distanceMeters;
+  const startOffset = segment.startOffsetMeters ?? 0;
+  const trackPositionMeters = startOffset + closest.distanceAlongPolylineMeters;
 
-  // 1. Distance score (40 pts max)
+  const accuracyFloor = Math.max(sample.accuracyMeters, config.routeMinimumAccuracyMeters);
+  const normalizedDistance = distance / accuracyFloor;
+
+  // 1. Distance score (40 pts max), softened by GPS-accuracy-normalized distance.
   const distRatio = Math.min(1, distance / config.routeSearchRadiusMeters);
-  const distanceScore = Math.max(0, 40 * (1 - distRatio * distRatio));
+  let distanceScore = Math.max(0, 40 * (1 - distRatio * distRatio));
+  if (normalizedDistance > 1) {
+    distanceScore *= 1 / (1 + (normalizedDistance - 1) * 0.45);
+  }
 
-  // 2. Heading score (30 pts max)
-  let headingScore = 15; // default neutral if heading unavailable
+  // 2. Heading score (30 pts max). Trajectory heading is preferred by the caller.
+  let headingScore = 15;
   let bearingDegrees = 0;
 
   if (segment.coordinates.length >= 2) {
@@ -28,10 +56,10 @@ export function scoreCandidate(
     const p2 = segment.coordinates[Math.min(idx + 1, segment.coordinates.length - 1)];
     bearingDegrees = calculateBearing(p1[0], p1[1], p2[0], p2[1]);
 
-    if (sample.headingDegrees !== null) {
-      const headingDiffForward = calculateHeadingDifference(sample.headingDegrees, bearingDegrees);
+    if (effectiveHeadingDegrees !== null) {
+      const headingDiffForward = calculateHeadingDifference(effectiveHeadingDegrees, bearingDegrees);
       const headingDiffBackward = calculateHeadingDifference(
-        sample.headingDegrees,
+        effectiveHeadingDegrees,
         (bearingDegrees + 180) % 360
       );
       const minDiff = Math.min(headingDiffForward, headingDiffBackward);
@@ -39,18 +67,24 @@ export function scoreCandidate(
     }
   }
 
-  // 3. Continuity score (20 pts max)
-  let continuityScore = 0;
-  if (previousMatchSegmentId === segment.id) {
-    continuityScore = 20;
-  } else if (previousMatchSegmentId && previousMatchSegmentId.split('-')[0] === segment.lineId) {
-    continuityScore = 15;
-  }
+  // 3. Topology continuity (up to 20 pts, scaled by lock state).
+  const continuityKind: ContinuityKind = classifyContinuity(previousSegment, segment, nearbySegments);
+  const continuityScore = continuityBonus(continuityKind, lockState, config);
 
-  // 4. History / Accuracy weighting (10 pts max)
+  // 4. Accuracy / history weighting (10 pts max).
   const historyScore = sample.accuracyMeters <= 20 ? 10 : sample.accuracyMeters <= 50 ? 5 : 0;
 
-  const totalScore = Math.round((distanceScore + headingScore + continuityScore + historyScore) * 10) / 10;
+  // 5. Asymmetric speed: fast travel can reject conventional lines. Slow travel never rejects Shinkansen.
+  let speedPenalty = 0;
+  if (sample.speedMps !== null && sample.speedMps > 0) {
+    const speedKmh = sample.speedMps * 3.6;
+    if (speedKmh > config.routeConventionalMaxSpeedKmh && !looksLikeShinkansen(line)) {
+      speedPenalty = config.routeImpossibleSpeedPenalty;
+    }
+  }
+
+  const totalScore =
+    Math.round((distanceScore + headingScore + continuityScore + historyScore - speedPenalty) * 10) / 10;
 
   return {
     segment,
@@ -63,5 +97,10 @@ export function scoreCandidate(
     totalScore,
     projectedPoint: closest.projectedPoint,
     bearingDegrees: Math.round(bearingDegrees * 10) / 10,
+    normalizedDistance: Math.round(normalizedDistance * 100) / 100,
+    continuityKind,
+    effectiveHeadingDegrees,
+    trackPositionMeters: Math.round(trackPositionMeters),
   };
 }
+

--- a/src/domain/railway/continuity.ts
+++ b/src/domain/railway/continuity.ts
@@ -1,0 +1,109 @@
+import { TrackingConfig } from '../../config/tracking-config';
+import { ContinuityKind, RouteLockState, TrackSegment } from '../models/railway';
+
+export function segmentsAreAdjacent(a: TrackSegment, b: TrackSegment): boolean {
+  if (a.id === b.id) return false;
+
+  const aNeighbors = new Set([...(a.previousSegmentIds ?? []), ...(a.nextSegmentIds ?? [])]);
+  if (aNeighbors.has(b.id)) return true;
+
+  const bNeighbors = new Set([...(b.previousSegmentIds ?? []), ...(b.nextSegmentIds ?? [])]);
+  if (bNeighbors.has(a.id)) return true;
+
+  const aStations = new Set([a.fromStationId, a.toStationId].filter(Boolean));
+  const bStations = new Set([b.fromStationId, b.toStationId].filter(Boolean));
+  for (const stationId of aStations) {
+    if (bStations.has(stationId)) return true;
+  }
+  return false;
+}
+
+export function classifyContinuity(
+  previous: TrackSegment | null,
+  candidate: TrackSegment,
+  nearbySegments: TrackSegment[]
+): ContinuityKind {
+  if (!previous) return 'unrelated';
+  if (previous.id === candidate.id) return 'same-segment';
+  if (segmentsAreAdjacent(previous, candidate)) return 'adjacent-segment';
+
+  const sameRoute =
+    previous.routeId !== undefined &&
+    candidate.routeId !== undefined &&
+    previous.routeId === candidate.routeId;
+  if (sameRoute || isReachableAlongTopology(previous, candidate, nearbySegments, 8)) {
+    return 'reachable-same-route';
+  }
+
+  if (previous.lineId === candidate.lineId) return 'same-line-disconnected';
+  return 'unrelated';
+}
+
+export function continuityBonus(
+  kind: ContinuityKind,
+  lockState: RouteLockState,
+  config: TrackingConfig
+): number {
+  const base =
+    kind === 'same-segment'
+      ? config.continuitySameSegment
+      : kind === 'adjacent-segment'
+        ? config.continuityAdjacentSegment
+        : kind === 'reachable-same-route'
+          ? config.continuityReachableSameRoute
+          : kind === 'same-line-disconnected'
+            ? config.continuitySameLineDisconnected
+            : 0;
+
+  const scale =
+    lockState === 'REACQUIRING'
+      ? config.continuityReacquiringScale
+      : lockState === 'SUSPICIOUS'
+        ? config.continuitySuspiciousScale
+        : 1;
+
+  return Math.round(base * scale * 10) / 10;
+}
+
+function isReachableAlongTopology(
+  from: TrackSegment,
+  to: TrackSegment,
+  nearbySegments: TrackSegment[],
+  maxHops: number
+): boolean {
+  if (from.lineId !== to.lineId && from.routeId !== to.routeId) return false;
+
+  const byId = new Map(nearbySegments.map((segment) => [segment.id, segment]));
+  byId.set(from.id, from);
+  byId.set(to.id, to);
+
+  const queue: Array<{ id: string; hops: number }> = [{ id: from.id, hops: 0 }];
+  const seen = new Set<string>([from.id]);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.id === to.id) return true;
+    if (current.hops >= maxHops) continue;
+
+    const segment = byId.get(current.id);
+    if (!segment) continue;
+
+    const neighborIds = new Set([
+      ...(segment.previousSegmentIds ?? []),
+      ...(segment.nextSegmentIds ?? []),
+    ]);
+    for (const other of byId.values()) {
+      if (other.id !== segment.id && segmentsAreAdjacent(segment, other)) {
+        neighborIds.add(other.id);
+      }
+    }
+
+    for (const neighborId of neighborIds) {
+      if (seen.has(neighborId)) continue;
+      seen.add(neighborId);
+      queue.push({ id: neighborId, hops: current.hops + 1 });
+    }
+  }
+
+  return false;
+}

--- a/src/domain/railway/continuity.ts
+++ b/src/domain/railway/continuity.ts
@@ -10,6 +10,8 @@ export function segmentsAreAdjacent(a: TrackSegment, b: TrackSegment): boolean {
   const bNeighbors = new Set([...(b.previousSegmentIds ?? []), ...(b.nextSegmentIds ?? [])]);
   if (bNeighbors.has(a.id)) return true;
 
+  if (a.lineId !== b.lineId) return false;
+
   const aStations = new Set([a.fromStationId, a.toStationId].filter(Boolean));
   const bStations = new Set([b.fromStationId, b.toStationId].filter(Boolean));
   for (const stationId of aStations) {
@@ -71,7 +73,8 @@ function isReachableAlongTopology(
   nearbySegments: TrackSegment[],
   maxHops: number
 ): boolean {
-  if (from.lineId !== to.lineId && from.routeId !== to.routeId) return false;
+  const sameDefinedRoute = from.routeId !== undefined && from.routeId === to.routeId;
+  if (from.lineId !== to.lineId && !sameDefinedRoute) return false;
 
   const byId = new Map(nearbySegments.map((segment) => [segment.id, segment]));
   byId.set(from.id, from);

--- a/src/domain/railway/journey-state-estimator.ts
+++ b/src/domain/railway/journey-state-estimator.ts
@@ -1,6 +1,6 @@
 import { TrackingConfig } from '../../config/tracking-config';
 import { LocationSample, FullSpeedState, TrackNavigationState } from '../models/location';
-import { JourneyState, RailwayLine, RouteMatch, Station, TrackSegment, TravelDirection } from '../models/railway';
+import { JourneyState, RailwayLine, RouteMatch, Station, TrackSegment, TravelDirection, shouldDisplaySelectedRoute } from '../models/railway';
 import { calculateBearing, calculateHeadingDifference } from '../geo/heading';
 import { haversineDistance } from '../geo/distance';
 import { RailwayDataRepository } from './repository';
@@ -87,8 +87,10 @@ export class JourneyStateEstimator {
     const navState = navStateInput ?? speedState?.navState;
     const now = sample?.timestampMs ?? navState?.lastPredictionTimestampMs ?? Date.now();
 
-    if (match?.selectedLine) {
-      this.cachedLine = match.selectedLine;
+    const displayableMatch = shouldDisplaySelectedRoute(match) ? match : null;
+
+    if (displayableMatch?.selectedLine) {
+      this.cachedLine = displayableMatch.selectedLine;
       this.lastMatchTimestampMs = now;
     }
 
@@ -104,7 +106,7 @@ export class JourneyStateEstimator {
       this.lastMatchTimestampMs !== null &&
       now - this.lastMatchTimestampMs >= this.config.routeMatchLossGraceMs;
 
-    if (!match && !isDrActive && (navState?.mode === 'lost' || isGraceExpired)) {
+    if (!displayableMatch && !isDrActive && (navState?.mode === 'lost' || isGraceExpired)) {
       this.cachedLine = null;
       return {
         line: null,
@@ -115,11 +117,13 @@ export class JourneyStateEstimator {
         distanceToNextStationMeters: null,
         progressRatio: null,
         confidence: 0.0,
-        status: 'ROUTE_UNCERTAIN',
+        status: match?.lockState === 'UNRESOLVED' || match?.lockState === 'REACQUIRING' ? 'MATCHING_ROUTE' : 'ROUTE_UNCERTAIN',
+        lockState: match?.lockState,
+        manualLockAway: match?.manualLockAway,
       };
     }
 
-    const activeLineId = match?.selectedLine.id || navState?.lineId || this.cachedLine?.id;
+    const activeLineId = displayableMatch?.selectedLine.id || navState?.lineId || this.cachedLine?.id;
 
     if (!activeLineId) {
       return {
@@ -131,11 +135,17 @@ export class JourneyStateEstimator {
         distanceToNextStationMeters: null,
         progressRatio: null,
         confidence: 0.0,
-        status: sample && sample.accuracyMeters > this.config.maxGpsAccuracyMeters ? 'GPS_LOW_ACCURACY' : 'ROUTE_UNCERTAIN',
+        status: sample && sample.accuracyMeters > this.config.maxGpsAccuracyMeters
+          ? 'GPS_LOW_ACCURACY'
+          : match?.lockState === 'UNRESOLVED' || match?.lockState === 'REACQUIRING'
+            ? 'MATCHING_ROUTE'
+            : 'ROUTE_UNCERTAIN',
+        lockState: match?.lockState,
+        manualLockAway: match?.manualLockAway,
       };
     }
 
-    const selectedLine = match?.selectedLine || this.cachedLine || (await this.repository.getLine(activeLineId));
+    const selectedLine = displayableMatch?.selectedLine || this.cachedLine || (await this.repository.getLine(activeLineId));
     if (selectedLine) {
       this.cachedLine = selectedLine;
     }
@@ -151,11 +161,13 @@ export class JourneyStateEstimator {
         progressRatio: null,
         confidence: 0.0,
         status: 'ROUTE_UNCERTAIN',
+        lockState: match?.lockState,
+        manualLockAway: match?.manualLockAway,
       };
     }
 
     let direction: TravelDirection = 'UNKNOWN';
-    if (match && sample) {
+    if (displayableMatch && sample) {
       const heading = sample.headingDegrees ?? (this.lastSample
         ? calculateBearing(
             this.lastSample.latitude,
@@ -166,7 +178,7 @@ export class JourneyStateEstimator {
         : null);
 
       if (heading !== null) {
-        const coords = match.selectedSegment.coordinates;
+        const coords = displayableMatch.selectedSegment.coordinates;
         const startPoint = coords[0];
         const endPoint = coords[coords.length - 1];
         const segmentBearing = calculateBearing(startPoint[0], startPoint[1], endPoint[0], endPoint[1]);
@@ -201,8 +213,10 @@ export class JourneyStateEstimator {
         nextStation: null,
         distanceToNextStationMeters: null,
         progressRatio: null,
-        confidence: match ? match.confidence : 0.5,
+        confidence: displayableMatch ? displayableMatch.confidence : 0.5,
         status: 'ROUTE_UNCERTAIN',
+        lockState: match?.lockState,
+        manualLockAway: match?.manualLockAway,
       };
     }
 
@@ -212,7 +226,7 @@ export class JourneyStateEstimator {
     let distanceToNextStationMeters: number | null = null;
     let progressRatio: number | null = null;
 
-    const currentSeg = currentSegmentInput || match?.selectedSegment;
+    const currentSeg = currentSegmentInput || displayableMatch?.selectedSegment;
     const isDown = isDownDirection(direction);
 
     if (currentSeg && (currentSeg.fromStationId || currentSeg.toStationId)) {
@@ -340,10 +354,14 @@ export class JourneyStateEstimator {
       : isUpDirection(direction)
         ? selectedLine.directionAName ?? '上り'
         : null;
-    const confidence = match ? match.confidence : (navState?.confidence ?? 0.5);
+    const confidence = displayableMatch ? displayableMatch.confidence : (navState?.confidence ?? 0.5);
 
     let status: JourneyState['status'] = 'TRACKING';
-    if (navState?.mode === 'dead-reckoning' || navState?.mode === 'dead-reckoning-low-confidence') {
+    if (match?.lockState === 'UNRESOLVED' || match?.lockState === 'REACQUIRING') {
+      status = 'MATCHING_ROUTE';
+    } else if (match?.lockState === 'SUSPICIOUS') {
+      status = 'ROUTE_UNCERTAIN';
+    } else if (navState?.mode === 'dead-reckoning' || navState?.mode === 'dead-reckoning-low-confidence') {
       status = 'TRACKING';
     } else if (confidence < this.config.confidenceMedium) {
       status = 'ROUTE_UNCERTAIN';
@@ -359,6 +377,8 @@ export class JourneyStateEstimator {
       progressRatio,
       confidence,
       status,
+      lockState: match?.lockState,
+      manualLockAway: match?.manualLockAway,
     };
   }
 

--- a/src/domain/railway/map-matcher.ts
+++ b/src/domain/railway/map-matcher.ts
@@ -1,28 +1,137 @@
 import { TrackingConfig } from '../../config/tracking-config';
 import { LocationSample } from '../models/location';
-import { RailwayLine, RouteCandidateScore, RouteMatch, TrackSegment } from '../models/railway';
+import {
+  RailwayLine,
+  RouteCandidateScore,
+  RouteChallengerState,
+  RouteHealth,
+  RouteLockEvent,
+  RouteLockState,
+  RouteMatch,
+  RouteSwitchReason,
+  TrackSegment,
+  WindowRouteScore,
+} from '../models/railway';
+import { computeTrajectory, resolveEffectiveHeading, trimLocationHistory } from '../geo/trajectory';
 import { scoreCandidate } from './candidate-scorer';
 import { calculateConfidence } from './confidence';
+import { evaluateRouteHealth, headingDifferenceOrNull, RouteObservation } from './route-health';
+import { scoreRoutesOverWindow } from './window-scorer';
 
 export interface RailwayDatabaseReader {
   findSegmentsNear(latitude: number, longitude: number, radiusMeters: number): Promise<TrackSegment[]>;
   getLine(lineId: string): Promise<RailwayLine | undefined>;
 }
 
+type PendingLeader = {
+  lineId: string;
+  segmentId: string;
+  firstSeenAtMs: number;
+  consecutiveCount: number;
+};
+
 export class MapMatcher {
   private currentMatch: RouteCandidateScore | null = null;
-  private pendingCandidateId: string | null = null;
-  private pendingCount = 0;
-  private pendingFirstSeenTimeMs = 0;
+  private lockState: RouteLockState = 'UNRESOLVED';
+  private history: LocationSample[] = [];
+  private observations: RouteObservation[] = [];
+  private challenger: RouteChallengerState | null = null;
+  private pendingLeader: PendingLeader | null = null;
+  private suspiciousSinceMs: number | null = null;
+  private manualReacquireActive = false;
+  private manualLockUntilMs: number | null = null;
+  private lastSwitchReason: RouteSwitchReason | null = null;
+  private pendingEvents: RouteLockEvent[] = [];
+  private lastCandidates: RouteCandidateScore[] = [];
+  private healthLowSinceMs: number | null = null;
 
   constructor(
     private db: RailwayDatabaseReader,
     private config: TrackingConfig
   ) {}
 
+  public getLockState(): RouteLockState {
+    return this.lockState;
+  }
+
+  public startManualReacquire(nowMs: number): void {
+    this.manualReacquireActive = true;
+    this.manualLockUntilMs = null;
+    this.pendingLeader = null;
+    this.challenger = null;
+    this.suspiciousSinceMs = null;
+    this.lastSwitchReason = 'manual-reacquire';
+    this.pushEvent('manual-reacquire', 'manual-reacquire', {
+      fromState: this.lockState,
+      previousLineId: this.currentMatch?.line.id ?? null,
+      previousSegmentId: this.currentMatch?.segment.id ?? null,
+    });
+    this.transitionTo('REACQUIRING', nowMs, 'manual-reacquire');
+    this.currentMatch = null;
+  }
+
+  public lockSelectedRoute(segmentId: string, nowMs: number): boolean {
+    const fromHistory = this.lastCandidates.find((candidate) => candidate.segment.id === segmentId)
+      ?? (this.currentMatch?.segment.id === segmentId ? this.currentMatch : null);
+    if (!fromHistory) return false;
+
+    this.manualReacquireActive = false;
+    this.manualLockUntilMs = nowMs + this.config.routeManualLockDurationMs;
+    this.currentMatch = fromHistory;
+    this.pendingLeader = null;
+    this.challenger = null;
+    this.suspiciousSinceMs = null;
+    this.lastSwitchReason = 'manual-selection';
+    this.pushEvent('manual-route-lock', 'manual-selection', {
+      lineId: fromHistory.line.id,
+      segmentId: fromHistory.segment.id,
+      score: fromHistory.totalScore,
+    });
+    this.transitionTo('MANUAL_LOCK', nowMs, 'manual-selection');
+    return true;
+  }
+
+  public unlockManualRoute(nowMs: number): void {
+    this.pushEvent('manual-route-unlock', undefined, {
+      fromLineId: this.currentMatch?.line.id ?? null,
+      fromSegmentId: this.currentMatch?.segment.id ?? null,
+    });
+    this.manualReacquireActive = false;
+    this.manualLockUntilMs = null;
+    this.currentMatch = null;
+    this.pendingLeader = null;
+    this.challenger = null;
+    this.suspiciousSinceMs = null;
+    this.healthLowSinceMs = null;
+    this.observations = [];
+    this.lastSwitchReason = null;
+    this.transitionTo('UNRESOLVED', nowMs);
+  }
+
+  public forceLockForTests(candidate: RouteCandidateScore): void {
+    this.currentMatch = candidate;
+    this.lockState = 'LOCKED';
+    this.manualReacquireActive = false;
+    this.lastCandidates = [candidate];
+    this.lastSwitchReason = 'initial-lock';
+  }
+
   public async match(sample: LocationSample): Promise<RouteMatch | null> {
+    const eventsAtStart = this.pendingEvents.length;
+
     if (sample.accuracyMeters > this.config.maxGpsAccuracyMeters) {
-      return null;
+      return this.buildMatch(sample, [], null, null, eventsAtStart);
+    }
+
+    this.history.push(sample);
+    this.history = trimLocationHistory(
+      this.history,
+      sample.timestampMs,
+      Math.max(this.config.routeWindowMs, this.config.routeTrajectoryWindowMs)
+    );
+
+    if (this.lockState === 'MANUAL_LOCK' && this.manualLockUntilMs !== null && sample.timestampMs >= this.manualLockUntilMs) {
+      this.unlockManualRoute(sample.timestampMs);
     }
 
     const segments = await this.db.findSegmentsNear(
@@ -32,86 +141,619 @@ export class MapMatcher {
     );
 
     if (segments.length === 0) {
-      return null;
+      return this.handleNoCandidates(sample, eventsAtStart);
     }
 
-    const candidateScores: RouteCandidateScore[] = [];
-    const prevSegId = this.currentMatch?.segment.id ?? null;
+    const stopped = (sample.speedMps ?? 0) * 3.6 <= this.config.stopSpeedThresholdKmh;
+    const trajectory = computeTrajectory(this.history, sample.timestampMs, this.config, stopped);
+    const effectiveHeading = resolveEffectiveHeading(trajectory, sample);
 
-    for (const seg of segments) {
-      const line = await this.db.getLine(seg.lineId);
+    const candidateScores: RouteCandidateScore[] = [];
+    for (const segment of segments) {
+      const line = await this.db.getLine(segment.lineId);
       if (!line) continue;
-      const score = scoreCandidate(sample, seg, line, prevSegId, this.config);
-      candidateScores.push(score);
+      candidateScores.push(
+        scoreCandidate({
+          sample,
+          segment,
+          line,
+          previousSegment: this.currentMatch?.segment ?? null,
+          nearbySegments: segments,
+          lockState: this.lockState,
+          effectiveHeadingDegrees: effectiveHeading,
+          config: this.config,
+        })
+      );
     }
 
     if (candidateScores.length === 0) {
-      return null;
+      return this.handleNoCandidates(sample, eventsAtStart);
     }
 
-    // Sort candidates descending by total score
     candidateScores.sort((a, b) => b.totalScore - a.totalScore);
+    this.lastCandidates = candidateScores.slice(0, 8);
 
     const topCandidate = candidateScores[0];
-    const secondCandidate = candidateScores[1] ?? null;
+    const secondCandidate = this.nextDifferentLine(candidateScores, topCandidate.line.id);
+    const scoreMargin = topCandidate.totalScore - (secondCandidate?.totalScore ?? 0);
+    const rescoredCurrent = this.rescoreCurrent(candidateScores);
 
-    // Apply Hysteresis for route switching
-    if (this.currentMatch === null) {
-      this.currentMatch = topCandidate;
-    } else if (topCandidate.segment.id !== this.currentMatch.segment.id) {
-      const isSameLine = topCandidate.line.id === this.currentMatch.line.id;
+    this.recordObservation(sample, rescoredCurrent ?? (this.isCurrentLine(topCandidate) ? topCandidate : null));
+    this.updateChallenger(topCandidate, rescoredCurrent, scoreMargin, sample.timestampMs);
 
-      if (this.pendingCandidateId === topCandidate.segment.id) {
-        this.pendingCount++;
-        const duration = sample.timestampMs - this.pendingFirstSeenTimeMs;
+    const health = this.lockState === 'UNRESOLVED'
+      ? null
+      : evaluateRouteHealth(
+          this.observations,
+          rescoredCurrent,
+          this.challenger && !this.isCurrentLine(topCandidate) ? this.challenger.latestMargin : null,
+          this.config
+        );
 
-        const isConsecutive = this.pendingCount >= (isSameLine ? 1 : this.config.routeSwitchConsecutiveCount);
-        const isTimeMet = duration >= (isSameLine ? 1000 : this.config.routeSwitchMinimumMs);
-        
-        // For same line adjacent segment transitions, allow switching smoothly
-        const scoreDifferenceSignificant = isSameLine
-          ? topCandidate.distanceMeters < this.currentMatch.distanceMeters || topCandidate.totalScore > this.currentMatch.totalScore - 15
-          : topCandidate.totalScore - this.currentMatch.totalScore > 15;
+    const windowScores = this.shouldScoreWindow()
+      ? scoreRoutesOverWindow(this.history, this.groupRoutes(candidateScores), this.config)
+      : [];
 
-        if ((isConsecutive || isTimeMet) && scoreDifferenceSignificant) {
-          this.currentMatch = topCandidate;
-          this.pendingCandidateId = null;
-          this.pendingCount = 0;
-        }
-      } else {
-        this.pendingCandidateId = topCandidate.segment.id;
-        this.pendingCount = 1;
-        this.pendingFirstSeenTimeMs = sample.timestampMs;
+    this.advanceState({
+      sample,
+      topCandidate,
+      secondCandidate,
+      scoreMargin,
+      rescoredCurrent,
+      health,
+      windowScores,
+      stopped,
+    });
 
-        // Immediate switch for same line if distance to new segment is much closer
-        if (isSameLine && topCandidate.distanceMeters < this.currentMatch.distanceMeters - 20) {
-          this.currentMatch = topCandidate;
-          this.pendingCandidateId = null;
-          this.pendingCount = 0;
-        }
-      }
-    } else {
-      // Top candidate is still current match
-      this.currentMatch = topCandidate;
-      this.pendingCandidateId = null;
-      this.pendingCount = 0;
-    }
-
-    const confidence = calculateConfidence(this.currentMatch, secondCandidate);
-
-    return {
-      selectedLine: this.currentMatch.line,
-      selectedSegment: this.currentMatch.segment,
-      confidence,
-      candidates: candidateScores.slice(0, 5), // top 5
-      timestampMs: sample.timestampMs,
-    };
+    return this.buildMatch(sample, candidateScores, health, windowScores, eventsAtStart, {
+      scoreMargin,
+      currentScore: this.currentMatch?.totalScore ?? null,
+      rescoredCurrentScore: rescoredCurrent?.totalScore ?? null,
+      trajectoryHeadingDegrees: trajectory.headingDegrees,
+    });
   }
 
   public reset(): void {
     this.currentMatch = null;
-    this.pendingCandidateId = null;
-    this.pendingCount = 0;
-    this.pendingFirstSeenTimeMs = 0;
+    this.lockState = 'UNRESOLVED';
+    this.history = [];
+    this.observations = [];
+    this.challenger = null;
+    this.pendingLeader = null;
+    this.suspiciousSinceMs = null;
+    this.manualReacquireActive = false;
+    this.manualLockUntilMs = null;
+    this.lastSwitchReason = null;
+    this.pendingEvents = [];
+    this.lastCandidates = [];
+    this.healthLowSinceMs = null;
   }
+
+  private async handleNoCandidates(sample: LocationSample, eventsAtStart: number): Promise<RouteMatch | null> {
+    if (this.currentMatch && this.lockState !== 'UNRESOLVED' && this.lockState !== 'MANUAL_LOCK') {
+      this.recordLostObservation(sample);
+      if (this.lockState === 'LOCKED') {
+        this.enterSuspicious(sample.timestampMs, 'current-route-lost');
+      } else if (this.lockState === 'SUSPICIOUS') {
+        this.maybeEnterReacquiring(sample.timestampMs);
+      } else if (this.lockState === 'REACQUIRING') {
+        this.pushEvent('route-lost', 'current-route-lost', {
+          lineId: this.currentMatch.line.id,
+          segmentId: this.currentMatch.segment.id,
+        });
+        this.currentMatch = null;
+        this.transitionTo('UNRESOLVED', sample.timestampMs, 'current-route-lost');
+      }
+    }
+    return this.buildMatch(sample, [], null, [], eventsAtStart);
+  }
+
+  private advanceState(input: {
+    sample: LocationSample;
+    topCandidate: RouteCandidateScore;
+    secondCandidate: RouteCandidateScore | null;
+    scoreMargin: number;
+    rescoredCurrent: RouteCandidateScore | null;
+    health: RouteHealth | null;
+    windowScores: WindowRouteScore[];
+    stopped: boolean;
+  }): void {
+    const { sample, topCandidate, scoreMargin, rescoredCurrent, health, windowScores } = input;
+
+    if (this.lockState === 'MANUAL_LOCK') {
+      if (rescoredCurrent) this.currentMatch = rescoredCurrent;
+      return;
+    }
+
+    if (this.lockState === 'UNRESOLVED') {
+      this.considerInitialLock(topCandidate, scoreMargin, sample.timestampMs);
+      return;
+    }
+
+    if (rescoredCurrent) {
+      this.adoptSameLineProgress(rescoredCurrent, topCandidate);
+    } else if (this.currentMatch) {
+      this.recordLostObservation(sample);
+    }
+
+    if (this.lockState === 'LOCKED') {
+      if (!rescoredCurrent) {
+        this.enterSuspicious(sample.timestampMs, 'current-route-lost');
+        return;
+      }
+      if (this.shouldEnterSuspicious(health, sample.timestampMs)) {
+        this.enterSuspicious(sample.timestampMs, this.challengerDominant() ? 'challenger-dominant' : 'route-health-low');
+      }
+      return;
+    }
+
+    if (this.lockState === 'SUSPICIOUS') {
+      if (this.shouldRecoverToLocked(health, scoreMargin, topCandidate)) {
+        if (rescoredCurrent) this.currentMatch = rescoredCurrent;
+        this.exitSuspicion();
+        this.transitionTo('LOCKED', sample.timestampMs);
+        return;
+      }
+      if (!this.isCurrentLine(topCandidate) && scoreMargin >= this.config.routeChallengerMinMargin) {
+        this.trackPendingLeader(topCandidate, scoreMargin, sample.timestampMs, true);
+      }
+      if (!this.maybeEnterReacquiring(sample.timestampMs)) return;
+    }
+
+    if (this.lockState === 'REACQUIRING') {
+      if (!this.currentMatch) {
+        this.considerInitialLock(topCandidate, scoreMargin, sample.timestampMs);
+        return;
+      }
+      this.considerReacquireLock(topCandidate, scoreMargin, health, windowScores, sample);
+    }
+  }
+
+  private considerInitialLock(topCandidate: RouteCandidateScore, scoreMargin: number, nowMs: number): void {
+    const minScore = this.config.routeInitialLockMinScore;
+    const minMargin = this.config.routeInitialLockMinMargin;
+    const neededCount = this.lockState === 'REACQUIRING'
+      ? this.config.routeRelockConsecutiveCount
+      : this.config.routeInitialLockConsecutiveCount;
+    const neededMs = this.lockState === 'REACQUIRING'
+      ? this.config.routeRelockMinimumMs
+      : this.config.routeInitialLockMinimumMs;
+    const qualifies = topCandidate.totalScore >= minScore && scoreMargin >= minMargin;
+
+    if (!qualifies) {
+      this.pendingLeader = null;
+      return;
+    }
+
+    if (this.pendingLeader && this.pendingLeader.lineId === topCandidate.line.id) {
+      this.pendingLeader.consecutiveCount += 1;
+      this.pendingLeader.segmentId = topCandidate.segment.id;
+    } else {
+      this.pendingLeader = {
+        lineId: topCandidate.line.id,
+        segmentId: topCandidate.segment.id,
+        firstSeenAtMs: nowMs,
+        consecutiveCount: 1,
+      };
+    }
+
+    const duration = nowMs - this.pendingLeader.firstSeenAtMs;
+    if (this.pendingLeader.consecutiveCount >= neededCount && duration >= neededMs) {
+      const reason: RouteSwitchReason = this.lockState === 'REACQUIRING' ? 'manual-reacquire' : 'initial-lock';
+      this.currentMatch = topCandidate;
+      this.pendingLeader = null;
+      this.lastSwitchReason = reason;
+      this.pushEvent('route-lock', reason, {
+        lineId: topCandidate.line.id,
+        segmentId: topCandidate.segment.id,
+        score: topCandidate.totalScore,
+        margin: scoreMargin,
+      });
+      this.manualReacquireActive = false;
+      this.transitionTo('LOCKED', nowMs, reason);
+    }
+  }
+
+  private considerReacquireLock(
+    topCandidate: RouteCandidateScore,
+    scoreMargin: number,
+    health: RouteHealth | null,
+    windowScores: WindowRouteScore[],
+    sample: LocationSample
+  ): void {
+    const nowMs = sample.timestampMs;
+    const windowLeader = windowScores[0] ?? null;
+    const windowSecond = windowScores[1] ?? null;
+    const windowMargin = windowLeader && windowSecond ? windowLeader.totalScore - windowSecond.totalScore : 1;
+    const windowAgrees =
+      windowLeader !== null &&
+      windowLeader.lineId === topCandidate.line.id &&
+      (windowScores.length < 2 || windowMargin >= 0.05);
+
+    const currentLineStillBest = this.currentMatch !== null && this.isCurrentLine(topCandidate);
+    const healthRecovered = (health?.total ?? 0) >= this.config.routeSuspiciousHealthThreshold + 0.15;
+
+    if (currentLineStillBest && healthRecovered && !this.manualReacquireActive) {
+      this.adoptSameLineProgress(this.rescoreCurrent([topCandidate]) ?? topCandidate, topCandidate);
+      this.finishReacquireLock(topCandidate, nowMs);
+      return;
+    }
+
+    const accuracyOk = sample.accuracyMeters <= Math.max(50, this.config.routeMinimumAccuracyMeters * 2);
+    const trajectoryOk = this.history.length >= this.config.routeWindowMinSamples;
+    const evidenceOk = accuracyOk || trajectoryOk;
+    const healthContradicts =
+      health === null || health.total < this.config.routeSuspiciousHealthThreshold || this.manualReacquireActive;
+    const triple =
+      evidenceOk &&
+      this.challengerDominant() &&
+      healthContradicts &&
+      scoreMargin >= this.config.routeChallengerMinMargin;
+
+    const windowSupportedSwitch =
+      evidenceOk &&
+      healthContradicts &&
+      windowAgrees &&
+      !this.isCurrentLine(topCandidate) &&
+      scoreMargin >= this.config.routeChallengerMinMargin &&
+      topCandidate.totalScore >= this.config.routeInitialLockMinScore;
+
+    const candidate = triple || windowSupportedSwitch ? topCandidate : null;
+    if (!candidate) {
+      this.trackPendingLeader(topCandidate, scoreMargin, nowMs, false);
+      return;
+    }
+
+    this.trackPendingLeader(candidate, scoreMargin, nowMs, true);
+    const pending = this.pendingLeader;
+    if (!pending || pending.lineId !== candidate.line.id) return;
+
+    const duration = nowMs - pending.firstSeenAtMs;
+    const neededCount = this.manualReacquireActive
+      ? this.config.routeRelockConsecutiveCount
+      : this.config.routeChallengerConsecutiveCount;
+    const neededMs = this.manualReacquireActive
+      ? this.config.routeRelockMinimumMs
+      : this.config.routeChallengerMinimumMs;
+
+    if (pending.consecutiveCount >= neededCount && duration >= neededMs) {
+      const reason: RouteSwitchReason = this.currentMatch && this.currentMatch.line.id !== candidate.line.id
+        ? 'challenger-dominant'
+        : this.manualReacquireActive
+          ? 'manual-reacquire'
+          : 'route-health-low';
+      this.switchCurrent(candidate, nowMs, reason);
+      this.finishReacquireLock(candidate, nowMs, reason);
+    }
+  }
+
+  private finishReacquireLock(candidate: RouteCandidateScore, nowMs: number, reason?: RouteSwitchReason): void {
+    this.manualReacquireActive = false;
+    this.suspiciousSinceMs = null;
+    this.pendingLeader = null;
+    this.challenger = null;
+    if (reason) this.lastSwitchReason = reason;
+    this.pushEvent('route-lock', reason, {
+      lineId: candidate.line.id,
+      segmentId: candidate.segment.id,
+      score: candidate.totalScore,
+    });
+    this.transitionTo('LOCKED', nowMs, reason);
+  }
+
+  private switchCurrent(candidate: RouteCandidateScore, nowMs: number, reason: RouteSwitchReason): void {
+    this.pushEvent('route-switch', reason, {
+      fromLineId: this.currentMatch?.line.id ?? null,
+      fromSegmentId: this.currentMatch?.segment.id ?? null,
+      toLineId: candidate.line.id,
+      toSegmentId: candidate.segment.id,
+      score: candidate.totalScore,
+      atMs: nowMs,
+    });
+    this.currentMatch = candidate;
+    this.observations = [];
+  }
+
+  private adoptSameLineProgress(rescoredCurrent: RouteCandidateScore, topCandidate: RouteCandidateScore): void {
+    if (this.currentMatch && topCandidate.line.id === this.currentMatch.line.id) {
+      this.currentMatch = topCandidate;
+      return;
+    }
+    this.currentMatch = rescoredCurrent;
+  }
+
+  private shouldEnterSuspicious(health: RouteHealth | null, nowMs: number): boolean {
+    if (this.challengerDominant()) return true;
+    if (!health) {
+      this.healthLowSinceMs = null;
+      return false;
+    }
+    if (health.total < this.config.routeSuspiciousHealthThreshold) {
+      if (this.healthLowSinceMs === null) this.healthLowSinceMs = nowMs;
+      return nowMs - this.healthLowSinceMs >= this.config.routeSuspiciousMinimumMs;
+    }
+    this.healthLowSinceMs = null;
+    return false;
+  }
+
+  private shouldRecoverToLocked(
+    health: RouteHealth | null,
+    scoreMargin: number,
+    topCandidate: RouteCandidateScore
+  ): boolean {
+    if (!this.currentMatch || !this.isCurrentLine(topCandidate)) return false;
+    if ((health?.total ?? 0) < this.config.routeSuspiciousHealthThreshold + 0.12) return false;
+    return scoreMargin >= 0 || !this.challenger;
+  }
+
+  private enterSuspicious(nowMs: number, reason: RouteSwitchReason): void {
+    if (this.lockState === 'SUSPICIOUS') return;
+    this.suspiciousSinceMs = nowMs;
+    this.lastSwitchReason = reason;
+    this.pushEvent('route-suspicious', reason, {
+      lineId: this.currentMatch?.line.id ?? null,
+      health: this.observations.length,
+    });
+    this.transitionTo('SUSPICIOUS', nowMs, reason);
+  }
+
+  private maybeEnterReacquiring(nowMs: number): boolean {
+    if (this.suspiciousSinceMs === null) this.suspiciousSinceMs = nowMs;
+    if (nowMs - this.suspiciousSinceMs < this.config.routeReacquireMinimumMs) return false;
+    this.pushEvent('route-reacquire-start', this.challenger ? 'challenger-dominant' : 'route-health-low', {
+      lineId: this.currentMatch?.line.id ?? null,
+      challengerLineId: this.challenger?.lineId ?? null,
+    });
+    this.transitionTo('REACQUIRING', nowMs, this.challenger ? 'challenger-dominant' : 'route-health-low');
+    return true;
+  }
+
+  private exitSuspicion(): void {
+    this.suspiciousSinceMs = null;
+    this.challenger = null;
+  }
+
+  private challengerDominant(): boolean {
+    if (!this.challenger || !this.currentMatch) return false;
+    if (this.challenger.lineId === this.currentMatch.line.id) return false;
+    const duration = this.challenger.lastSeenAtMs - this.challenger.firstSeenAtMs;
+    return (
+      this.challenger.latestMargin >= this.config.routeChallengerMinMargin &&
+      this.challenger.consecutiveWins >= this.config.routeChallengerConsecutiveCount &&
+      duration >= this.config.routeChallengerMinimumMs
+    );
+  }
+
+  private updateChallenger(
+    topCandidate: RouteCandidateScore,
+    rescoredCurrent: RouteCandidateScore | null,
+    scoreMargin: number,
+    nowMs: number
+  ): void {
+    if (!this.currentMatch || this.isCurrentLine(topCandidate)) {
+      if (this.challenger && nowMs - this.challenger.lastSeenAtMs > this.config.routeChallengerMinimumMs) {
+        this.challenger = null;
+      }
+      return;
+    }
+
+    const comparedMargin = rescoredCurrent
+      ? topCandidate.totalScore - rescoredCurrent.totalScore
+      : scoreMargin;
+
+    if (this.challenger && this.challenger.lineId === topCandidate.line.id) {
+      this.challenger.consecutiveWins += 1;
+      this.challenger.lastSeenAtMs = nowMs;
+      this.challenger.latestScore = topCandidate.totalScore;
+      this.challenger.latestMargin = comparedMargin;
+      this.challenger.segmentId = topCandidate.segment.id;
+      this.challenger.routeId = topCandidate.segment.routeId ?? null;
+      return;
+    }
+
+    this.challenger = {
+      segmentId: topCandidate.segment.id,
+      routeId: topCandidate.segment.routeId ?? null,
+      lineId: topCandidate.line.id,
+      consecutiveWins: 1,
+      firstSeenAtMs: nowMs,
+      lastSeenAtMs: nowMs,
+      latestScore: topCandidate.totalScore,
+      latestMargin: comparedMargin,
+    };
+  }
+
+  private trackPendingLeader(
+    candidate: RouteCandidateScore,
+    _scoreMargin: number,
+    nowMs: number,
+    qualifies: boolean
+  ): void {
+    if (!qualifies) {
+      this.pendingLeader = null;
+      return;
+    }
+    if (this.pendingLeader && this.pendingLeader.lineId === candidate.line.id) {
+      this.pendingLeader.consecutiveCount += 1;
+      this.pendingLeader.segmentId = candidate.segment.id;
+      return;
+    }
+    this.pendingLeader = {
+      lineId: candidate.line.id,
+      segmentId: candidate.segment.id,
+      firstSeenAtMs: nowMs,
+      consecutiveCount: 1,
+    };
+  }
+
+  private rescoreCurrent(candidateScores: RouteCandidateScore[]): RouteCandidateScore | null {
+    if (!this.currentMatch) return null;
+    return (
+      candidateScores.find((candidate) => candidate.segment.id === this.currentMatch?.segment.id) ??
+      candidateScores.find((candidate) => candidate.line.id === this.currentMatch?.line.id) ??
+      null
+    );
+  }
+
+  private isCurrentLine(candidate: RouteCandidateScore): boolean {
+    return this.currentMatch !== null && candidate.line.id === this.currentMatch.line.id;
+  }
+
+  private nextDifferentLine(
+    candidates: RouteCandidateScore[],
+    lineId: string
+  ): RouteCandidateScore | null {
+    return candidates.find((candidate) => candidate.line.id !== lineId) ?? candidates[1] ?? null;
+  }
+
+  private recordObservation(sample: LocationSample, scored: RouteCandidateScore | null): void {
+    if (!scored) return;
+    this.observations.push({
+      timestampMs: sample.timestampMs,
+      lineId: scored.line.id,
+      segmentId: scored.segment.id,
+      routeId: scored.segment.routeId ?? null,
+      distanceMeters: scored.distanceMeters,
+      headingDifferenceDegrees: headingDifferenceOrNull(scored.effectiveHeadingDegrees ?? sample.headingDegrees, scored.bearingDegrees),
+      trackPositionMeters: scored.trackPositionMeters ?? null,
+      stationSequence: stationSequenceHint(scored.segment),
+    });
+    this.observations = this.observations.filter(
+      (obs) => sample.timestampMs - obs.timestampMs <= this.config.routeWindowMs
+    );
+  }
+
+  private recordLostObservation(sample: LocationSample): void {
+    if (!this.currentMatch) return;
+    this.observations.push({
+      timestampMs: sample.timestampMs,
+      lineId: this.currentMatch.line.id,
+      segmentId: this.currentMatch.segment.id,
+      routeId: this.currentMatch.segment.routeId ?? null,
+      distanceMeters: this.config.routeSearchRadiusMeters,
+      headingDifferenceDegrees: 90,
+      trackPositionMeters: null,
+      stationSequence: null,
+    });
+    this.observations = this.observations.filter(
+      (obs) => sample.timestampMs - obs.timestampMs <= this.config.routeWindowMs
+    );
+  }
+
+  private shouldScoreWindow(): boolean {
+    return this.lockState === 'REACQUIRING' || this.manualReacquireActive || this.lockState === 'SUSPICIOUS';
+  }
+
+  private groupRoutes(candidates: RouteCandidateScore[]) {
+    const byKey = new Map<string, { routeId: string; line: RailwayLine; segments: TrackSegment[] }>();
+    for (const candidate of candidates) {
+      const routeId = candidate.segment.routeId ?? `line:${candidate.line.id}`;
+      const existing = byKey.get(routeId);
+      if (existing) {
+        if (!existing.segments.some((segment) => segment.id === candidate.segment.id)) {
+          existing.segments.push(candidate.segment);
+        }
+        continue;
+      }
+      byKey.set(routeId, {
+        routeId,
+        line: candidate.line,
+        segments: [candidate.segment],
+      });
+    }
+    return [...byKey.values()];
+  }
+
+  private transitionTo(state: RouteLockState, _nowMs: number, reason?: RouteSwitchReason): void {
+    if (this.lockState === state) {
+      if (reason) this.lastSwitchReason = reason;
+      return;
+    }
+    this.lockState = state;
+    if (reason) this.lastSwitchReason = reason;
+  }
+
+  private pushEvent(
+    type: RouteLockEvent['type'],
+    reason: RouteSwitchReason | undefined,
+    data: RouteLockEvent['data']
+  ): void {
+    this.pendingEvents.push({
+      type,
+      reason,
+      data: {
+        ...data,
+        lockState: this.lockState,
+      },
+    });
+  }
+
+  private consumeEvents(fromIndex: number): RouteLockEvent[] {
+    const events = this.pendingEvents.slice(fromIndex);
+    this.pendingEvents = [];
+    return events;
+  }
+
+  private buildMatch(
+    sample: LocationSample,
+    candidates: RouteCandidateScore[],
+    health: RouteHealth | null,
+    windowScores: WindowRouteScore[] | null,
+    eventsAtStart: number,
+    extras: Partial<RouteMatch> = {}
+  ): RouteMatch | null {
+    const selected = this.currentMatch ?? candidates[0] ?? null;
+    if (!selected) {
+      this.consumeEvents(eventsAtStart);
+      return null;
+    }
+
+    const second = this.nextDifferentLine(candidates, selected.line.id);
+    let confidence = calculateConfidence(selected, second);
+    if (this.lockState === 'UNRESOLVED' || (this.lockState === 'REACQUIRING' && this.manualReacquireActive)) {
+      confidence = Math.min(confidence, 0.45);
+    } else if (this.lockState === 'MANUAL_LOCK') {
+      confidence = Math.max(confidence, 0.9);
+    }
+
+    const showSelectedRoute =
+      this.currentMatch !== null &&
+      (this.lockState === 'LOCKED' ||
+        this.lockState === 'SUSPICIOUS' ||
+        this.lockState === 'MANUAL_LOCK' ||
+        (this.lockState === 'REACQUIRING' && !this.manualReacquireActive));
+
+    const manualLockAway =
+      this.lockState === 'MANUAL_LOCK' &&
+      selected.distanceMeters > this.config.routeManualLockMaxDistanceMeters;
+
+    const scoreMargin =
+      extras.scoreMargin ??
+      (candidates.length > 0 ? candidates[0].totalScore - (candidates[1]?.totalScore ?? 0) : 0);
+
+    return {
+      selectedLine: selected.line,
+      selectedSegment: selected.segment,
+      confidence,
+      candidates: candidates.slice(0, 5),
+      timestampMs: sample.timestampMs,
+      lockState: this.lockState,
+      routeHealth: health,
+      challenger: this.challenger,
+      scoreMargin,
+      currentScore: extras.currentScore ?? this.currentMatch?.totalScore ?? null,
+      rescoredCurrentScore: extras.rescoredCurrentScore ?? null,
+      trajectoryHeadingDegrees: extras.trajectoryHeadingDegrees ?? null,
+      switchReason: this.lastSwitchReason,
+      manualLockAway,
+      showSelectedRoute,
+      windowScores: windowScores ?? [],
+      lockEvents: this.consumeEvents(eventsAtStart),
+    };
+  }
+}
+
+function stationSequenceHint(segment: TrackSegment): number | null {
+  const from = Number.parseInt(segment.fromStationId.replace(/\D+/g, ''), 10);
+  return Number.isFinite(from) ? from : null;
 }

--- a/src/domain/railway/map-matcher.ts
+++ b/src/domain/railway/map-matcher.ts
@@ -9,10 +9,12 @@ import {
   RouteLockState,
   RouteMatch,
   RouteSwitchReason,
+  Station,
   TrackSegment,
   WindowRouteScore,
+  routeIdentityKey,
 } from '../models/railway';
-import { computeTrajectory, resolveEffectiveHeading, trimLocationHistory } from '../geo/trajectory';
+import { computeTrajectory, osSpeedStopped, resolveEffectiveHeading, trimLocationHistory } from '../geo/trajectory';
 import { scoreCandidate } from './candidate-scorer';
 import { calculateConfidence } from './confidence';
 import { evaluateRouteHealth, headingDifferenceOrNull, RouteObservation } from './route-health';
@@ -21,13 +23,21 @@ import { scoreRoutesOverWindow } from './window-scorer';
 export interface RailwayDatabaseReader {
   findSegmentsNear(latitude: number, longitude: number, radiusMeters: number): Promise<TrackSegment[]>;
   getLine(lineId: string): Promise<RailwayLine | undefined>;
+  getStation?(stationId: string): Promise<Station | undefined>;
 }
 
 type PendingLeader = {
+  routeKey: string;
   lineId: string;
   segmentId: string;
   firstSeenAtMs: number;
   consecutiveCount: number;
+};
+
+type RouteConfirmation = {
+  routeKey: string;
+  firstSeenAtMs: number;
+  count: number;
 };
 
 export class MapMatcher {
@@ -44,6 +54,7 @@ export class MapMatcher {
   private pendingEvents: RouteLockEvent[] = [];
   private lastCandidates: RouteCandidateScore[] = [];
   private healthLowSinceMs: number | null = null;
+  private confirmation: RouteConfirmation | null = null;
 
   constructor(
     private db: RailwayDatabaseReader,
@@ -54,11 +65,16 @@ export class MapMatcher {
     return this.lockState;
   }
 
+  public takeLockEvents(): RouteLockEvent[] {
+    return this.consumeEvents();
+  }
+
   public startManualReacquire(nowMs: number): void {
     this.manualReacquireActive = true;
     this.manualLockUntilMs = null;
     this.pendingLeader = null;
     this.challenger = null;
+    this.confirmation = null;
     this.suspiciousSinceMs = null;
     this.lastSwitchReason = 'manual-reacquire';
     this.pushEvent('manual-reacquire', 'manual-reacquire', {
@@ -80,6 +96,7 @@ export class MapMatcher {
     this.currentMatch = fromHistory;
     this.pendingLeader = null;
     this.challenger = null;
+    this.confirmation = null;
     this.suspiciousSinceMs = null;
     this.lastSwitchReason = 'manual-selection';
     this.pushEvent('manual-route-lock', 'manual-selection', {
@@ -101,6 +118,7 @@ export class MapMatcher {
     this.currentMatch = null;
     this.pendingLeader = null;
     this.challenger = null;
+    this.confirmation = null;
     this.suspiciousSinceMs = null;
     this.healthLowSinceMs = null;
     this.observations = [];
@@ -117,10 +135,8 @@ export class MapMatcher {
   }
 
   public async match(sample: LocationSample): Promise<RouteMatch | null> {
-    const eventsAtStart = this.pendingEvents.length;
-
     if (sample.accuracyMeters > this.config.maxGpsAccuracyMeters) {
-      return this.buildMatch(sample, [], null, null, eventsAtStart);
+      return this.buildMatch(sample, [], null, null);
     }
 
     this.history.push(sample);
@@ -141,12 +157,12 @@ export class MapMatcher {
     );
 
     if (segments.length === 0) {
-      return this.handleNoCandidates(sample, eventsAtStart);
+      return this.handleNoCandidates(sample);
     }
 
-    const stopped = (sample.speedMps ?? 0) * 3.6 <= this.config.stopSpeedThresholdKmh;
-    const trajectory = computeTrajectory(this.history, sample.timestampMs, this.config, stopped);
-    const effectiveHeading = resolveEffectiveHeading(trajectory, sample);
+    const trajectory = computeTrajectory(this.history, sample.timestampMs, this.config);
+    const osStopped = osSpeedStopped(sample, this.config);
+    const effectiveHeading = resolveEffectiveHeading(trajectory, sample, osStopped);
 
     const candidateScores: RouteCandidateScore[] = [];
     for (const segment of segments) {
@@ -167,18 +183,28 @@ export class MapMatcher {
     }
 
     if (candidateScores.length === 0) {
-      return this.handleNoCandidates(sample, eventsAtStart);
+      return this.handleNoCandidates(sample);
     }
 
     candidateScores.sort((a, b) => b.totalScore - a.totalScore);
     this.lastCandidates = candidateScores.slice(0, 8);
 
     const topCandidate = candidateScores[0];
-    const secondCandidate = this.nextDifferentLine(candidateScores, topCandidate.line.id);
+    const secondCandidate = this.nextDifferentRoute(candidateScores, routeIdentityKey(topCandidate.segment));
     const scoreMargin = topCandidate.totalScore - (secondCandidate?.totalScore ?? 0);
     const rescoredCurrent = this.rescoreCurrent(candidateScores);
+    if (this.lockState === 'MANUAL_LOCK' && !rescoredCurrent && this.currentMatch) {
+      const projected = await this.projectLockedSegment(sample);
+      if (projected) {
+        this.currentMatch = projected;
+      }
+    }
 
-    this.recordObservation(sample, rescoredCurrent ?? (this.isCurrentLine(topCandidate) ? topCandidate : null));
+    await this.recordObservation(
+      sample,
+      rescoredCurrent,
+      trajectory.reliable && osStopped !== true ? trajectory.headingDegrees : null
+    );
     this.updateChallenger(topCandidate, rescoredCurrent, scoreMargin, sample.timestampMs);
 
     const health = this.lockState === 'UNRESOLVED'
@@ -186,7 +212,7 @@ export class MapMatcher {
       : evaluateRouteHealth(
           this.observations,
           rescoredCurrent,
-          this.challenger && !this.isCurrentLine(topCandidate) ? this.challenger.latestMargin : null,
+          this.challenger && !this.isCurrentRoute(topCandidate) ? this.challenger.latestMargin : null,
           this.config
         );
 
@@ -202,10 +228,9 @@ export class MapMatcher {
       rescoredCurrent,
       health,
       windowScores,
-      stopped,
     });
 
-    return this.buildMatch(sample, candidateScores, health, windowScores, eventsAtStart, {
+    return this.buildMatch(sample, candidateScores, health, windowScores, {
       scoreMargin,
       currentScore: this.currentMatch?.totalScore ?? null,
       rescoredCurrentScore: rescoredCurrent?.totalScore ?? null,
@@ -227,10 +252,17 @@ export class MapMatcher {
     this.pendingEvents = [];
     this.lastCandidates = [];
     this.healthLowSinceMs = null;
+    this.confirmation = null;
   }
 
-  private async handleNoCandidates(sample: LocationSample, eventsAtStart: number): Promise<RouteMatch | null> {
-    if (this.currentMatch && this.lockState !== 'UNRESOLVED' && this.lockState !== 'MANUAL_LOCK') {
+  private async handleNoCandidates(sample: LocationSample): Promise<RouteMatch | null> {
+    if (this.lockState === 'MANUAL_LOCK' && this.currentMatch) {
+      const projected = await this.projectLockedSegment(sample);
+      if (projected) this.currentMatch = projected;
+      return this.buildMatch(sample, projected ? [projected] : [], null, []);
+    }
+
+    if (this.currentMatch && this.lockState !== 'UNRESOLVED') {
       this.recordLostObservation(sample);
       if (this.lockState === 'LOCKED') {
         this.enterSuspicious(sample.timestampMs, 'current-route-lost');
@@ -245,7 +277,7 @@ export class MapMatcher {
         this.transitionTo('UNRESOLVED', sample.timestampMs, 'current-route-lost');
       }
     }
-    return this.buildMatch(sample, [], null, [], eventsAtStart);
+    return this.buildMatch(sample, [], null, []);
   }
 
   private advanceState(input: {
@@ -256,7 +288,6 @@ export class MapMatcher {
     rescoredCurrent: RouteCandidateScore | null;
     health: RouteHealth | null;
     windowScores: WindowRouteScore[];
-    stopped: boolean;
   }): void {
     const { sample, topCandidate, scoreMargin, rescoredCurrent, health, windowScores } = input;
 
@@ -271,7 +302,7 @@ export class MapMatcher {
     }
 
     if (rescoredCurrent) {
-      this.adoptSameLineProgress(rescoredCurrent, topCandidate);
+      this.adoptSameRouteProgress(rescoredCurrent, topCandidate);
     } else if (this.currentMatch) {
       this.recordLostObservation(sample);
     }
@@ -294,17 +325,13 @@ export class MapMatcher {
         this.transitionTo('LOCKED', sample.timestampMs);
         return;
       }
-      if (!this.isCurrentLine(topCandidate) && scoreMargin >= this.config.routeChallengerMinMargin) {
-        this.trackPendingLeader(topCandidate, scoreMargin, sample.timestampMs, true);
+      if (!this.isCurrentRoute(topCandidate) && scoreMargin >= this.config.routeChallengerMinMargin) {
+        this.trackPendingLeader(topCandidate, sample.timestampMs, true);
       }
       if (!this.maybeEnterReacquiring(sample.timestampMs)) return;
     }
 
     if (this.lockState === 'REACQUIRING') {
-      if (!this.currentMatch) {
-        this.considerInitialLock(topCandidate, scoreMargin, sample.timestampMs);
-        return;
-      }
       this.considerReacquireLock(topCandidate, scoreMargin, health, windowScores, sample);
     }
   }
@@ -325,11 +352,12 @@ export class MapMatcher {
       return;
     }
 
-    if (this.pendingLeader && this.pendingLeader.lineId === topCandidate.line.id) {
+    if (this.pendingLeader && this.pendingLeader.routeKey === routeIdentityKey(topCandidate.segment)) {
       this.pendingLeader.consecutiveCount += 1;
       this.pendingLeader.segmentId = topCandidate.segment.id;
     } else {
       this.pendingLeader = {
+        routeKey: routeIdentityKey(topCandidate.segment),
         lineId: topCandidate.line.id,
         segmentId: topCandidate.segment.id,
         firstSeenAtMs: nowMs,
@@ -365,65 +393,113 @@ export class MapMatcher {
     const windowLeader = windowScores[0] ?? null;
     const windowSecond = windowScores[1] ?? null;
     const windowMargin = windowLeader && windowSecond ? windowLeader.totalScore - windowSecond.totalScore : 1;
+    const windowLeaderCandidate = this.candidateForWindow(windowLeader, topCandidate);
     const windowAgrees =
-      windowLeader !== null &&
-      windowLeader.lineId === topCandidate.line.id &&
+      windowLeaderCandidate !== null &&
       (windowScores.length < 2 || windowMargin >= 0.05);
 
-    const currentLineStillBest = this.currentMatch !== null && this.isCurrentLine(topCandidate);
+    const currentRouteStillBest = this.currentMatch !== null && this.isCurrentRoute(topCandidate);
     const healthRecovered = (health?.total ?? 0) >= this.config.routeSuspiciousHealthThreshold + 0.15;
 
-    if (currentLineStillBest && healthRecovered && !this.manualReacquireActive) {
-      this.adoptSameLineProgress(this.rescoreCurrent([topCandidate]) ?? topCandidate, topCandidate);
+    if (currentRouteStillBest && healthRecovered && !this.manualReacquireActive) {
+      this.adoptSameRouteProgress(this.rescoreCurrent([topCandidate]) ?? topCandidate, topCandidate);
       this.finishReacquireLock(topCandidate, nowMs);
       return;
     }
 
+    if (this.currentMatch && this.isCurrentRoute(topCandidate) && this.confirmation) {
+      this.continueConfirmation(topCandidate, nowMs);
+      return;
+    }
+
+    const preferred = windowAgrees && windowLeaderCandidate ? windowLeaderCandidate : topCandidate;
     const accuracyOk = sample.accuracyMeters <= Math.max(50, this.config.routeMinimumAccuracyMeters * 2);
     const trajectoryOk = this.history.length >= this.config.routeWindowMinSamples;
     const evidenceOk = accuracyOk || trajectoryOk;
     const healthContradicts =
-      health === null || health.total < this.config.routeSuspiciousHealthThreshold || this.manualReacquireActive;
+      this.currentMatch === null ||
+      health === null ||
+      health.total < this.config.routeSuspiciousHealthThreshold ||
+      this.manualReacquireActive;
     const triple =
+      this.currentMatch !== null &&
       evidenceOk &&
       this.challengerDominant() &&
       healthContradicts &&
-      scoreMargin >= this.config.routeChallengerMinMargin;
+      scoreMargin >= this.config.routeChallengerMinMargin &&
+      !this.isCurrentRoute(preferred);
 
     const windowSupportedSwitch =
       evidenceOk &&
       healthContradicts &&
       windowAgrees &&
-      !this.isCurrentLine(topCandidate) &&
-      scoreMargin >= this.config.routeChallengerMinMargin &&
-      topCandidate.totalScore >= this.config.routeInitialLockMinScore;
+      preferred.totalScore >= this.config.routeInitialLockMinScore &&
+      (this.currentMatch === null || !this.isCurrentRoute(preferred));
 
-    const candidate = triple || windowSupportedSwitch ? topCandidate : null;
+    const candidate = triple || windowSupportedSwitch ? preferred : null;
     if (!candidate) {
-      this.trackPendingLeader(topCandidate, scoreMargin, nowMs, false);
+      this.trackPendingLeader(preferred, nowMs, false);
+      this.confirmation = null;
       return;
     }
 
-    this.trackPendingLeader(candidate, scoreMargin, nowMs, true);
+    this.trackPendingLeader(candidate, nowMs, true);
     const pending = this.pendingLeader;
-    if (!pending || pending.lineId !== candidate.line.id) return;
+    if (!pending || pending.routeKey !== routeIdentityKey(candidate.segment)) return;
 
     const duration = nowMs - pending.firstSeenAtMs;
-    const neededCount = this.manualReacquireActive
+    const neededCount = this.manualReacquireActive || this.currentMatch === null
       ? this.config.routeRelockConsecutiveCount
       : this.config.routeChallengerConsecutiveCount;
-    const neededMs = this.manualReacquireActive
+    const neededMs = this.manualReacquireActive || this.currentMatch === null
       ? this.config.routeRelockMinimumMs
       : this.config.routeChallengerMinimumMs;
 
     if (pending.consecutiveCount >= neededCount && duration >= neededMs) {
-      const reason: RouteSwitchReason = this.currentMatch && this.currentMatch.line.id !== candidate.line.id
+      const reason: RouteSwitchReason = this.currentMatch && routeIdentityKey(this.currentMatch.segment) !== routeIdentityKey(candidate.segment)
         ? 'challenger-dominant'
         : this.manualReacquireActive
           ? 'manual-reacquire'
           : 'route-health-low';
       this.switchCurrent(candidate, nowMs, reason);
-      this.finishReacquireLock(candidate, nowMs, reason);
+      this.beginConfirmation(candidate, nowMs);
+    }
+  }
+
+  private candidateForWindow(
+    windowLeader: WindowRouteScore | null,
+    fallback: RouteCandidateScore
+  ): RouteCandidateScore | null {
+    if (!windowLeader) return null;
+    return (
+      this.lastCandidates.find((candidate) => routeIdentityKey(candidate.segment) === windowLeader.routeId) ??
+      this.lastCandidates.find((candidate) => candidate.line.id === windowLeader.lineId) ??
+      (routeIdentityKey(fallback.segment) === windowLeader.routeId || fallback.line.id === windowLeader.lineId
+        ? fallback
+        : null)
+    );
+  }
+
+  private beginConfirmation(candidate: RouteCandidateScore, nowMs: number): void {
+    this.confirmation = {
+      routeKey: routeIdentityKey(candidate.segment),
+      firstSeenAtMs: nowMs,
+      count: 1,
+    };
+  }
+
+  private continueConfirmation(candidate: RouteCandidateScore, nowMs: number): void {
+    if (!this.confirmation || this.confirmation.routeKey !== routeIdentityKey(candidate.segment)) {
+      this.beginConfirmation(candidate, nowMs);
+      return;
+    }
+    this.confirmation.count += 1;
+    const duration = nowMs - this.confirmation.firstSeenAtMs;
+    if (
+      this.confirmation.count >= this.config.routeRelockConsecutiveCount &&
+      duration >= this.config.routeRelockMinimumMs
+    ) {
+      this.finishReacquireLock(candidate, nowMs, this.lastSwitchReason ?? 'challenger-dominant');
     }
   }
 
@@ -432,6 +508,7 @@ export class MapMatcher {
     this.suspiciousSinceMs = null;
     this.pendingLeader = null;
     this.challenger = null;
+    this.confirmation = null;
     if (reason) this.lastSwitchReason = reason;
     this.pushEvent('route-lock', reason, {
       lineId: candidate.line.id,
@@ -454,8 +531,8 @@ export class MapMatcher {
     this.observations = [];
   }
 
-  private adoptSameLineProgress(rescoredCurrent: RouteCandidateScore, topCandidate: RouteCandidateScore): void {
-    if (this.currentMatch && topCandidate.line.id === this.currentMatch.line.id) {
+  private adoptSameRouteProgress(rescoredCurrent: RouteCandidateScore, topCandidate: RouteCandidateScore): void {
+    if (this.currentMatch && this.isCurrentRoute(topCandidate)) {
       this.currentMatch = topCandidate;
       return;
     }
@@ -481,7 +558,7 @@ export class MapMatcher {
     scoreMargin: number,
     topCandidate: RouteCandidateScore
   ): boolean {
-    if (!this.currentMatch || !this.isCurrentLine(topCandidate)) return false;
+    if (!this.currentMatch || !this.isCurrentRoute(topCandidate)) return false;
     if ((health?.total ?? 0) < this.config.routeSuspiciousHealthThreshold + 0.12) return false;
     return scoreMargin >= 0 || !this.challenger;
   }
@@ -515,7 +592,7 @@ export class MapMatcher {
 
   private challengerDominant(): boolean {
     if (!this.challenger || !this.currentMatch) return false;
-    if (this.challenger.lineId === this.currentMatch.line.id) return false;
+    if (this.challenger.routeId === routeIdentityKey(this.currentMatch.segment)) return false;
     const duration = this.challenger.lastSeenAtMs - this.challenger.firstSeenAtMs;
     return (
       this.challenger.latestMargin >= this.config.routeChallengerMinMargin &&
@@ -530,30 +607,28 @@ export class MapMatcher {
     scoreMargin: number,
     nowMs: number
   ): void {
-    if (!this.currentMatch || this.isCurrentLine(topCandidate)) {
-      if (this.challenger && nowMs - this.challenger.lastSeenAtMs > this.config.routeChallengerMinimumMs) {
-        this.challenger = null;
-      }
+    if (!this.currentMatch || this.isCurrentRoute(topCandidate)) {
+      this.challenger = null;
       return;
     }
 
     const comparedMargin = rescoredCurrent
       ? topCandidate.totalScore - rescoredCurrent.totalScore
       : scoreMargin;
+    const challengerKey = routeIdentityKey(topCandidate.segment);
 
-    if (this.challenger && this.challenger.lineId === topCandidate.line.id) {
+    if (this.challenger && this.challenger.routeId === challengerKey) {
       this.challenger.consecutiveWins += 1;
       this.challenger.lastSeenAtMs = nowMs;
       this.challenger.latestScore = topCandidate.totalScore;
       this.challenger.latestMargin = comparedMargin;
       this.challenger.segmentId = topCandidate.segment.id;
-      this.challenger.routeId = topCandidate.segment.routeId ?? null;
       return;
     }
 
     this.challenger = {
       segmentId: topCandidate.segment.id,
-      routeId: topCandidate.segment.routeId ?? null,
+      routeId: challengerKey,
       lineId: topCandidate.line.id,
       consecutiveWins: 1,
       firstSeenAtMs: nowMs,
@@ -565,7 +640,6 @@ export class MapMatcher {
 
   private trackPendingLeader(
     candidate: RouteCandidateScore,
-    _scoreMargin: number,
     nowMs: number,
     qualifies: boolean
   ): void {
@@ -573,12 +647,14 @@ export class MapMatcher {
       this.pendingLeader = null;
       return;
     }
-    if (this.pendingLeader && this.pendingLeader.lineId === candidate.line.id) {
+    const key = routeIdentityKey(candidate.segment);
+    if (this.pendingLeader && this.pendingLeader.routeKey === key) {
       this.pendingLeader.consecutiveCount += 1;
       this.pendingLeader.segmentId = candidate.segment.id;
       return;
     }
     this.pendingLeader = {
+      routeKey: key,
       lineId: candidate.line.id,
       segmentId: candidate.segment.id,
       firstSeenAtMs: nowMs,
@@ -588,35 +664,44 @@ export class MapMatcher {
 
   private rescoreCurrent(candidateScores: RouteCandidateScore[]): RouteCandidateScore | null {
     if (!this.currentMatch) return null;
+    const currentKey = routeIdentityKey(this.currentMatch.segment);
     return (
       candidateScores.find((candidate) => candidate.segment.id === this.currentMatch?.segment.id) ??
-      candidateScores.find((candidate) => candidate.line.id === this.currentMatch?.line.id) ??
+      candidateScores.find((candidate) => routeIdentityKey(candidate.segment) === currentKey) ??
       null
     );
   }
 
-  private isCurrentLine(candidate: RouteCandidateScore): boolean {
-    return this.currentMatch !== null && candidate.line.id === this.currentMatch.line.id;
+  private isCurrentRoute(candidate: RouteCandidateScore): boolean {
+    return this.currentMatch !== null && routeIdentityKey(candidate.segment) === routeIdentityKey(this.currentMatch.segment);
   }
 
-  private nextDifferentLine(
+  private nextDifferentRoute(
     candidates: RouteCandidateScore[],
-    lineId: string
+    routeKey: string
   ): RouteCandidateScore | null {
-    return candidates.find((candidate) => candidate.line.id !== lineId) ?? candidates[1] ?? null;
+    return candidates.find((candidate) => routeIdentityKey(candidate.segment) !== routeKey) ?? candidates[1] ?? null;
   }
 
-  private recordObservation(sample: LocationSample, scored: RouteCandidateScore | null): void {
+  private async recordObservation(
+    sample: LocationSample,
+    scored: RouteCandidateScore | null,
+    trajectoryHeadingDegrees: number | null
+  ): Promise<void> {
     if (!scored) return;
+    const station = this.db.getStation ? await this.db.getStation(scored.segment.fromStationId) : undefined;
     this.observations.push({
       timestampMs: sample.timestampMs,
       lineId: scored.line.id,
       segmentId: scored.segment.id,
       routeId: scored.segment.routeId ?? null,
       distanceMeters: scored.distanceMeters,
-      headingDifferenceDegrees: headingDifferenceOrNull(scored.effectiveHeadingDegrees ?? sample.headingDegrees, scored.bearingDegrees),
+      headingDifferenceDegrees: headingDifferenceOrNull(sample.headingDegrees, scored.bearingDegrees),
+      trajectoryHeadingDifferenceDegrees: headingDifferenceOrNull(trajectoryHeadingDegrees, scored.bearingDegrees),
       trackPositionMeters: scored.trackPositionMeters ?? null,
-      stationSequence: stationSequenceHint(scored.segment),
+      stationSequence: station?.sequence ?? null,
+      previousSegmentIds: scored.segment.previousSegmentIds ?? [],
+      nextSegmentIds: scored.segment.nextSegmentIds ?? [],
     });
     this.observations = this.observations.filter(
       (obs) => sample.timestampMs - obs.timestampMs <= this.config.routeWindowMs
@@ -632,8 +717,11 @@ export class MapMatcher {
       routeId: this.currentMatch.segment.routeId ?? null,
       distanceMeters: this.config.routeSearchRadiusMeters,
       headingDifferenceDegrees: 90,
+      trajectoryHeadingDifferenceDegrees: 90,
       trackPositionMeters: null,
       stationSequence: null,
+      previousSegmentIds: this.currentMatch.segment.previousSegmentIds ?? [],
+      nextSegmentIds: this.currentMatch.segment.nextSegmentIds ?? [],
     });
     this.observations = this.observations.filter(
       (obs) => sample.timestampMs - obs.timestampMs <= this.config.routeWindowMs
@@ -688,10 +776,24 @@ export class MapMatcher {
     });
   }
 
-  private consumeEvents(fromIndex: number): RouteLockEvent[] {
-    const events = this.pendingEvents.slice(fromIndex);
+  private consumeEvents(): RouteLockEvent[] {
+    const events = this.pendingEvents;
     this.pendingEvents = [];
     return events;
+  }
+
+  private async projectLockedSegment(sample: LocationSample): Promise<RouteCandidateScore | null> {
+    if (!this.currentMatch) return null;
+    return scoreCandidate({
+      sample,
+      segment: this.currentMatch.segment,
+      line: this.currentMatch.line,
+      previousSegment: this.currentMatch.segment,
+      nearbySegments: [this.currentMatch.segment],
+      lockState: this.lockState,
+      effectiveHeadingDegrees: sample.headingDegrees,
+      config: this.config,
+    });
   }
 
   private buildMatch(
@@ -699,16 +801,14 @@ export class MapMatcher {
     candidates: RouteCandidateScore[],
     health: RouteHealth | null,
     windowScores: WindowRouteScore[] | null,
-    eventsAtStart: number,
     extras: Partial<RouteMatch> = {}
   ): RouteMatch | null {
     const selected = this.currentMatch ?? candidates[0] ?? null;
     if (!selected) {
-      this.consumeEvents(eventsAtStart);
       return null;
     }
 
-    const second = this.nextDifferentLine(candidates, selected.line.id);
+    const second = this.nextDifferentRoute(candidates, routeIdentityKey(selected.segment));
     let confidence = calculateConfidence(selected, second);
     if (this.lockState === 'UNRESOLVED' || (this.lockState === 'REACQUIRING' && this.manualReacquireActive)) {
       confidence = Math.min(confidence, 0.45);
@@ -748,12 +848,7 @@ export class MapMatcher {
       manualLockAway,
       showSelectedRoute,
       windowScores: windowScores ?? [],
-      lockEvents: this.consumeEvents(eventsAtStart),
+      lockEvents: this.consumeEvents(),
     };
   }
-}
-
-function stationSequenceHint(segment: TrackSegment): number | null {
-  const from = Number.parseInt(segment.fromStationId.replace(/\D+/g, ''), 10);
-  return Number.isFinite(from) ? from : null;
 }

--- a/src/domain/railway/route-health.ts
+++ b/src/domain/railway/route-health.ts
@@ -9,8 +9,11 @@ export type RouteObservation = {
   routeId: string | null;
   distanceMeters: number;
   headingDifferenceDegrees: number | null;
+  trajectoryHeadingDifferenceDegrees: number | null;
   trackPositionMeters: number | null;
   stationSequence: number | null;
+  previousSegmentIds: string[];
+  nextSegmentIds: string[];
 };
 
 export function emptyRouteHealth(): RouteHealth {
@@ -46,19 +49,25 @@ export function evaluateRouteHealth(
     .filter((value): value is number => value !== null);
   const meanHeadingDiff = headingDiffs.length > 0 ? average(headingDiffs) : 45;
   const headingConsistency = clamp01(1 - meanHeadingDiff / 90);
-  const trajectoryConsistency = headingConsistency;
+
+  const trajectoryDiffs = observations
+    .map((obs) => obs.trajectoryHeadingDifferenceDegrees)
+    .filter((value): value is number => value !== null);
+  const trajectoryConsistency =
+    trajectoryDiffs.length === 0 ? 0.5 : clamp01(1 - average(trajectoryDiffs) / 90);
 
   const stationSequences = observations
     .map((obs) => obs.stationSequence)
     .filter((value): value is number => value !== null);
   const stationSequenceConsistency =
-    stationSequences.length < 2 ? 0.7 : monotonicityRatio(stationSequences, 0);
+    stationSequences.length < 2 ? 0.5 : monotonicityRatio(stationSequences, 0);
 
-  const sameOrAdjacent = observations.filter((obs, index) => {
-    if (index === 0) return true;
-    return obs.lineId === observations[index - 1].lineId;
+  const topologyPairs = observations.length < 2 ? 0 : observations.length - 1;
+  const connectedPairs = observations.filter((obs, index) => {
+    if (index === 0) return false;
+    return observationsAreTopologicallyConnected(observations[index - 1], obs);
   }).length;
-  const topologyConsistency = observations.length === 0 ? 0.5 : sameOrAdjacent / observations.length;
+  const topologyConsistency = topologyPairs === 0 ? 0.5 : connectedPairs / topologyPairs;
 
   const positions = observations
     .map((obs) => obs.trackPositionMeters)
@@ -96,6 +105,18 @@ export function evaluateRouteHealth(
     challengerDominance: round2(challengerDominance),
     total: round2(total),
   };
+}
+
+export function observationsAreTopologicallyConnected(
+  previous: RouteObservation,
+  current: RouteObservation
+): boolean {
+  if (previous.segmentId === current.segmentId) return true;
+  if (previous.nextSegmentIds.includes(current.segmentId)) return true;
+  if (previous.previousSegmentIds.includes(current.segmentId)) return true;
+  if (current.nextSegmentIds.includes(previous.segmentId)) return true;
+  if (current.previousSegmentIds.includes(previous.segmentId)) return true;
+  return false;
 }
 
 export function headingDifferenceOrNull(

--- a/src/domain/railway/route-health.ts
+++ b/src/domain/railway/route-health.ts
@@ -1,0 +1,136 @@
+import { TrackingConfig } from '../../config/tracking-config';
+import { calculateHeadingDifference } from '../geo/heading';
+import { RouteCandidateScore, RouteHealth } from '../models/railway';
+
+export type RouteObservation = {
+  timestampMs: number;
+  lineId: string;
+  segmentId: string;
+  routeId: string | null;
+  distanceMeters: number;
+  headingDifferenceDegrees: number | null;
+  trackPositionMeters: number | null;
+  stationSequence: number | null;
+};
+
+export function emptyRouteHealth(): RouteHealth {
+  return {
+    distanceConsistency: 0,
+    headingConsistency: 0,
+    trajectoryConsistency: 0,
+    stationSequenceConsistency: 0,
+    topologyConsistency: 0,
+    progressConsistency: 0,
+    challengerDominance: 0,
+    total: 0,
+  };
+}
+
+export function evaluateRouteHealth(
+  observations: RouteObservation[],
+  current: RouteCandidateScore | null,
+  challengerMargin: number | null,
+  config: TrackingConfig
+): RouteHealth {
+  if (observations.length === 0 && !current) {
+    return emptyRouteHealth();
+  }
+
+  const distances = observations.map((obs) => obs.distanceMeters);
+  if (current) distances.push(current.distanceMeters);
+  const meanDistance = average(distances);
+  const distanceConsistency = clamp01(1 - meanDistance / 120);
+
+  const headingDiffs = observations
+    .map((obs) => obs.headingDifferenceDegrees)
+    .filter((value): value is number => value !== null);
+  const meanHeadingDiff = headingDiffs.length > 0 ? average(headingDiffs) : 45;
+  const headingConsistency = clamp01(1 - meanHeadingDiff / 90);
+  const trajectoryConsistency = headingConsistency;
+
+  const stationSequences = observations
+    .map((obs) => obs.stationSequence)
+    .filter((value): value is number => value !== null);
+  const stationSequenceConsistency =
+    stationSequences.length < 2 ? 0.7 : monotonicityRatio(stationSequences, 0);
+
+  const sameOrAdjacent = observations.filter((obs, index) => {
+    if (index === 0) return true;
+    return obs.lineId === observations[index - 1].lineId;
+  }).length;
+  const topologyConsistency = observations.length === 0 ? 0.5 : sameOrAdjacent / observations.length;
+
+  const positions = observations
+    .map((obs) => obs.trackPositionMeters)
+    .filter((value): value is number => value !== null);
+  let progressConsistency =
+    positions.length < 3 ? 0.7 : monotonicityRatio(positions, config.routeProgressJitterMeters);
+  if (meanDistance > 80) {
+    progressConsistency *= 0.4;
+  }
+
+  const dominance = challengerMargin !== null && challengerMargin > 0
+    ? clamp01(challengerMargin / Math.max(config.routeChallengerMinMargin * 2, 1))
+    : 0;
+  const challengerDominance = 1 - dominance;
+
+  let total = clamp01(
+    distanceConsistency * 0.34 +
+      headingConsistency * 0.1 +
+      trajectoryConsistency * 0.1 +
+      stationSequenceConsistency * 0.1 +
+      topologyConsistency * 0.08 +
+      progressConsistency * 0.2 +
+      challengerDominance * 0.08
+  );
+  if (meanDistance > 150) total = Math.min(total, 0.32);
+  else if (meanDistance > 80) total = Math.min(total, 0.42);
+
+  return {
+    distanceConsistency: round2(distanceConsistency),
+    headingConsistency: round2(headingConsistency),
+    trajectoryConsistency: round2(trajectoryConsistency),
+    stationSequenceConsistency: round2(stationSequenceConsistency),
+    topologyConsistency: round2(topologyConsistency),
+    progressConsistency: round2(progressConsistency),
+    challengerDominance: round2(challengerDominance),
+    total: round2(total),
+  };
+}
+
+export function headingDifferenceOrNull(
+  headingDegrees: number | null | undefined,
+  bearingDegrees: number
+): number | null {
+  if (headingDegrees === null || headingDegrees === undefined) return null;
+  const forward = calculateHeadingDifference(headingDegrees, bearingDegrees);
+  const backward = calculateHeadingDifference(headingDegrees, (bearingDegrees + 180) % 360);
+  return Math.min(forward, backward);
+}
+
+function monotonicityRatio(values: number[], jitter: number): number {
+  let forward = 0;
+  let backward = 0;
+  for (let i = 1; i < values.length; i++) {
+    const delta = values[i] - values[i - 1];
+    if (Math.abs(delta) <= jitter) continue;
+    if (delta > 0) forward++;
+    else backward++;
+  }
+  const decided = forward + backward;
+  if (decided === 0) return 0.75;
+  return Math.max(forward, backward) / decided;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/domain/railway/window-scorer.ts
+++ b/src/domain/railway/window-scorer.ts
@@ -3,7 +3,8 @@ import { LocationSample } from '../models/location';
 import { RailwayLine, TrackSegment, WindowRouteScore } from '../models/railway';
 import { findClosestPointOnPolyline } from '../geo/polyline';
 import { calculateBearing, calculateHeadingDifference } from '../geo/heading';
-import { computeTrajectory } from '../geo/trajectory';
+import { computeTrajectory, osSpeedStopped } from '../geo/trajectory';
+import { segmentsAreAdjacent } from './continuity';
 
 export type WindowScoreableRoute = {
   routeId: string;
@@ -19,11 +20,13 @@ export function scoreRoutesOverWindow(
   if (history.length === 0) return [];
 
   const latest = history[history.length - 1];
-  const trajectory = computeTrajectory(history, latest.timestampMs, config, false);
-  const stopped = (latest.speedMps ?? 0) * 3.6 <= config.stopSpeedThresholdKmh;
+  const trajectory = computeTrajectory(history, latest.timestampMs, config);
+  const osStopped = osSpeedStopped(latest, config);
+  const heading = osStopped === true || !trajectory.reliable ? null : trajectory.headingDegrees;
+  const stopped = osStopped === true;
 
   return routes
-    .map((route) => scoreOneRoute(history, route, trajectory.headingDegrees, stopped, config))
+    .map((route) => scoreOneRoute(history, route, heading, stopped, config))
     .sort((a, b) => b.totalScore - a.totalScore);
 }
 
@@ -42,12 +45,11 @@ function scoreOneRoute(
   const meanDistanceScore = clamp01(1 - meanDistance / 120);
 
   const headingDiffs = projections
-    .map((projection, index) => {
-      const heading = trajectoryHeading ?? history[index].headingDegrees;
-      if (heading === null) return null;
+    .map((projection) => {
+      if (trajectoryHeading === null) return null;
       return Math.min(
-        calculateHeadingDifference(heading, projection.bearingDegrees),
-        calculateHeadingDifference(heading, (projection.bearingDegrees + 180) % 360)
+        calculateHeadingDifference(trajectoryHeading, projection.bearingDegrees),
+        calculateHeadingDifference(trajectoryHeading, (projection.bearingDegrees + 180) % 360)
       );
     })
     .filter((value): value is number => value !== null);
@@ -63,9 +65,16 @@ function scoreOneRoute(
   const sequences = projections
     .map((projection) => projection.stationSequence)
     .filter((value): value is number => value !== null);
-  const stationSequenceScore = sequences.length < 2 ? 0.65 : monotonicityRatio(sequences, 0);
+  const stationSequenceScore = sequences.length < 2 ? 0.5 : monotonicityRatio(sequences, 0);
 
-  const topologyScore = projections.every((projection) => projection.lineId === route.line.id) ? 1 : 0.4;
+  const topologyPairs = projections.length < 2 ? 0 : projections.length - 1;
+  const connectedPairs = projections.filter((projection, index) => {
+    const previous = projections[index - 1]?.segment;
+    const current = projection.segment;
+    if (index === 0 || !previous || !current) return false;
+    return previous.id === current.id || segmentsAreAdjacent(previous, current);
+  }).length;
+  const topologyScore = topologyPairs === 0 ? 0.5 : connectedPairs / topologyPairs;
 
   const totalScore =
     meanDistanceScore * 0.32 +
@@ -94,6 +103,7 @@ function projectOntoRoute(sample: LocationSample, segments: TrackSegment[]) {
     trackPositionMeters: null as number | null,
     stationSequence: null as number | null,
     lineId: segments[0]?.lineId ?? '',
+    segment: null as TrackSegment | null,
   };
 
   for (const segment of segments) {
@@ -107,17 +117,13 @@ function projectOntoRoute(sample: LocationSample, segments: TrackSegment[]) {
       distanceMeters: closest.distanceMeters,
       bearingDegrees: calculateBearing(p1[0], p1[1], p2[0], p2[1]),
       trackPositionMeters: (segment.startOffsetMeters ?? 0) + closest.distanceAlongPolylineMeters,
-      stationSequence: stationSequenceHint(segment),
+      stationSequence: segment.startOffsetMeters ?? null,
       lineId: segment.lineId,
+      segment,
     };
   }
 
   return best;
-}
-
-function stationSequenceHint(segment: TrackSegment): number | null {
-  const from = Number.parseInt(segment.fromStationId.replace(/\D+/g, ''), 10);
-  return Number.isFinite(from) ? from : null;
 }
 
 function monotonicityRatio(values: number[], jitter: number): number {

--- a/src/domain/railway/window-scorer.ts
+++ b/src/domain/railway/window-scorer.ts
@@ -1,0 +1,158 @@
+import { TrackingConfig } from '../../config/tracking-config';
+import { LocationSample } from '../models/location';
+import { RailwayLine, TrackSegment, WindowRouteScore } from '../models/railway';
+import { findClosestPointOnPolyline } from '../geo/polyline';
+import { calculateBearing, calculateHeadingDifference } from '../geo/heading';
+import { computeTrajectory } from '../geo/trajectory';
+
+export type WindowScoreableRoute = {
+  routeId: string;
+  line: RailwayLine;
+  segments: TrackSegment[];
+};
+
+export function scoreRoutesOverWindow(
+  history: LocationSample[],
+  routes: WindowScoreableRoute[],
+  config: TrackingConfig
+): WindowRouteScore[] {
+  if (history.length === 0) return [];
+
+  const latest = history[history.length - 1];
+  const trajectory = computeTrajectory(history, latest.timestampMs, config, false);
+  const stopped = (latest.speedMps ?? 0) * 3.6 <= config.stopSpeedThresholdKmh;
+
+  return routes
+    .map((route) => scoreOneRoute(history, route, trajectory.headingDegrees, stopped, config))
+    .sort((a, b) => b.totalScore - a.totalScore);
+}
+
+function scoreOneRoute(
+  history: LocationSample[],
+  route: WindowScoreableRoute,
+  trajectoryHeading: number | null,
+  stopped: boolean,
+  config: TrackingConfig
+): WindowRouteScore {
+  const nowMs = history[history.length - 1]?.timestampMs ?? 0;
+  const weights = history.map((sample) => Math.exp(-(nowMs - sample.timestampMs) / 5000));
+  const projections = history.map((sample) => projectOntoRoute(sample, route.segments));
+  const distances = projections.map((projection) => projection.distanceMeters);
+  const meanDistance = weightedAverage(distances, weights);
+  const meanDistanceScore = clamp01(1 - meanDistance / 120);
+
+  const headingDiffs = projections
+    .map((projection, index) => {
+      const heading = trajectoryHeading ?? history[index].headingDegrees;
+      if (heading === null) return null;
+      return Math.min(
+        calculateHeadingDifference(heading, projection.bearingDegrees),
+        calculateHeadingDifference(heading, (projection.bearingDegrees + 180) % 360)
+      );
+    })
+    .filter((value): value is number => value !== null);
+  const headingConsistencyScore = headingDiffs.length === 0 ? 0.5 : clamp01(1 - average(headingDiffs) / 90);
+
+  const positions = projections
+    .map((projection) => projection.trackPositionMeters)
+    .filter((value): value is number => value !== null);
+  const progressMonotonicityScore = stopped || positions.length < 3
+    ? 0.7
+    : monotonicityRatio(positions, config.routeProgressJitterMeters);
+
+  const sequences = projections
+    .map((projection) => projection.stationSequence)
+    .filter((value): value is number => value !== null);
+  const stationSequenceScore = sequences.length < 2 ? 0.65 : monotonicityRatio(sequences, 0);
+
+  const topologyScore = projections.every((projection) => projection.lineId === route.line.id) ? 1 : 0.4;
+
+  const totalScore =
+    meanDistanceScore * 0.32 +
+    headingConsistencyScore * 0.2 +
+    progressMonotonicityScore * 0.22 +
+    stationSequenceScore * 0.14 +
+    topologyScore * 0.12;
+
+  return {
+    routeId: route.routeId,
+    lineId: route.line.id,
+    lineName: route.line.name,
+    meanDistanceScore: round2(meanDistanceScore),
+    headingConsistencyScore: round2(headingConsistencyScore),
+    progressMonotonicityScore: round2(progressMonotonicityScore),
+    stationSequenceScore: round2(stationSequenceScore),
+    topologyScore: round2(topologyScore),
+    totalScore: round2(totalScore),
+  };
+}
+
+function projectOntoRoute(sample: LocationSample, segments: TrackSegment[]) {
+  let best = {
+    distanceMeters: Number.POSITIVE_INFINITY,
+    bearingDegrees: 0,
+    trackPositionMeters: null as number | null,
+    stationSequence: null as number | null,
+    lineId: segments[0]?.lineId ?? '',
+  };
+
+  for (const segment of segments) {
+    if (segment.coordinates.length < 2) continue;
+    const closest = findClosestPointOnPolyline(sample.latitude, sample.longitude, segment.coordinates);
+    if (closest.distanceMeters >= best.distanceMeters) continue;
+    const idx = closest.segmentIndex;
+    const p1 = segment.coordinates[idx];
+    const p2 = segment.coordinates[Math.min(idx + 1, segment.coordinates.length - 1)];
+    best = {
+      distanceMeters: closest.distanceMeters,
+      bearingDegrees: calculateBearing(p1[0], p1[1], p2[0], p2[1]),
+      trackPositionMeters: (segment.startOffsetMeters ?? 0) + closest.distanceAlongPolylineMeters,
+      stationSequence: stationSequenceHint(segment),
+      lineId: segment.lineId,
+    };
+  }
+
+  return best;
+}
+
+function stationSequenceHint(segment: TrackSegment): number | null {
+  const from = Number.parseInt(segment.fromStationId.replace(/\D+/g, ''), 10);
+  return Number.isFinite(from) ? from : null;
+}
+
+function monotonicityRatio(values: number[], jitter: number): number {
+  let forward = 0;
+  let backward = 0;
+  for (let i = 1; i < values.length; i++) {
+    const delta = values[i] - values[i - 1];
+    if (Math.abs(delta) <= jitter) continue;
+    if (delta > 0) forward++;
+    else backward++;
+  }
+  const decided = forward + backward;
+  if (decided === 0) return 0.75;
+  return Math.max(forward, backward) / decided;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function weightedAverage(values: number[], weights: number[]): number {
+  let weighted = 0;
+  let total = 0;
+  for (let i = 0; i < values.length; i++) {
+    weighted += values[i] * (weights[i] ?? 1);
+    total += weights[i] ?? 1;
+  }
+  return total === 0 ? 0 : weighted / total;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/domain/speed/navigation-state-estimator.ts
+++ b/src/domain/speed/navigation-state-estimator.ts
@@ -1,6 +1,6 @@
 import { TrackingConfig } from '../../config/tracking-config';
 import { LocationSample, TrackNavigationState } from '../models/location';
-import { RouteMatch, TrackSegment } from '../models/railway';
+import { RouteMatch, TrackSegment, shouldDisplaySelectedRoute } from '../models/railway';
 import { RoutePositionProjector } from '../railway/route-position-projector';
 
 export interface GpsObservation {
@@ -220,7 +220,7 @@ export class NavigationStateEstimator {
     const obsVelocityMps = sample.speedMps ?? this.navState.velocityMps;
     let obsTrackPositionMeters: number | null = null;
 
-    if (match) {
+    if (match && shouldDisplaySelectedRoute(match)) {
       this.currentSegment = match.selectedSegment;
       this.navState.lineId = match.selectedLine.id;
       this.navState.routeId = match.selectedSegment.routeId ?? `route-${match.selectedLine.id}-main`;

--- a/src/index.css
+++ b/src/index.css
@@ -371,3 +371,84 @@ body {
   background-color: #da3633;
   color: white;
 }
+
+.badge.LOCKED, .badge.MANUAL_LOCK {
+  background-color: #238636;
+  color: white;
+}
+
+.badge.UNRESOLVED, .badge.MATCHING_ROUTE {
+  background-color: #1f6feb;
+  color: white;
+}
+
+.badge.SUSPICIOUS, .badge.ROUTE_UNCERTAIN {
+  background-color: #d29922;
+  color: black;
+}
+
+.badge.REACQUIRING {
+  background-color: #db6d28;
+  color: white;
+}
+
+.route-control-section {
+  margin-top: 20px;
+  background-color: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  line-height: 1.6;
+}
+
+.route-control-section > p {
+  margin-top: 8px;
+  color: #8c959f;
+}
+
+.route-control-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.route-lock-warning {
+  margin-top: 10px;
+  color: #f85149;
+  font-weight: 600;
+}
+
+.route-candidates {
+  margin-top: 14px;
+}
+
+.route-candidates h3 {
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.route-candidates ul {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.route-candidate-button {
+  width: 100%;
+  text-align: left;
+  background-color: #21262d;
+  color: #c9d1d9;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.route-candidate-button strong {
+  display: block;
+}
+
+.route-candidate-button small {
+  color: #8c959f;
+}

--- a/src/infrastructure/even-g2/hud-renderer.ts
+++ b/src/infrastructure/even-g2/hud-renderer.ts
@@ -41,7 +41,13 @@ export class HudRenderer {
     } else if (status === 'GPS_LOW_ACCURACY' || navState.mode === 'gps-degraded') {
       statusMode = 'GPS_DEGRADED';
       statusRightText = 'GPS弱';
-    } else if (confidence < 0.55) {
+    } else if (journeyState.lockState === 'REACQUIRING') {
+      statusMode = 'REACQUIRING';
+      statusRightText = '再検出中';
+    } else if (journeyState.lockState === 'SUSPICIOUS') {
+      statusMode = 'UNCERTAIN';
+      statusRightText = '確認中';
+    } else if (journeyState.lockState === 'UNRESOLVED' || status === 'MATCHING_ROUTE' || confidence < 0.55) {
       statusMode = 'UNCERTAIN';
       statusRightText = '判定中';
     }
@@ -66,8 +72,16 @@ export class HudRenderer {
     }
 
     // 3. HEADER Region Formulation
-    let lineName = '路線特定中';
-    if (line && confidence >= 0.55) {
+    let lineName = '路線判定中';
+    const showLine =
+      line &&
+      journeyState.lockState !== 'UNRESOLVED' &&
+      journeyState.lockState !== 'REACQUIRING' &&
+      (journeyState.lockState === 'LOCKED' ||
+        journeyState.lockState === 'SUSPICIOUS' ||
+        journeyState.lockState === 'MANUAL_LOCK' ||
+        (journeyState.lockState === undefined && confidence >= 0.55));
+    if (showLine && line) {
       lineName = line.name;
     }
 

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -1,5 +1,5 @@
 import { LocationSample, FullSpeedState } from '../../domain/models/location';
-import { JourneyState, RouteMatch } from '../../domain/models/railway';
+import { JourneyState, RouteLockEvent, RouteMatch } from '../../domain/models/railway';
 import { HudViewModel } from '../../domain/models/hud';
 import { TelemetrySink, NoopTelemetrySink } from '../telemetry/sinks';
 import {
@@ -56,6 +56,9 @@ export class EstimationLogger {
       emaOutputSpeed: smoothedSpeedKmh,
       gpsAccuracyMeters: rawLocation?.accuracyMeters ?? null,
       selectedLine: entry.match?.selectedLine.name ?? 'None',
+      lockState: entry.match?.lockState ?? entry.journey.lockState ?? null,
+      scoreMargin: entry.match?.scoreMargin ?? null,
+      routeHealth: entry.match?.routeHealth?.total ?? null,
     });
 
     for (const listener of this.listeners) {
@@ -71,6 +74,45 @@ export class EstimationLogger {
   public logGpsObservation(sample: LocationSample, accepted = true, rejectionReason?: string): void {
     if (!this.isDiagnosticEnabled()) return;
     this.sink.write(createGpsTelemetryEvent(this.identity, sample, accepted, rejectionReason));
+  }
+
+  public logRouteObservation(sample: LocationSample, match: RouteMatch | null): void {
+    if (!match) return;
+    this.writeRouteTransition(sample.timestampMs, 'route-observation', {
+      lockState: match.lockState ?? null,
+      currentLineId: match.selectedLine.id,
+      currentSegmentId: match.selectedSegment.id,
+      currentScore: match.currentScore ?? match.candidates[0]?.totalScore ?? null,
+      rescoredScore: match.rescoredCurrentScore ?? null,
+      topLineId: match.candidates[0]?.line.id ?? null,
+      topScore: match.candidates[0]?.totalScore ?? null,
+      secondScore: match.candidates[1]?.totalScore ?? null,
+      scoreMargin: match.scoreMargin ?? null,
+      healthTotal: match.routeHealth?.total ?? null,
+      challengerLineId: match.challenger?.lineId ?? null,
+      challengerWins: match.challenger?.consecutiveWins ?? null,
+      trajectoryHeading: match.trajectoryHeadingDegrees ?? null,
+      switchReason: match.switchReason ?? null,
+    });
+    this.logRouteEvents(match.lockEvents ?? [], sample.timestampMs);
+  }
+
+  public logRouteEvents(events: RouteLockEvent[], timestampMs: number): void {
+    for (const event of events) {
+      this.writeRouteTransition(timestampMs, event.type, {
+        reason: event.reason ?? null,
+        ...event.data,
+      });
+    }
+  }
+
+  private writeRouteTransition(
+    timestampMs: number,
+    message: string,
+    data: Record<string, string | number | boolean | null>
+  ): void {
+    if (!this.isDiagnosticEnabled()) return;
+    this.sink.write(createStateTransitionTelemetryEvent(this.identity, timestampMs, 'route', message, data));
   }
 
   public flush(): Promise<void> {

--- a/src/infrastructure/telemetry/types.ts
+++ b/src/infrastructure/telemetry/types.ts
@@ -1,5 +1,6 @@
 import type { EstimationLogEntry } from '../logging/logger';
 import type { LocationSample } from '../../domain/models/location';
+import type { RouteLockState, RouteSwitchReason } from '../../domain/models/railway';
 
 export const TELEMETRY_SCHEMA_VERSION = 1 as const;
 
@@ -49,7 +50,7 @@ export type EstimationTelemetryEvent = TelemetryEventBase & {
     selectedRouteId: string | null;
     selectedSegmentId: string | null;
     confidence: number;
-    lockState?: string | null;
+    lockState?: RouteLockState | null;
     currentScore?: number | null;
     rescoredCurrentScore?: number | null;
     scoreMargin?: number | null;
@@ -57,7 +58,7 @@ export type EstimationTelemetryEvent = TelemetryEventBase & {
     routeHealthTotal?: number | null;
     challengerLineId?: string | null;
     challengerWins?: number | null;
-    switchReason?: string | null;
+    switchReason?: RouteSwitchReason | null;
     candidates: Array<{
       lineId: string;
       segmentId: string;

--- a/src/infrastructure/telemetry/types.ts
+++ b/src/infrastructure/telemetry/types.ts
@@ -49,6 +49,15 @@ export type EstimationTelemetryEvent = TelemetryEventBase & {
     selectedRouteId: string | null;
     selectedSegmentId: string | null;
     confidence: number;
+    lockState?: string | null;
+    currentScore?: number | null;
+    rescoredCurrentScore?: number | null;
+    scoreMargin?: number | null;
+    trajectoryHeadingDegrees?: number | null;
+    routeHealthTotal?: number | null;
+    challengerLineId?: string | null;
+    challengerWins?: number | null;
+    switchReason?: string | null;
     candidates: Array<{
       lineId: string;
       segmentId: string;
@@ -56,6 +65,7 @@ export type EstimationTelemetryEvent = TelemetryEventBase & {
       distanceScore: number;
       headingScore: number;
       continuityScore: number;
+      historyScore?: number | null;
       totalScore: number;
     }>;
   };
@@ -165,6 +175,15 @@ export function createEstimationTelemetryEvent(
       selectedRouteId: match?.selectedSegment.routeId ?? navState.routeId,
       selectedSegmentId: match?.selectedSegment.id ?? navState.segmentId,
       confidence: match?.confidence ?? 0,
+      lockState: match?.lockState ?? null,
+      currentScore: match?.currentScore ?? null,
+      rescoredCurrentScore: match?.rescoredCurrentScore ?? null,
+      scoreMargin: match?.scoreMargin ?? null,
+      trajectoryHeadingDegrees: match?.trajectoryHeadingDegrees ?? null,
+      routeHealthTotal: match?.routeHealth?.total ?? null,
+      challengerLineId: match?.challenger?.lineId ?? null,
+      challengerWins: match?.challenger?.consecutiveWins ?? null,
+      switchReason: match?.switchReason ?? null,
       candidates: (match?.candidates ?? []).map((candidate) => ({
         lineId: candidate.line.id,
         segmentId: candidate.segment.id,
@@ -172,6 +191,7 @@ export function createEstimationTelemetryEvent(
         distanceScore: candidate.distanceScore,
         headingScore: candidate.headingScore,
         continuityScore: candidate.continuityScore,
+        historyScore: candidate.historyScore,
         totalScore: candidate.totalScore,
       })),
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,10 +113,58 @@ async function init() {
     }
   });
 
+  const routeCandidateList = document.getElementById('route-candidate-list');
+  const routeCandidates = document.getElementById('route-candidates');
+  const unlockRouteButton = document.getElementById('btn-unlock-route') as HTMLButtonElement | null;
+  const routeLockWarning = document.getElementById('route-lock-warning');
+
+  const renderRouteControls = () => {
+    const match = controller.getCurrentRouteMatch();
+    const lockState = match?.lockState ?? 'UNRESOLVED';
+    if (unlockRouteButton) unlockRouteButton.hidden = lockState !== 'MANUAL_LOCK';
+    if (routeLockWarning) routeLockWarning.hidden = !(lockState === 'MANUAL_LOCK' && match?.manualLockAway);
+
+    const candidates = match?.candidates ?? [];
+    const showCandidates =
+      lockState === 'REACQUIRING' ||
+      lockState === 'UNRESOLVED' ||
+      (typeof match?.scoreMargin === 'number' && match.scoreMargin < 15 && candidates.length > 1);
+    if (routeCandidates) routeCandidates.hidden = !showCandidates || candidates.length === 0;
+    if (routeCandidateList) {
+      routeCandidateList.innerHTML = candidates
+        .map((candidate) => {
+          const percent = Math.max(0, Math.min(100, Math.round(candidate.totalScore)));
+          return `<li>
+            <button type="button" class="route-candidate-button" data-segment-id="${candidate.segment.id}">
+              <strong>${candidate.line.name}</strong>
+              <small>${percent}% · ${candidate.distanceMeters}m · ${candidate.segment.id}</small>
+            </button>
+          </li>`;
+        })
+        .join('');
+    }
+  };
+
   logger.subscribe((entry) => {
     const lastImageResult = evenG2Adapter.getLastImageResult ? evenG2Adapter.getLastImageResult() : 'none';
     const syncStatus = db.getSyncStatus ? db.getSyncStatus() : undefined;
     debugPanel.update(entry, lastImageResult, syncStatus);
+    renderRouteControls();
+  });
+
+  document.getElementById('btn-reacquire-route')?.addEventListener('click', () => {
+    void controller.startManualReacquire();
+  });
+
+  document.getElementById('btn-unlock-route')?.addEventListener('click', () => {
+    void controller.unlockManualRoute();
+  });
+
+  routeCandidateList?.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement | null;
+    const button = target?.closest<HTMLButtonElement>('button[data-segment-id]');
+    if (!button?.dataset.segmentId) return;
+    void controller.lockSelectedRoute(button.dataset.segmentId);
   });
 
   document.getElementById('btn-start')?.addEventListener('click', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { DeviceMotionSensorFusionProvider } from './infrastructure/sensors/devic
 import { HudViewModel } from './domain/models/hud';
 import { captureRuntimeError } from './infrastructure/observability/sentry';
 import type { DiagnosticStatus } from './infrastructure/telemetry/runtime-telemetry';
+import { DEFAULT_TRACKING_CONFIG } from './config/tracking-config';
 
 class DemoGpsReplayerProvider implements LocationProvider {
   private listener: ((sample: LocationSample) => void) | null = null;
@@ -128,20 +129,27 @@ async function init() {
     const showCandidates =
       lockState === 'REACQUIRING' ||
       lockState === 'UNRESOLVED' ||
-      (typeof match?.scoreMargin === 'number' && match.scoreMargin < 15 && candidates.length > 1);
+      (typeof match?.scoreMargin === 'number' &&
+        match.scoreMargin < DEFAULT_TRACKING_CONFIG.routeCandidateTieMargin &&
+        candidates.length > 1);
     if (routeCandidates) routeCandidates.hidden = !showCandidates || candidates.length === 0;
     if (routeCandidateList) {
-      routeCandidateList.innerHTML = candidates
-        .map((candidate) => {
-          const percent = Math.max(0, Math.min(100, Math.round(candidate.totalScore)));
-          return `<li>
-            <button type="button" class="route-candidate-button" data-segment-id="${candidate.segment.id}">
-              <strong>${candidate.line.name}</strong>
-              <small>${percent}% · ${candidate.distanceMeters}m · ${candidate.segment.id}</small>
-            </button>
-          </li>`;
-        })
-        .join('');
+      routeCandidateList.replaceChildren();
+      for (const candidate of candidates) {
+        const percent = Math.max(0, Math.min(100, Math.round(candidate.totalScore)));
+        const item = document.createElement('li');
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'route-candidate-button';
+        button.dataset.segmentId = candidate.segment.id;
+        const name = document.createElement('strong');
+        name.textContent = candidate.line.name;
+        const detail = document.createElement('small');
+        detail.textContent = `${percent}% · ${candidate.distanceMeters}m · ${candidate.segment.id}`;
+        button.append(name, detail);
+        item.append(button);
+        routeCandidateList.append(item);
+      }
     }
   };
 

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -1,5 +1,6 @@
 import { EstimationLogEntry } from '../infrastructure/logging/logger';
 import { DatasetSyncStatus } from '../infrastructure/storage/dexie-railway-database';
+import { escapeHtml, escapeHtmlValue } from './html';
 
 export class DebugPanel {
   private container: HTMLElement;
@@ -47,18 +48,18 @@ export class DebugPanel {
         <div class="debug-card" style="border-left: 4px solid #00AAFF;">
           <h3>Cloudflare R2 On-Demand H3 Tile Status</h3>
           <div>同期ステータス: ${renderSyncBadge(datasetSyncStatus?.status)}</div>
-          <div>データセットバージョン: <strong>${datasetSyncStatus?.version ?? 'v1.0.0'}</strong></div>
-          <div>現在地 H3 Cell: <strong style="color: #FFDD55;">${datasetSyncStatus?.currentCellId ?? '未検出'}</strong></div>
+          <div>データセットバージョン: <strong>${escapeHtmlValue(datasetSyncStatus?.version, 'v1.0.0')}</strong></div>
+          <div>現在地 H3 Cell: <strong style="color: #FFDD55;">${escapeHtmlValue(datasetSyncStatus?.currentCellId, '未検出')}</strong></div>
           <div>オンデマンド取得済みタイル数: <strong>${datasetSyncStatus?.loadedTileCount ?? 0} 個</strong></div>
           <div>キャッシュ内規模: <strong>${datasetSyncStatus?.totalLines ?? 0} 路線 / ${datasetSyncStatus?.totalStations ?? 0} 駅</strong></div>
-          <div>ベースURL: <small style="color: #88CCFF;">${datasetSyncStatus?.baseUrl ?? '(ローカル内蔵データ)'}</small></div>
-          ${datasetSyncStatus?.errorMessage ? `<div style="color: #FF8888; font-size: 11px; margin-top: 4px;">Error: ${datasetSyncStatus.errorMessage}</div>` : ''}
+          <div>ベースURL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.baseUrl, '(ローカル内蔵データ)')}</small></div>
+          ${datasetSyncStatus?.errorMessage ? `<div style="color: #FF8888; font-size: 11px; margin-top: 4px;">Error: ${escapeHtml(datasetSyncStatus.errorMessage)}</div>` : ''}
         </div>
 
         <div class="debug-card">
           <h3>Dead Reckoning & G2 SDK Image Status</h3>
-          <div>Navigation Mode: <span class="badge ${navState.mode}">${navState.mode}</span></div>
-          <div>G2 PNG Update Status: <strong style="color: #00FF00; background: #000; padding: 2px 6px; border-radius: 4px;">${lastImageResult ?? 'none'}</strong></div>
+          <div>Navigation Mode: <span class="badge ${escapeHtml(navState.mode)}">${escapeHtml(navState.mode)}</span></div>
+          <div>G2 PNG Update Status: <strong style="color: #00FF00; background: #000; padding: 2px 6px; border-radius: 4px;">${escapeHtmlValue(lastImageResult, 'none')}</strong></div>
           <div>GPS Age: <strong>${typeof gpsAgeMs === 'number' ? `${gpsAgeMs} ms` : gpsAgeMs}</strong></div>
           <div>Track Position: ${navState.trackPositionMeters !== null ? `${navState.trackPositionMeters.toFixed(1)} m` : '未測定'}</div>
           <div>Predicted Speed (1D): ${formatSpeed(navState.velocityMps * 3.6)}</div>
@@ -75,31 +76,31 @@ export class DebugPanel {
           <div style="margin-top: 6px; border-top: 1px dashed rgba(255,255,255,0.1); padding-top: 4px;">
             Selected speed: <strong>${formatSpeed(selectedEstimate.speedKmh)}</strong>
           </div>
-          <div>Selected source: <span class="badge ${selectedEstimate.source}">${selectedEstimate.source}</span></div>
+          <div>Selected source: <span class="badge ${escapeHtml(selectedEstimate.source)}">${escapeHtml(selectedEstimate.source)}</span></div>
           <div>EMA Output: <strong>${formatSpeed(smoothedSpeedKmh)}</strong></div>
           <div>状態: ${isStopped ? '静止 (Stopped)' : '移動中'} / ${isValid ? '有効' : '無効'}</div>
         </div>
 
         <div class="debug-card">
           <h3>路線・駅推定結果</h3>
-          <div>採用路線: <strong>${journey.line ? journey.line.name : '未定 (なし)'}</strong></div>
-          <div>進行方向: ${journey.directionName ?? '不明'} (${journey.direction})</div>
-          <div>前駅: ${journey.previousStation?.name ?? 'なし'}</div>
-          <div>次駅: ${journey.nextStation?.name ?? 'なし'}</div>
+          <div>採用路線: <strong>${journey.line ? escapeHtml(journey.line.name) : '未定 (なし)'}</strong></div>
+          <div>進行方向: ${escapeHtmlValue(journey.directionName, '不明')} (${escapeHtml(journey.direction)})</div>
+          <div>前駅: ${escapeHtmlValue(journey.previousStation?.name, 'なし')}</div>
+          <div>次駅: ${escapeHtmlValue(journey.nextStation?.name, 'なし')}</div>
           <div>次駅まで距離: ${journey.distanceToNextStationMeters !== null ? `${journey.distanceToNextStationMeters} m` : 'なし'}</div>
           <div>路線判定信頼度: <strong>${(journey.confidence * 100).toFixed(0)}% (${journey.confidence.toFixed(2)})</strong></div>
-          <div>ステータス: <span class="badge ${journey.status}">${journey.status}</span></div>
+          <div>ステータス: <span class="badge ${escapeHtml(journey.status)}">${escapeHtml(journey.status)}</span></div>
         </div>
 
         <div class="debug-card">
           <h3>Route Matching Reliability</h3>
-          <div>Route State: <span class="badge ${match?.lockState ?? 'UNRESOLVED'}">${match?.lockState ?? 'UNRESOLVED'}</span></div>
-          <div>Current Route: <strong>${match?.selectedLine.name ?? 'なし'}</strong></div>
-          <div>Current Segment: ${match?.selectedSegment.id ?? 'なし'}</div>
+          <div>Route State: <span class="badge ${escapeHtml(match?.lockState ?? 'UNRESOLVED')}">${escapeHtml(match?.lockState ?? 'UNRESOLVED')}</span></div>
+          <div>Current Route: <strong>${escapeHtmlValue(match?.selectedLine.name, 'なし')}</strong></div>
+          <div>Current Segment: ${escapeHtmlValue(match?.selectedSegment.id, 'なし')}</div>
           <div>Current Score: ${match?.currentScore ?? match?.candidates.find((c) => c.segment.id === match?.selectedSegment.id)?.totalScore ?? '--'}</div>
           <div>Current Score (rescored): ${match?.rescoredCurrentScore ?? '--'}</div>
-          <div>Top Candidate: ${match?.candidates[0] ? `${match.candidates[0].line.name} (${match.candidates[0].totalScore})` : 'なし'}</div>
-          <div>Second Candidate: ${match?.candidates[1] ? `${match.candidates[1].line.name} (${match.candidates[1].totalScore})` : 'なし'}</div>
+          <div>Top Candidate: ${match?.candidates[0] ? `${escapeHtml(match.candidates[0].line.name)} (${match.candidates[0].totalScore})` : 'なし'}</div>
+          <div>Second Candidate: ${match?.candidates[1] ? `${escapeHtml(match.candidates[1].line.name)} (${match.candidates[1].totalScore})` : 'なし'}</div>
           <div>Score Margin: <strong>${match?.scoreMargin ?? '--'}</strong></div>
           <div>Route Health: <strong>${match?.routeHealth ? match.routeHealth.total.toFixed(2) : '--'}</strong></div>
           <div>Distance Consistency: ${match?.routeHealth?.distanceConsistency ?? '--'}</div>
@@ -107,7 +108,7 @@ export class DebugPanel {
           <div>Trajectory Consistency: ${match?.routeHealth?.trajectoryConsistency ?? '--'}</div>
           <div>Progress Consistency: ${match?.routeHealth?.progressConsistency ?? '--'}</div>
           <div>Station Sequence Consistency: ${match?.routeHealth?.stationSequenceConsistency ?? '--'}</div>
-          <div>Challenger: ${match?.challenger ? match.challenger.lineId : 'なし'}</div>
+          <div>Challenger: ${match?.challenger ? escapeHtml(match.challenger.lineId) : 'なし'}</div>
           <div>Challenger Score: ${match?.challenger?.latestScore ?? '--'}</div>
           <div>Consecutive Wins: ${match?.challenger?.consecutiveWins ?? '--'}</div>
           <div>Duration: ${match?.challenger ? `${Math.max(0, match.challenger.lastSeenAtMs - match.challenger.firstSeenAtMs)} ms` : '--'}</div>
@@ -136,7 +137,7 @@ export class DebugPanel {
                       .map(
                         (c) => `
                       <tr class="${c.segment.id === match.selectedSegment.id ? 'active-row' : ''}">
-                        <td>${c.line.name}<br><small>${c.segment.id}</small></td>
+                        <td>${escapeHtml(c.line.name)}<br><small>${escapeHtml(c.segment.id)}</small></td>
                         <td>${c.distanceMeters}m</td>
                         <td>${c.distanceScore}</td>
                         <td>${c.headingScore}</td>

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -91,6 +91,30 @@ export class DebugPanel {
           <div>ステータス: <span class="badge ${journey.status}">${journey.status}</span></div>
         </div>
 
+        <div class="debug-card">
+          <h3>Route Matching Reliability</h3>
+          <div>Route State: <span class="badge ${match?.lockState ?? 'UNRESOLVED'}">${match?.lockState ?? 'UNRESOLVED'}</span></div>
+          <div>Current Route: <strong>${match?.selectedLine.name ?? 'なし'}</strong></div>
+          <div>Current Segment: ${match?.selectedSegment.id ?? 'なし'}</div>
+          <div>Current Score: ${match?.currentScore ?? match?.candidates.find((c) => c.segment.id === match?.selectedSegment.id)?.totalScore ?? '--'}</div>
+          <div>Current Score (rescored): ${match?.rescoredCurrentScore ?? '--'}</div>
+          <div>Top Candidate: ${match?.candidates[0] ? `${match.candidates[0].line.name} (${match.candidates[0].totalScore})` : 'なし'}</div>
+          <div>Second Candidate: ${match?.candidates[1] ? `${match.candidates[1].line.name} (${match.candidates[1].totalScore})` : 'なし'}</div>
+          <div>Score Margin: <strong>${match?.scoreMargin ?? '--'}</strong></div>
+          <div>Route Health: <strong>${match?.routeHealth ? match.routeHealth.total.toFixed(2) : '--'}</strong></div>
+          <div>Distance Consistency: ${match?.routeHealth?.distanceConsistency ?? '--'}</div>
+          <div>Heading Consistency: ${match?.routeHealth?.headingConsistency ?? '--'}</div>
+          <div>Trajectory Consistency: ${match?.routeHealth?.trajectoryConsistency ?? '--'}</div>
+          <div>Progress Consistency: ${match?.routeHealth?.progressConsistency ?? '--'}</div>
+          <div>Station Sequence Consistency: ${match?.routeHealth?.stationSequenceConsistency ?? '--'}</div>
+          <div>Challenger: ${match?.challenger ? match.challenger.lineId : 'なし'}</div>
+          <div>Challenger Score: ${match?.challenger?.latestScore ?? '--'}</div>
+          <div>Consecutive Wins: ${match?.challenger?.consecutiveWins ?? '--'}</div>
+          <div>Duration: ${match?.challenger ? `${Math.max(0, match.challenger.lastSeenAtMs - match.challenger.firstSeenAtMs)} ms` : '--'}</div>
+          <div>Trajectory Heading: ${match?.trajectoryHeadingDegrees !== null && match?.trajectoryHeadingDegrees !== undefined ? `${match.trajectoryHeadingDegrees.toFixed(1)}°` : '--'}</div>
+          <div>Manual Lock State: ${match?.lockState === 'MANUAL_LOCK' ? (match.manualLockAway ? '離れている' : 'ロック中') : 'なし'}</div>
+        </div>
+
         <div class="debug-card candidates-card">
           <h3>候補路線・セグメント スコア内訳</h3>
           ${
@@ -103,6 +127,7 @@ export class DebugPanel {
                       <th>距離点</th>
                       <th>Heading点</th>
                       <th>連続性</th>
+                      <th>履歴</th>
                       <th>合計点</th>
                     </tr>
                   </thead>
@@ -116,6 +141,7 @@ export class DebugPanel {
                         <td>${c.distanceScore}</td>
                         <td>${c.headingScore}</td>
                         <td>${c.continuityScore}</td>
+                        <td>${c.historyScore}</td>
                         <td><strong>${c.totalScore}</strong></td>
                       </tr>
                     `

--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -1,0 +1,13 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function escapeHtmlValue(value: string | number | null | undefined, fallback = ''): string {
+  if (value === null || value === undefined) return fallback;
+  return escapeHtml(String(value));
+}

--- a/tests/even-g2/hud-renderer.test.ts
+++ b/tests/even-g2/hud-renderer.test.ts
@@ -136,4 +136,47 @@ describe('HudRenderer status mapping', () => {
     expect(model.footer.statusRight).toBe('測位中');
     expect(model.rawFormattedText).toContain('路線再特定中');
   });
+
+  it('keeps speed visible and shows 路線判定中 while the route is unresolved', () => {
+    const nowMs = LAST_GPS_MS + 1000;
+    const state = speedState(
+      { speedKmh: 42, confidence: 0.8, source: 'os-geolocation', timestamp: nowMs },
+      42,
+      'gps-locked'
+    );
+
+    const model = renderer.createViewModel(
+      state,
+      journeyState({
+        line: null,
+        confidence: 0.3,
+        status: 'MATCHING_ROUTE',
+        lockState: 'UNRESOLVED',
+      }),
+      nowMs
+    );
+
+    expect(model.header.lineName).toBe('路線判定中');
+    expect(model.footer.statusRight).toBe('判定中');
+    expect(model.speed.displaySpeedKmhText).toBe('42');
+  });
+
+  it('keeps the current line and shows 確認中 while the route is suspicious', () => {
+    const nowMs = LAST_GPS_MS + 1000;
+    const state = speedState(
+      { speedKmh: 78, confidence: 0.8, source: 'os-geolocation', timestamp: nowMs },
+      78,
+      'gps-locked'
+    );
+
+    const model = renderer.createViewModel(
+      state,
+      journeyState({ lockState: 'SUSPICIOUS', status: 'ROUTE_UNCERTAIN' }),
+      nowMs
+    );
+
+    expect(model.header.lineName).toBe('小田急小田原線');
+    expect(model.footer.statusRight).toBe('確認中');
+    expect(model.speed.displaySpeedKmhText).toBe('78');
+  });
 });

--- a/tests/railway/asakusabashi-sobu.test.ts
+++ b/tests/railway/asakusabashi-sobu.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TRACKING_CONFIG, TrackingConfig } from '../../src/config/tracking-config';
+import { LocationSample } from '../../src/domain/models/location';
+import { RailwayLine, RouteCandidateScore, TrackSegment } from '../../src/domain/models/railway';
+import { MapMatcher, RailwayDatabaseReader } from '../../src/domain/railway/map-matcher';
+import { scoreCandidate } from '../../src/domain/railway/candidate-scorer';
+
+const SOBU: RailwayLine = {
+  id: 'jreast-chuo-sobu-local',
+  operatorId: 'jreast',
+  name: 'JR中央・総武線各駅停車',
+};
+
+const SHINKANSEN: RailwayLine = {
+  id: 'jreast-tohoku-shinkansen',
+  operatorId: 'jreast',
+  name: 'JR東北新幹線',
+};
+
+const sobuSegment: TrackSegment = {
+  id: 'sobu-asakusabashi-akihabara',
+  lineId: SOBU.id,
+  routeId: 'route-sobu-west',
+  fromStationId: 'asakusabashi',
+  toStationId: 'akihabara',
+  coordinates: [
+    [35.6968, 139.7900],
+    [35.6972, 139.7864],
+    [35.6978, 139.7800],
+    [35.6983, 139.7730],
+    [35.6990, 139.7680],
+  ],
+  lengthMeters: 2000,
+  startOffsetMeters: 12300,
+};
+
+const shinkansenSegment: TrackSegment = {
+  id: 'tohoku-tokyo-ueno',
+  lineId: SHINKANSEN.id,
+  routeId: 'route-tohoku-north',
+  fromStationId: 'tokyo',
+  toStationId: 'ueno',
+  coordinates: [
+    [35.6812, 139.7671],
+    [35.6900, 139.7700],
+    [35.6980, 139.7735],
+    [35.7141, 139.7774],
+  ],
+  lengthMeters: 3700,
+  startOffsetMeters: 2100,
+};
+
+class TokyoEastDb implements RailwayDatabaseReader {
+  async findSegmentsNear(): Promise<TrackSegment[]> {
+    return [sobuSegment, shinkansenSegment];
+  }
+  async getLine(lineId: string): Promise<RailwayLine | undefined> {
+    if (lineId === SOBU.id) return SOBU;
+    if (lineId === SHINKANSEN.id) return SHINKANSEN;
+    return undefined;
+  }
+}
+
+const config: TrackingConfig = {
+  ...DEFAULT_TRACKING_CONFIG,
+  routeInitialLockConsecutiveCount: 3,
+  routeInitialLockMinimumMs: 2000,
+  routeSuspiciousMinimumMs: 1500,
+  routeReacquireMinimumMs: 1500,
+  routeChallengerConsecutiveCount: 2,
+  routeChallengerMinimumMs: 1500,
+  routeChallengerMinMargin: 6,
+  routeRelockConsecutiveCount: 2,
+  routeRelockMinimumMs: 1500,
+  routeWindowMinSamples: 3,
+};
+
+function point(lat: number, lon: number, timestampMs: number, extras: Partial<LocationSample> = {}): LocationSample {
+  return {
+    latitude: lat,
+    longitude: lon,
+    accuracyMeters: 12,
+    speedMps: 12,
+    headingDegrees: extras.headingDegrees ?? 275,
+    timestampMs,
+    ...extras,
+  };
+}
+
+/** GPS error near the Shinkansen, then a westbound Sobu run Asakusabashi -> Akihabara. */
+const ASAKUSABASHI_TO_AKIHABARA: LocationSample[] = [
+  point(35.6976, 139.7740, 1_000, { headingDegrees: 10 }),
+  point(35.6974, 139.7748, 2_000, { headingDegrees: 350 }),
+  point(35.6972, 139.7864, 3_000),
+  point(35.6974, 139.7840, 4_000),
+  point(35.6976, 139.7815, 5_000),
+  point(35.6978, 139.7790, 6_000),
+  point(35.6980, 139.7765, 7_000),
+  point(35.6983, 139.7730, 8_000),
+  point(35.6986, 139.7708, 9_000),
+  point(35.6990, 139.7680, 10_000),
+];
+
+const TOKYO_TO_UENO_SHINKANSEN: LocationSample[] = [
+  point(35.6820, 139.7674, 1_000, { speedMps: 20, headingDegrees: 20 }),
+  point(35.6860, 139.7688, 2_000, { speedMps: 40, headingDegrees: 18 }),
+  point(35.6900, 139.7700, 3_000, { speedMps: 55, headingDegrees: 16 }),
+  point(35.6940, 139.7718, 4_000, { speedMps: 60, headingDegrees: 15 }),
+  point(35.6980, 139.7735, 5_000, { speedMps: 58, headingDegrees: 14 }),
+  point(35.7060, 139.7754, 6_000, { speedMps: 62, headingDegrees: 14 }),
+  point(35.7120, 139.7768, 7_000, { speedMps: 45, headingDegrees: 13 }),
+];
+
+function shinkansenScore(sample: LocationSample): RouteCandidateScore {
+  return scoreCandidate({
+    sample,
+    segment: shinkansenSegment,
+    line: SHINKANSEN,
+    previousSegment: shinkansenSegment,
+    nearbySegments: [sobuSegment, shinkansenSegment],
+    lockState: 'LOCKED',
+    effectiveHeadingDegrees: sample.headingDegrees,
+    config,
+  });
+}
+
+describe('Asakusabashi / Chuo-Sobu misclassification fixture', () => {
+  it('does not immediately lock the Tohoku Shinkansen when it is briefly the top candidate', async () => {
+    const matcher = new MapMatcher(new TokyoEastDb(), config);
+
+    const first = await matcher.match(ASAKUSABASHI_TO_AKIHABARA[0]);
+    expect(first?.lockState).toBe('UNRESOLVED');
+
+    const second = await matcher.match(ASAKUSABASHI_TO_AKIHABARA[1]);
+    expect(second?.lockState).toBe('UNRESOLVED');
+
+    let last = second;
+    for (const sample of ASAKUSABASHI_TO_AKIHABARA.slice(2)) {
+      last = await matcher.match(sample);
+    }
+
+    expect(last?.lockState).toBe('LOCKED');
+    expect(last?.selectedLine.id).toBe(SOBU.id);
+  });
+
+  it('recovers from a wrong Shinkansen lock while riding Asakusabashi to Akihabara', async () => {
+    const matcher = new MapMatcher(new TokyoEastDb(), config);
+    matcher.forceLockForTests(shinkansenScore(ASAKUSABASHI_TO_AKIHABARA[0]));
+    expect(matcher.getLockState()).toBe('LOCKED');
+
+    const states: string[] = [];
+    let last = null;
+    for (const sample of ASAKUSABASHI_TO_AKIHABARA) {
+      last = await matcher.match(sample);
+      if (last?.lockState) states.push(last.lockState);
+    }
+
+    expect(states).toContain('SUSPICIOUS');
+    expect(states).toContain('REACQUIRING');
+    expect(last?.lockState).toBe('LOCKED');
+    expect(last?.selectedLine.id).toBe(SOBU.id);
+  });
+
+  it('does not flicker away from a healthy Chuo-Sobu lock when a parallel candidate spikes', async () => {
+    const matcher = new MapMatcher(new TokyoEastDb(), config);
+    for (const sample of ASAKUSABASHI_TO_AKIHABARA.slice(2, 6)) {
+      await matcher.match(sample);
+    }
+    expect(matcher.getLockState()).toBe('LOCKED');
+
+    const spike = await matcher.match(point(35.6979, 139.7736, 20_000, { headingDegrees: 15 }));
+    expect(spike?.selectedLine.id).toBe(SOBU.id);
+    expect(spike?.lockState).toBe('LOCKED');
+
+    const after = await matcher.match(point(35.6981, 139.7750, 21_000));
+    expect(after?.selectedLine.id).toBe(SOBU.id);
+    expect(after?.lockState).toBe('LOCKED');
+  });
+
+  it('still locks the Tohoku Shinkansen on a real Tokyo-Ueno run', async () => {
+    const matcher = new MapMatcher(new TokyoEastDb(), config);
+    let last = null;
+    for (const sample of TOKYO_TO_UENO_SHINKANSEN) {
+      last = await matcher.match(sample);
+    }
+    expect(last?.lockState).toBe('LOCKED');
+    expect(last?.selectedLine.id).toBe(SHINKANSEN.id);
+  });
+});

--- a/tests/railway/asakusabashi-sobu.test.ts
+++ b/tests/railway/asakusabashi-sobu.test.ts
@@ -99,6 +99,8 @@ const ASAKUSABASHI_TO_AKIHABARA: LocationSample[] = [
   point(35.6983, 139.7730, 8_000),
   point(35.6986, 139.7708, 9_000),
   point(35.6990, 139.7680, 10_000),
+  point(35.6992, 139.7665, 11_000),
+  point(35.6994, 139.7650, 12_000),
 ];
 
 const TOKYO_TO_UENO_SHINKANSEN: LocationSample[] = [

--- a/tests/railway/continuity.test.ts
+++ b/tests/railway/continuity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
+import { TrackSegment } from '../../src/domain/models/railway';
+import { classifyContinuity, continuityBonus } from '../../src/domain/railway/continuity';
+
+const base: TrackSegment = {
+  id: 'a-1',
+  lineId: 'line-a',
+  routeId: 'route-a',
+  fromStationId: 's1',
+  toStationId: 's2',
+  coordinates: [[35, 139], [35.1, 139]],
+  nextSegmentIds: ['a-2'],
+};
+
+const adjacent: TrackSegment = {
+  id: 'a-2',
+  lineId: 'line-a',
+  routeId: 'route-a',
+  fromStationId: 's2',
+  toStationId: 's3',
+  coordinates: [[35.1, 139], [35.2, 139]],
+  previousSegmentIds: ['a-1'],
+};
+
+const disconnectedSameLine: TrackSegment = {
+  id: 'a-9',
+  lineId: 'line-a',
+  routeId: 'route-a-other',
+  fromStationId: 's20',
+  toStationId: 's21',
+  coordinates: [[36, 140], [36.1, 140]],
+};
+
+const otherLine: TrackSegment = {
+  id: 'b-1',
+  lineId: 'line-b',
+  routeId: 'route-b',
+  fromStationId: 'x',
+  toStationId: 'y',
+  coordinates: [[35, 139.1], [35.1, 139.1]],
+};
+
+describe('topology continuity', () => {
+  it('ranks same segment above adjacent, reachable, disconnected, then unrelated', () => {
+    expect(classifyContinuity(base, base, [base])).toBe('same-segment');
+    expect(classifyContinuity(base, adjacent, [base, adjacent])).toBe('adjacent-segment');
+    expect(classifyContinuity(base, disconnectedSameLine, [base, disconnectedSameLine])).toBe('same-line-disconnected');
+    expect(classifyContinuity(base, otherLine, [base, otherLine])).toBe('unrelated');
+  });
+
+  it('does not give a high bonus to a disconnected segment on the same line', () => {
+    const disconnected = continuityBonus('same-line-disconnected', 'LOCKED', DEFAULT_TRACKING_CONFIG);
+    const adjacentBonus = continuityBonus('adjacent-segment', 'LOCKED', DEFAULT_TRACKING_CONFIG);
+    expect(disconnected).toBe(2);
+    expect(disconnected).toBeLessThan(adjacentBonus / 2);
+  });
+});

--- a/tests/railway/continuity.test.ts
+++ b/tests/railway/continuity.test.ts
@@ -49,6 +49,25 @@ describe('topology continuity', () => {
     expect(classifyContinuity(base, otherLine, [base, otherLine])).toBe('unrelated');
   });
 
+  it('does not treat different lines that share a station as reachable when routeId is missing', () => {
+    const sobu: TrackSegment = {
+      id: 'sobu-akihabara',
+      lineId: 'chuo-sobu',
+      fromStationId: 'akihabara',
+      toStationId: 'kanda',
+      coordinates: [[35.698, 139.773], [35.691, 139.771]],
+    };
+    const shinkansen: TrackSegment = {
+      id: 'tohoku-tokyo-ueno',
+      lineId: 'tohoku-shinkansen',
+      fromStationId: 'tokyo',
+      toStationId: 'akihabara',
+      coordinates: [[35.681, 139.767], [35.698, 139.773]],
+    };
+
+    expect(classifyContinuity(sobu, shinkansen, [sobu, shinkansen])).toBe('unrelated');
+  });
+
   it('does not give a high bonus to a disconnected segment on the same line', () => {
     const disconnected = continuityBonus('same-line-disconnected', 'LOCKED', DEFAULT_TRACKING_CONFIG);
     const adjacentBonus = continuityBonus('adjacent-segment', 'LOCKED', DEFAULT_TRACKING_CONFIG);

--- a/tests/railway/map-matcher.test.ts
+++ b/tests/railway/map-matcher.test.ts
@@ -1,97 +1,398 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
+import { DEFAULT_TRACKING_CONFIG, TrackingConfig } from '../../src/config/tracking-config';
 import { MapMatcher, RailwayDatabaseReader } from '../../src/domain/railway/map-matcher';
 import { RailwayLine, TrackSegment } from '../../src/domain/models/railway';
 import { LocationSample } from '../../src/domain/models/location';
+import { scoreCandidate } from '../../src/domain/railway/candidate-scorer';
+
+const LINE_A: RailwayLine = { id: 'line-a', operatorId: 'op', name: '在来線A' };
+const LINE_B: RailwayLine = { id: 'line-b', operatorId: 'op', name: '在来線B' };
+const SHINKANSEN: RailwayLine = { id: 'line-shinkansen', operatorId: 'jre', name: 'JR東北新幹線' };
+
+const segA1: TrackSegment = {
+  id: 'seg-a-1',
+  lineId: 'line-a',
+  routeId: 'route-a',
+  fromStationId: 'st-1',
+  toStationId: 'st-2',
+  coordinates: [
+    [35.0, 139.0],
+    [35.1, 139.0],
+  ],
+  lengthMeters: 11120,
+  startOffsetMeters: 0,
+  nextSegmentIds: ['seg-a-2'],
+};
+
+const segA2: TrackSegment = {
+  id: 'seg-a-2',
+  lineId: 'line-a',
+  routeId: 'route-a',
+  fromStationId: 'st-2',
+  toStationId: 'st-3',
+  coordinates: [
+    [35.1, 139.0],
+    [35.2, 139.0],
+  ],
+  lengthMeters: 11120,
+  startOffsetMeters: 11120,
+  previousSegmentIds: ['seg-a-1'],
+};
+
+const segB1: TrackSegment = {
+  id: 'seg-b-1',
+  lineId: 'line-b',
+  routeId: 'route-b',
+  fromStationId: 'st-x',
+  toStationId: 'st-y',
+  coordinates: [
+    [35.05, 139.008],
+    [35.15, 139.008],
+  ],
+  lengthMeters: 11120,
+  startOffsetMeters: 0,
+};
 
 class MockRailwayDatabase implements RailwayDatabaseReader {
-  public line: RailwayLine = {
-    id: 'test-line',
-    operatorId: 'op',
-    name: 'テスト線',
-  };
-
-  public segA: TrackSegment = {
-    id: 'seg-A',
-    lineId: 'test-line',
-    fromStationId: 'st1',
-    toStationId: 'st2',
-    coordinates: [
-      [35.0, 139.0],
-      [35.1, 139.0],
-    ],
-  };
-
-  public segB: TrackSegment = {
-    id: 'seg-B',
-    lineId: 'test-line',
-    fromStationId: 'st2',
-    toStationId: 'st3',
-    coordinates: [
-      [35.1, 139.0],
-      [35.2, 139.0],
-    ],
-  };
+  public segments: TrackSegment[] = [segA1, segA2, segB1];
+  public lines = new Map<string, RailwayLine>([
+    [LINE_A.id, LINE_A],
+    [LINE_B.id, LINE_B],
+    [SHINKANSEN.id, SHINKANSEN],
+  ]);
 
   async findSegmentsNear(): Promise<TrackSegment[]> {
-    return [this.segA, this.segB];
+    return this.segments;
   }
 
   async getLine(lineId: string): Promise<RailwayLine | undefined> {
-    if (lineId === 'test-line') return this.line;
-    return undefined;
+    return this.lines.get(lineId);
   }
 }
 
-describe('MapMatcher', () => {
+function sample(lat: number, lon: number, timestampMs: number, extras: Partial<LocationSample> = {}): LocationSample {
+  return {
+    latitude: lat,
+    longitude: lon,
+    accuracyMeters: 10,
+    speedMps: 20,
+    headingDegrees: 0,
+    timestampMs,
+    ...extras,
+  };
+}
+
+function config(overrides: Partial<TrackingConfig> = {}): TrackingConfig {
+  return { ...DEFAULT_TRACKING_CONFIG, ...overrides };
+}
+
+async function lockOnA(matcher: MapMatcher, startMs = 10_000): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await matcher.match(sample(35.04, 139.0, startMs + i * 1000));
+  }
+}
+
+describe('MapMatcher initial lock', () => {
   let db: MockRailwayDatabase;
   let matcher: MapMatcher;
 
   beforeEach(() => {
     db = new MockRailwayDatabase();
-    matcher = new MapMatcher(db, DEFAULT_TRACKING_CONFIG);
+    matcher = new MapMatcher(db, config());
   });
 
-  it('matches closest line segment and returns valid confidence', async () => {
-    const sample: LocationSample = {
-      latitude: 35.05,
-      longitude: 139.0,
-      accuracyMeters: 10,
-      speedMps: 20,
-      headingDegrees: 0,
-      timestampMs: 10000,
-    };
-
-    const match = await matcher.match(sample);
+  it('does not lock after a single GPS fix', async () => {
+    const match = await matcher.match(sample(35.05, 139.0, 10_000));
     expect(match).not.toBeNull();
-    expect(match?.selectedSegment.id).toBe('seg-A');
-    expect(match?.confidence).toBeGreaterThan(0.5);
+    expect(match?.lockState).toBe('UNRESOLVED');
+    expect(match?.showSelectedRoute).toBe(false);
+    expect(match?.selectedSegment.id).toBe('seg-a-1');
   });
 
-  it('suppresses rapid route switching using hysteresis rules', async () => {
-    // 1st sample near seg-A
-    const sample1: LocationSample = {
-      latitude: 35.02,
-      longitude: 139.0,
-      accuracyMeters: 10,
-      speedMps: 20,
-      headingDegrees: 0,
-      timestampMs: 10000,
-    };
-    const m1 = await matcher.match(sample1);
-    expect(m1?.selectedSegment.id).toBe('seg-A');
+  it('locks after the same candidate stays ahead across enough fixes', async () => {
+    let last = await matcher.match(sample(35.04, 139.0, 10_000));
+    last = await matcher.match(sample(35.045, 139.0, 11_000));
+    last = await matcher.match(sample(35.05, 139.0, 12_000));
+    last = await matcher.match(sample(35.055, 139.0, 13_000));
 
-    // 2nd sample slightly closer to seg-B but not enough consecutive times
-    const sample2: LocationSample = {
-      latitude: 35.12,
-      longitude: 139.0,
-      accuracyMeters: 10,
-      speedMps: 20,
-      headingDegrees: 0,
-      timestampMs: 11000,
-    };
-    const m2 = await matcher.match(sample2);
-    // Should still hold seg-A due to hysteresis count threshold (requires 3 consecutive or 5s)
-    expect(m2?.selectedSegment.id).toBe('seg-A');
+    expect(last?.lockState).toBe('LOCKED');
+    expect(last?.selectedLine.id).toBe('line-a');
+    expect(last?.showSelectedRoute).toBe(true);
+    expect(last?.lockEvents?.some((event) => event.type === 'route-lock')).toBe(true);
+  });
+
+  it('stays unresolved when top and second scores are too close', async () => {
+    db.segments = [
+      segA1,
+      {
+        ...segB1,
+        coordinates: [
+          [35.0, 139.0004],
+          [35.1, 139.0004],
+        ],
+      },
+    ];
+
+    let last = null;
+    for (let i = 0; i < 5; i++) {
+      last = await matcher.match(sample(35.05, 139.0002, 10_000 + i * 1000));
+    }
+
+    expect(last?.lockState).toBe('UNRESOLVED');
+    expect(last?.scoreMargin ?? 99).toBeLessThan(DEFAULT_TRACKING_CONFIG.routeInitialLockMinMargin);
+  });
+
+  it('does not immediately lock a wrong route while stopped', async () => {
+    const match = await matcher.match(sample(35.05, 139.0, 10_000, { speedMps: 0, headingDegrees: null }));
+    expect(match?.lockState).toBe('UNRESOLVED');
+    expect(match?.showSelectedRoute).toBe(false);
+  });
+});
+
+describe('MapMatcher current rescore', () => {
+  it('compares the challenger against the current route rescored at this fix', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config());
+    await lockOnA(matcher);
+
+    const next = await matcher.match(sample(35.16, 139.0, 20_000));
+    expect(next?.lockState).toBe('LOCKED');
+    expect(next?.rescoredCurrentScore).not.toBeNull();
+    expect(next?.selectedLine.id).toBe('line-a');
+    expect(next?.selectedSegment.id).toBe('seg-a-2');
+  });
+
+  it('treats a current route that left the search radius as lost evidence', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config({
+      routeSuspiciousMinimumMs: 0,
+      routeReacquireMinimumMs: 0,
+    }));
+    await lockOnA(matcher);
+
+    db.segments = [segB1];
+    const lost = await matcher.match(sample(35.12, 139.008, 20_000));
+    expect(lost?.lockState === 'SUSPICIOUS' || lost?.lockState === 'REACQUIRING').toBe(true);
+    expect(lost?.rescoredCurrentScore ?? null).toBeNull();
+  });
+});
+
+describe('MapMatcher continuity and health', () => {
+  it('gives the highest continuity bonus to the same segment', () => {
+    const same = scoreCandidate({
+      sample: sample(35.05, 139.0, 1),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: segA1,
+      nearbySegments: [segA1, segA2],
+      lockState: 'LOCKED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const adjacent = scoreCandidate({
+      sample: sample(35.11, 139.0, 1),
+      segment: segA2,
+      line: LINE_A,
+      previousSegment: segA1,
+      nearbySegments: [segA1, segA2],
+      lockState: 'LOCKED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const otherLine = scoreCandidate({
+      sample: sample(35.05, 139.008, 1),
+      segment: segB1,
+      line: LINE_B,
+      previousSegment: segA1,
+      nearbySegments: [segA1, segA2, segB1],
+      lockState: 'LOCKED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+
+    expect(same.continuityScore).toBe(DEFAULT_TRACKING_CONFIG.continuitySameSegment);
+    expect(adjacent.continuityScore).toBe(DEFAULT_TRACKING_CONFIG.continuityAdjacentSegment);
+    expect(otherLine.continuityScore).toBe(0);
+    expect(same.continuityScore).toBeGreaterThan(adjacent.continuityScore);
+  });
+
+  it('reduces continuity bias while suspicious and almost removes it while reacquiring', () => {
+    const locked = scoreCandidate({
+      sample: sample(35.05, 139.0, 1),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: segA1,
+      nearbySegments: [segA1],
+      lockState: 'LOCKED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const suspicious = scoreCandidate({
+      sample: sample(35.05, 139.0, 1),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: segA1,
+      nearbySegments: [segA1],
+      lockState: 'SUSPICIOUS',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const reacquiring = scoreCandidate({
+      sample: sample(35.05, 139.0, 1),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: segA1,
+      nearbySegments: [segA1],
+      lockState: 'REACQUIRING',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+
+    expect(suspicious.continuityScore).toBeLessThan(locked.continuityScore);
+    expect(reacquiring.continuityScore).toBeLessThan(suspicious.continuityScore);
+    expect(reacquiring.continuityScore).toBeLessThanOrEqual(2);
+  });
+
+  it('does not penalize a shinkansen for being slow, but penalizes conventional lines at 250 km/h', () => {
+    const fastConventional = scoreCandidate({
+      sample: sample(35.05, 139.0, 1, { speedMps: 250 / 3.6 }),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: null,
+      nearbySegments: [segA1],
+      lockState: 'UNRESOLVED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const slowShinkansen = scoreCandidate({
+      sample: sample(35.05, 139.0, 1, { speedMps: 5 / 3.6 }),
+      segment: { ...segA1, id: 'shin-1', lineId: SHINKANSEN.id },
+      line: SHINKANSEN,
+      previousSegment: null,
+      nearbySegments: [segA1],
+      lockState: 'UNRESOLVED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+    const slowConventional = scoreCandidate({
+      sample: sample(35.05, 139.0, 1, { speedMps: 5 / 3.6 }),
+      segment: segA1,
+      line: LINE_A,
+      previousSegment: null,
+      nearbySegments: [segA1],
+      lockState: 'UNRESOLVED',
+      effectiveHeadingDegrees: 0,
+      config: DEFAULT_TRACKING_CONFIG,
+    });
+
+    expect(fastConventional.totalScore).toBeLessThan(slowConventional.totalScore);
+    expect(slowShinkansen.totalScore).toBeGreaterThan(fastConventional.totalScore - 5);
+  });
+});
+
+describe('MapMatcher challenger and health recovery', () => {
+  it('does not switch after a single high-scoring challenger fix', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config());
+    await lockOnA(matcher);
+
+    const spike = await matcher.match(sample(35.12, 139.008, 20_000));
+    expect(spike?.selectedLine.id).toBe('line-a');
+    expect(spike?.lockState).toBe('LOCKED');
+    expect(spike?.challenger?.lineId).toBe('line-b');
+    expect(spike?.challenger?.consecutiveWins).toBe(1);
+  });
+
+  it('tracks a persistent challenger without switching while current health stays healthy', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config({
+      routeChallengerConsecutiveCount: 2,
+      routeChallengerMinimumMs: 1000,
+    }));
+    await lockOnA(matcher);
+
+    // Stay on line A, even if B is briefly closer, because health remains high on A.
+    await matcher.match(sample(35.06, 139.001, 20_000));
+    const stillA = await matcher.match(sample(35.07, 139.001, 21_000));
+    expect(stillA?.selectedLine.id).toBe('line-a');
+    expect(stillA?.lockState).toBe('LOCKED');
+  });
+
+  it('switches only when health is low, the challenger is clearly better, and that persists', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config({
+      routeSuspiciousMinimumMs: 1000,
+      routeReacquireMinimumMs: 1000,
+      routeChallengerConsecutiveCount: 2,
+      routeChallengerMinimumMs: 1000,
+      routeChallengerMinMargin: 5,
+      routeRelockConsecutiveCount: 2,
+      routeRelockMinimumMs: 1000,
+      routeWindowMinSamples: 2,
+    }));
+    await lockOnA(matcher);
+
+    let last = null;
+    for (let i = 0; i < 8; i++) {
+      last = await matcher.match(sample(35.12 + i * 0.005, 139.008, 20_000 + i * 1000));
+    }
+
+    expect(last?.lockState).toBe('LOCKED');
+    expect(last?.selectedLine.id).toBe('line-b');
+    expect(last?.switchReason).toBe('challenger-dominant');
+  });
+});
+
+describe('MapMatcher manual reacquire and lock', () => {
+  it('clears continuity bias and re-evaluates the GPS window after a manual reacquire', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config({
+      routeRelockConsecutiveCount: 2,
+      routeRelockMinimumMs: 1000,
+      routeWindowMinSamples: 2,
+      routeInitialLockMinMargin: 5,
+    }));
+    await lockOnA(matcher);
+    expect(matcher.getLockState()).toBe('LOCKED');
+
+    matcher.startManualReacquire(20_000);
+    expect(matcher.getLockState()).toBe('REACQUIRING');
+
+    const first = await matcher.match(sample(35.12, 139.008, 21_000));
+    expect(first?.lockState).toBe('REACQUIRING');
+    expect(first?.showSelectedRoute).toBe(false);
+    expect(first?.candidates[0]?.continuityScore ?? 99).toBeLessThan(2);
+
+    await matcher.match(sample(35.13, 139.008, 22_000));
+    const locked = await matcher.match(sample(35.14, 139.008, 23_000));
+    expect(locked?.lockState).toBe('LOCKED');
+    expect(locked?.selectedLine.id).toBe('line-b');
+  });
+
+  it('prioritizes a user-selected route and warns when the user is far from it', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config({ routeManualLockMaxDistanceMeters: 80 }));
+    await matcher.match(sample(35.05, 139.0, 10_000));
+    expect(matcher.lockSelectedRoute('seg-b-1', 11_000)).toBe(true);
+
+    const locked = await matcher.match(sample(35.05, 139.0, 12_000));
+    expect(locked?.lockState).toBe('MANUAL_LOCK');
+    expect(locked?.selectedLine.id).toBe('line-b');
+    expect(locked?.manualLockAway).toBe(true);
+
+    const stillB = await matcher.match(sample(35.06, 139.0, 13_000));
+    expect(stillB?.selectedLine.id).toBe('line-b');
+  });
+
+  it('returns to unresolved auto matching when the user unlocks a manual lock', async () => {
+    const db = new MockRailwayDatabase();
+    const matcher = new MapMatcher(db, config());
+    await matcher.match(sample(35.05, 139.0, 10_000));
+    matcher.lockSelectedRoute('seg-a-1', 11_000);
+
+    matcher.unlockManualRoute(12_000);
+    const next = await matcher.match(sample(35.05, 139.0, 13_000));
+    expect(next?.lockState).toBe('UNRESOLVED');
+    expect(next?.showSelectedRoute).toBe(false);
   });
 });

--- a/tests/railway/map-matcher.test.ts
+++ b/tests/railway/map-matcher.test.ts
@@ -332,11 +332,14 @@ describe('MapMatcher challenger and health recovery', () => {
     }));
     await lockOnA(matcher);
 
+    const states: string[] = [];
     let last = null;
-    for (let i = 0; i < 8; i++) {
-      last = await matcher.match(sample(35.12 + i * 0.005, 139.008, 20_000 + i * 1000));
+    for (let i = 0; i < 7; i++) {
+      last = await matcher.match(sample(35.12 + i * 0.004, 139.008, 20_000 + i * 1000));
+      if (last?.lockState) states.push(last.lockState);
     }
 
+    expect(states).toContain('REACQUIRING');
     expect(last?.lockState).toBe('LOCKED');
     expect(last?.selectedLine.id).toBe('line-b');
     expect(last?.switchReason).toBe('challenger-dominant');
@@ -352,19 +355,22 @@ describe('MapMatcher manual reacquire and lock', () => {
       routeWindowMinSamples: 2,
       routeInitialLockMinMargin: 5,
     }));
-    await lockOnA(matcher);
+    await lockOnA(matcher, 1_000);
     expect(matcher.getLockState()).toBe('LOCKED');
 
     matcher.startManualReacquire(20_000);
     expect(matcher.getLockState()).toBe('REACQUIRING');
 
-    const first = await matcher.match(sample(35.12, 139.008, 21_000));
+    const first = await matcher.match(sample(35.10, 139.008, 21_000));
     expect(first?.lockState).toBe('REACQUIRING');
     expect(first?.showSelectedRoute).toBe(false);
     expect(first?.candidates[0]?.continuityScore ?? 99).toBeLessThan(2);
+    expect(first?.windowScores?.some((score) => score.routeId === 'route-b')).toBe(true);
 
-    await matcher.match(sample(35.13, 139.008, 22_000));
-    const locked = await matcher.match(sample(35.14, 139.008, 23_000));
+    await matcher.match(sample(35.11, 139.008, 22_000));
+    await matcher.match(sample(35.12, 139.008, 23_000));
+    await matcher.match(sample(35.13, 139.008, 24_000));
+    const locked = await matcher.match(sample(35.14, 139.008, 25_000));
     expect(locked?.lockState).toBe('LOCKED');
     expect(locked?.selectedLine.id).toBe('line-b');
   });

--- a/tests/railway/route-matching-review.test.ts
+++ b/tests/railway/route-matching-review.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TRACKING_CONFIG, TrackingConfig } from '../../src/config/tracking-config';
+import { LocationSample } from '../../src/domain/models/location';
+import { RailwayLine, TrackSegment } from '../../src/domain/models/railway';
+import { computeTrajectory, osSpeedStopped, resolveEffectiveHeading } from '../../src/domain/geo/trajectory';
+import { MapMatcher, RailwayDatabaseReader } from '../../src/domain/railway/map-matcher';
+import { evaluateRouteHealth, RouteObservation } from '../../src/domain/railway/route-health';
+import { scoreRoutesOverWindow } from '../../src/domain/railway/window-scorer';
+
+const LINE: RailwayLine = { id: 'line-a', operatorId: 'op', name: '在来線A' };
+
+const route1: TrackSegment = {
+  id: 'route-1-seg',
+  lineId: LINE.id,
+  routeId: 'route-1',
+  fromStationId: 'st-ebina',
+  toStationId: 'st-zama',
+  coordinates: [
+    [35.0, 139.0],
+    [35.1, 139.0],
+  ],
+  startOffsetMeters: 0,
+  previousSegmentIds: [],
+  nextSegmentIds: ['route-1-next'],
+};
+
+const route2: TrackSegment = {
+  id: 'route-2-seg',
+  lineId: LINE.id,
+  routeId: 'route-2',
+  fromStationId: 'st-shinjuku',
+  toStationId: 'st-yoyogi',
+  coordinates: [
+    [35.2, 139.02],
+    [35.3, 139.02],
+  ],
+  startOffsetMeters: 0,
+  previousSegmentIds: [],
+  nextSegmentIds: [],
+};
+
+class DualRouteDb implements RailwayDatabaseReader {
+  constructor(public segments: TrackSegment[]) {}
+  async findSegmentsNear(): Promise<TrackSegment[]> {
+    return this.segments;
+  }
+  async getLine(): Promise<RailwayLine | undefined> {
+    return LINE;
+  }
+  async getStation(id: string) {
+    const sequences: Record<string, number> = { 'st-ebina': 1, 'st-zama': 2, 'st-shinjuku': 8, 'st-yoyogi': 9 };
+    return { id, lineId: LINE.id, name: id, sequence: sequences[id] ?? 0, latitude: 35, longitude: 139 };
+  }
+}
+
+function sample(lat: number, lon: number, timestampMs: number, extras: Partial<LocationSample> = {}): LocationSample {
+  return {
+    latitude: lat,
+    longitude: lon,
+    accuracyMeters: 10,
+    speedMps: 20,
+    headingDegrees: 0,
+    timestampMs,
+    ...extras,
+  };
+}
+
+function config(overrides: Partial<TrackingConfig> = {}): TrackingConfig {
+  return { ...DEFAULT_TRACKING_CONFIG, ...overrides };
+}
+
+describe('review: MANUAL_LOCK stays on the selected route', () => {
+  it('does not move a manual lock onto another route of the same line', async () => {
+    const db = new DualRouteDb([route1, route2]);
+    const matcher = new MapMatcher(db, config());
+    await matcher.match(sample(35.05, 139.0, 1_000));
+    expect(matcher.lockSelectedRoute('route-1-seg', 2_000)).toBe(true);
+
+    db.segments = [route2];
+    const next = await matcher.match(sample(35.25, 139.02, 3_000));
+
+    expect(next?.lockState).toBe('MANUAL_LOCK');
+    expect(next?.selectedSegment.routeId).toBe('route-1');
+    expect(next?.selectedSegment.id).toBe('route-1-seg');
+    expect(next?.manualLockAway).toBe(true);
+  });
+
+  it('marks the user away when the locked route is outside the search results', async () => {
+    const db = new DualRouteDb([route1]);
+    const matcher = new MapMatcher(db, config({ routeManualLockMaxDistanceMeters: 80 }));
+    await matcher.match(sample(35.05, 139.0, 1_000));
+    matcher.lockSelectedRoute('route-1-seg', 2_000);
+
+    db.segments = [];
+    const away = await matcher.match(sample(36.0, 140.0, 3_000));
+    expect(away?.lockState).toBe('MANUAL_LOCK');
+    expect(away?.selectedSegment.id).toBe('route-1-seg');
+    expect(away?.manualLockAway).toBe(true);
+  });
+});
+
+describe('review: manual reacquire uses the GPS window', () => {
+  it('keeps window scores on the reacquire path and does not lock on the first fix', async () => {
+    const db = new DualRouteDb([route1, route2]);
+    const matcher = new MapMatcher(db, config({
+      routeRelockConsecutiveCount: 3,
+      routeRelockMinimumMs: 3000,
+      routeWindowMinSamples: 2,
+    }));
+    for (let i = 0; i < 4; i++) {
+      await matcher.match(sample(35.04 + i * 0.01, 139.0, 10_000 + i * 1000));
+    }
+    matcher.startManualReacquire(20_000);
+
+    const first = await matcher.match(sample(35.25, 139.02, 21_000));
+    expect(first?.lockState).toBe('REACQUIRING');
+    expect(first?.windowScores?.some((score) => score.routeId === 'route-2')).toBe(true);
+    expect(first?.showSelectedRoute).toBe(false);
+  });
+});
+
+describe('review: challenger wins must be consecutive', () => {
+  it('resets consecutiveWins when the current route wins a fix in between', async () => {
+    const other: RailwayLine = { id: 'line-b', operatorId: 'op', name: '在来線B' };
+    const otherSeg: TrackSegment = {
+      id: 'b-1',
+      lineId: other.id,
+      routeId: 'route-b',
+      fromStationId: 'x',
+      toStationId: 'y',
+      coordinates: [
+        [35.05, 139.008],
+        [35.15, 139.008],
+      ],
+    };
+    const db: RailwayDatabaseReader = {
+      async findSegmentsNear() {
+        return [route1, otherSeg];
+      },
+      async getLine(id) {
+        return id === other.id ? other : LINE;
+      },
+    };
+    const matcher = new MapMatcher(db, config());
+    for (let i = 0; i < 4; i++) {
+      await matcher.match(sample(35.04, 139.0, 10_000 + i * 1000));
+    }
+
+    const win1 = await matcher.match(sample(35.12, 139.008, 20_000));
+    expect(win1?.challenger?.consecutiveWins).toBe(1);
+
+    const currentWins = await matcher.match(sample(35.05, 139.0, 21_000));
+    expect(currentWins?.challenger).toBeNull();
+
+    const win2 = await matcher.match(sample(35.12, 139.008, 22_000));
+    expect(win2?.challenger?.consecutiveWins).toBe(1);
+    expect(win2?.lockState).toBe('LOCKED');
+  });
+});
+
+describe('review: route health uses real topology and trajectory', () => {
+  it('does not copy heading into trajectory, and penalizes disconnected segment jumps', () => {
+    const observations: RouteObservation[] = [
+      {
+        timestampMs: 1,
+        lineId: LINE.id,
+        segmentId: 'a',
+        routeId: 'route-1',
+        distanceMeters: 12,
+        headingDifferenceDegrees: 10,
+        trajectoryHeadingDifferenceDegrees: 80,
+        trackPositionMeters: 100,
+        stationSequence: 1,
+        previousSegmentIds: [],
+        nextSegmentIds: ['b'],
+      },
+      {
+        timestampMs: 2,
+        lineId: LINE.id,
+        segmentId: 'z',
+        routeId: 'route-1',
+        distanceMeters: 14,
+        headingDifferenceDegrees: 12,
+        trajectoryHeadingDifferenceDegrees: 85,
+        trackPositionMeters: 400,
+        stationSequence: 2,
+        previousSegmentIds: [],
+        nextSegmentIds: [],
+      },
+    ];
+
+    const health = evaluateRouteHealth(observations, null, null, DEFAULT_TRACKING_CONFIG);
+    expect(health.trajectoryConsistency).not.toBe(health.headingConsistency);
+    expect(health.trajectoryConsistency).toBeLessThan(health.headingConsistency);
+    expect(health.topologyConsistency).toBe(0);
+    expect(health.stationSequenceConsistency).toBeGreaterThan(0);
+  });
+});
+
+describe('review: auto-switch stays in REACQUIRING before LOCKED', () => {
+  it('does not fully lock a new route on the same fix that switches', async () => {
+    const other: RailwayLine = { id: 'line-b', operatorId: 'op', name: '在来線B' };
+    const otherSeg: TrackSegment = {
+      id: 'b-1',
+      lineId: other.id,
+      routeId: 'route-b',
+      fromStationId: 'x',
+      toStationId: 'y',
+      coordinates: [
+        [35.05, 139.008],
+        [35.15, 139.008],
+      ],
+      startOffsetMeters: 0,
+    };
+    const db: RailwayDatabaseReader = {
+      async findSegmentsNear() {
+        return [route1, otherSeg];
+      },
+      async getLine(id) {
+        return id === other.id ? other : LINE;
+      },
+    };
+    const matcher = new MapMatcher(db, config({
+      routeSuspiciousMinimumMs: 1000,
+      routeReacquireMinimumMs: 1000,
+      routeChallengerConsecutiveCount: 2,
+      routeChallengerMinimumMs: 1000,
+      routeChallengerMinMargin: 5,
+      routeRelockConsecutiveCount: 3,
+      routeRelockMinimumMs: 2000,
+      routeWindowMinSamples: 2,
+    }));
+    for (let i = 0; i < 4; i++) {
+      await matcher.match(sample(35.04, 139.0, 10_000 + i * 1000));
+    }
+
+    const states: string[] = [];
+    let switchedAt: string | null = null;
+    for (let i = 0; i < 8; i++) {
+      const result = await matcher.match(sample(35.12 + i * 0.005, 139.008, 20_000 + i * 1000));
+      states.push(result?.lockState ?? 'none');
+      if (result?.selectedSegment.id === 'b-1' && switchedAt === null) {
+        switchedAt = result.lockState ?? null;
+      }
+    }
+
+    expect(switchedAt).toBe('REACQUIRING');
+    expect(states).toContain('REACQUIRING');
+  });
+});
+
+describe('review: trajectory heading and lock events', () => {
+  it('uses movement heading when OS speed is missing but the track has moved', () => {
+    const history = [
+      sample(35.0, 139.0, 1_000, { speedMps: null, headingDegrees: null }),
+      sample(35.001, 139.0, 4_000, { speedMps: null, headingDegrees: null }),
+      sample(35.002, 139.0, 7_000, { speedMps: null, headingDegrees: null }),
+    ];
+    const trajectory = computeTrajectory(history, 7_000, DEFAULT_TRACKING_CONFIG);
+    expect(osSpeedStopped(history[2], DEFAULT_TRACKING_CONFIG)).toBeNull();
+    expect(trajectory.reliable).toBe(true);
+    expect(resolveEffectiveHeading(trajectory, history[2], null)).toBe(trajectory.headingDegrees);
+  });
+
+  it('does not treat GPS jitter as a heading while the OS speed says stopped', () => {
+    const history = [
+      sample(35.0, 139.0, 1_000, { speedMps: 0, headingDegrees: 90 }),
+      sample(35.0002, 139.0, 2_000, { speedMps: 0, headingDegrees: 90 }),
+    ];
+    const trajectory = computeTrajectory(history, 2_000, {
+      ...DEFAULT_TRACKING_CONFIG,
+      routeTrajectoryMinDistanceMeters: 5,
+    });
+    const heading = resolveEffectiveHeading(trajectory, history[1], true);
+    expect(heading).toBe(90);
+  });
+
+  it('includes a manual-reacquire event on the next match', async () => {
+    const db = new DualRouteDb([route1]);
+    const matcher = new MapMatcher(db, config());
+    await matcher.match(sample(35.05, 139.0, 1_000));
+    matcher.startManualReacquire(2_000);
+    const next = await matcher.match(sample(35.05, 139.0, 3_000));
+    expect(next?.lockEvents?.some((event) => event.type === 'manual-reacquire')).toBe(true);
+  });
+});
+
+describe('review: window topology is not always 1', () => {
+  it('scores a disconnected jump lower than a continuous segment', () => {
+    const history = [
+      sample(35.05, 139.0, 1_000),
+      sample(35.25, 139.02, 2_000),
+      sample(35.28, 139.02, 3_000),
+    ];
+    const scores = scoreRoutesOverWindow(
+      history,
+      [
+        { routeId: 'route-1', line: LINE, segments: [route1] },
+        { routeId: 'route-2', line: LINE, segments: [route2] },
+      ],
+      DEFAULT_TRACKING_CONFIG
+    );
+    const mixed = scoreRoutesOverWindow(
+      history,
+      [{ routeId: 'mixed', line: LINE, segments: [route1, route2] }],
+      DEFAULT_TRACKING_CONFIG
+    );
+    expect(scores[0].topologyScore).toBeGreaterThan(0);
+    expect(mixed[0].topologyScore).toBeLessThan(1);
+  });
+});

--- a/tests/ui/html.test.ts
+++ b/tests/ui/html.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../../src/ui/html';
+
+describe('escapeHtml', () => {
+  it('escapes markup that would otherwise inject into innerHTML', () => {
+    expect(escapeHtml(`<img src=x onerror="alert(1)"> JR&"中央"`)).toBe(
+      '&lt;img src=x onerror=&quot;alert(1)&quot;&gt; JR&amp;&quot;中央&quot;'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Even G2 testing around Asakusabashi locked RailGlance onto the Tohoku Shinkansen and kept that wrong line through Akihabara. The matcher adopted the first GPS fix immediately, then compared a fresh challenger against a stale current-route score and kept paying continuity bonus to the wrong segment.

This implements `docs/ROUTE_MATCHING_RELIABILITY_SPEC.md`:

- Conservative lock states: `UNRESOLVED` → `LOCKED` → `SUSPICIOUS` → `REACQUIRING`, plus `MANUAL_LOCK`
- Rescore the current route on every GPS fix before any switch decision
- Require score margin, persistence, and time before the first lock
- Topology-based continuity, trajectory heading, and accuracy-normalized distance
- Route health + challenger tracking; auto-switch only when contradiction, challenger superiority, and persistence all agree
- Phone-only “路線を再検出” / candidate pick / “自動判定に戻す”, without stopping the speed display
- Debug panel and diagnostic telemetry for lock state, health, challenger, and rescored scores

Review follow-up (second commit):

- Keep `MANUAL_LOCK` on the selected `routeId`; do not fall back to another route on the same line
- Project the locked segment when it leaves the search radius so `manualLockAway` still updates
- Use sliding-window scores on manual reacquire instead of first-lock scoring
- Count challenger wins only when they are consecutive
- Separate trajectory, heading, topology, and station sequence in route health
- Confirm a newly switched route for several fixes before `LOCKED`
- Treat missing OS speed as unknown, not 0 km/h
- Drain pre-queued lock events (`manual-reacquire` / lock / unlock) on the next match

## Test plan

- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test` (211 passing), including:
  - initial lock / close-race unresolved
  - current-route rescore and search-radius loss
  - continuity ranking and state-scaled bias
  - challenger persistence without flicker
  - conservative auto-switch, with a confirm window after the switch
  - manual reacquire / lock / unlock
  - Asakusabashi → Akihabara fixture (no instant Shinkansen lock, recovery from a wrong lock, stable Sobu lock, Tokyo–Ueno Shinkansen still locks)
  - review regressions: same-line different route under `MANUAL_LOCK`, consecutive challenger wins, window scoring on reacquire, lock-event drain
- [ ] Real-device ride: Asakusabashi → Akihabara on Chuo-Sobu local
- [ ] Confirm a Tokyo–Ueno Shinkansen run still locks correctly
- [ ] Tap 路線を再検出 on the phone and confirm speed keeps updating