### PR TITLE
Reduce HUD update latency

### DIFF
--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -94,8 +94,13 @@ export class AppController {
   private renderTimerId: any = null;
   private isRunning = false;
   private isConnectingEvenG2 = false;
-  private renderTickInFlight = false;
-  private renderTickPending = false;
+
+  // Serializes estimator mutations that can overlap: real GPS fixes, manual
+  // reacquire/lock/unlock reprocessing, and the periodic DR/staleness tick.
+  // The tail never rejects so one failure cannot poison later work.
+  private estimationWork: Promise<void> = Promise.resolve();
+  // Coalesce periodic ticks so they cannot backlog behind slow GPS work.
+  private estimatorTickQueued = false;
 
   // Location provider lifecycle serialization.
   // - `locationLifecycle` is a never-rejecting tail promise used as a FIFO queue so that
@@ -172,31 +177,40 @@ export class AppController {
   }
 
   public async startManualReacquire(): Promise<void> {
-    this.mapMatcher.startManualReacquire(Date.now());
-    this.journeyEstimator.invalidateRoute();
-    this.speedEstimator.getNavStateEstimator().clearRoute();
-    if (this.latestSample) {
-      await this.onLocationUpdate(this.latestSample);
-    }
+    await this.enqueueEstimationWork(async () => {
+      this.mapMatcher.startManualReacquire(Date.now());
+      this.journeyEstimator.invalidateRoute();
+      this.speedEstimator.getNavStateEstimator().clearRoute();
+      if (this.latestSample) {
+        // Call the internal processor directly: enqueueing public onLocationUpdate
+        // from queued work would deadlock on this same FIFO.
+        await this.processLocationUpdate(this.latestSample, this.locationGeneration);
+      }
+    });
   }
 
   public async lockSelectedRoute(segmentId: string): Promise<boolean> {
-    const locked = this.mapMatcher.lockSelectedRoute(segmentId, Date.now());
-    if (!locked) return false;
-    if (this.latestSample) {
-      await this.onLocationUpdate(this.latestSample);
-    }
-    return true;
+    let locked = false;
+    await this.enqueueEstimationWork(async () => {
+      locked = this.mapMatcher.lockSelectedRoute(segmentId, Date.now());
+      if (!locked) return;
+      if (this.latestSample) {
+        await this.processLocationUpdate(this.latestSample, this.locationGeneration);
+      }
+    });
+    return locked;
   }
 
   public async unlockManualRoute(): Promise<void> {
-    this.mapMatcher.unlockManualRoute(Date.now());
-    this.journeyEstimator.invalidateRoute();
-    this.speedEstimator.getNavStateEstimator().clearRoute();
-    this.currentMatch = null;
-    if (this.latestSample) {
-      await this.onLocationUpdate(this.latestSample);
-    }
+    await this.enqueueEstimationWork(async () => {
+      this.mapMatcher.unlockManualRoute(Date.now());
+      this.journeyEstimator.invalidateRoute();
+      this.speedEstimator.getNavStateEstimator().clearRoute();
+      this.currentMatch = null;
+      if (this.latestSample) {
+        await this.processLocationUpdate(this.latestSample, this.locationGeneration);
+      }
+    });
   }
 
   public getCurrentRouteMatch(): RouteMatch | null {
@@ -207,9 +221,10 @@ export class AppController {
     if (this.isRunning) return;
     this.isRunning = true;
 
-    // 1. Immediately start HUD render timer (Web Viewport DOM / Local Preview)
+    // Periodic estimator tick for dead-reckoning, staleness, and GPS-loss.
+    // HUD snapshots after a real GPS fix are published immediately, not here.
     this.renderTimerId = setInterval(() => {
-      void this.runRenderTick();
+      this.scheduleEstimatorTick();
     }, this.config.hudRefreshMs);
 
     // 2. Connect Even G2 in background with persistent auto-reconnect
@@ -294,7 +309,16 @@ export class AppController {
     // dropped even before its stop() resolves.
     this.locationGeneration++;
     this.locationProvider = newProvider;
+    // Clear the visible/controller state synchronously for the switch contract.
+    // A second reset is queued below so any matcher mutation that is still in
+    // flight cannot leak into the new provider's state.
     this.resetEstimationState();
+    // Queue the reset behind any in-flight match, but do not make the provider
+    // lifecycle wait for it: callers may need to complete the switch while the
+    // outgoing provider's current match is still awaiting an external result.
+    void this.enqueueEstimationWork(async () => {
+      this.resetEstimationState();
+    });
 
     return this.enqueueLocationLifecycle(async () => {
       await this.deactivateLocationProvider();
@@ -389,7 +413,9 @@ export class AppController {
       this.locationGeneration++;
       this.activeLocationProvider = null;
       await this.stopProviderSafely(provider);
-      this.resetEstimationState();
+      await this.enqueueEstimationWork(async () => {
+        this.resetEstimationState();
+      });
       this.onLocationError(this.toLocationProviderError(error));
     }
   }
@@ -432,6 +458,19 @@ export class AppController {
   }
 
   /**
+   * FIFO for estimator mutations. Real GPS fixes are never coalesced: PR #42
+   * route-lock uses consecutive counts and fix history, so every sample must run.
+   */
+  private enqueueEstimationWork(task: () => Promise<void>): Promise<void> {
+    const run = this.estimationWork.then(task);
+    this.estimationWork = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  /**
    * Processes one location sample. Results are computed into locals and only committed
    * while the sample's provider generation is still the current one: a switch/stop that
    * lands while map matching or journey estimation is awaited must not be able to write
@@ -443,7 +482,14 @@ export class AppController {
   public async onLocationUpdate(sample: LocationSample): Promise<void> {
     // Captured synchronously at invocation: the provider callback checks the generation
     // and calls this in the same synchronous block, so both observe the same value.
+    // The queued processor must keep this snapshot — capturing again when the task
+    // starts would treat a sample that queued across a switch as live.
     const generation = this.locationGeneration;
+    return this.enqueueEstimationWork(() => this.processLocationUpdate(sample, generation));
+  }
+
+  private async processLocationUpdate(sample: LocationSample, generation: number): Promise<void> {
+    if (generation !== this.locationGeneration) return;
 
     // Safe to publish immediately: this runs before any await, so a later switch's
     // resetEstimationState() clears it rather than being overwritten by it. Keeping it
@@ -503,6 +549,39 @@ export class AppController {
     this.speedEstimator.getNavStateEstimator().setDirection(
       this.toNavigationDirection(this.currentJourney.direction)
     );
+    this.publishHudSnapshot();
+  }
+
+  /**
+   * Pure HUD publish from already-committed estimator state. Must not rematch,
+   * re-estimate speed, or re-estimate journey — those belong to the GPS path
+   * and the periodic tick only.
+   */
+  private publishHudSnapshot(nowMs = Date.now()): void {
+    this.currentViewModel = this.hudRenderer.createViewModel(
+      this.currentFullSpeedState,
+      this.currentJourney,
+      nowMs
+    );
+
+    // render() is non-blocking for Glass BLE (coalesced flush). Do not let a
+    // slow/hung bridge transfer stall the AppController estimation loop.
+    void Promise.resolve(this.evenG2Adapter.render(this.currentViewModel)).catch((error) => {
+      console.warn('[AppController] Even G2 render notice:', error);
+      captureRuntimeError(error, 'even-g2-render');
+    });
+
+    const logEntry: EstimationLogEntry = {
+      timestampMs: nowMs,
+      rawLocation: this.latestSample,
+      speedState: this.currentFullSpeedState,
+      match: this.currentMatch,
+      journey: this.currentJourney,
+      hudViewModel: this.currentViewModel,
+      bridgeConnected: this.evenG2Adapter.isBridgeConnected?.() ?? false,
+      lastImageResult: this.evenG2Adapter.getLastImageResult(),
+    };
+    this.logger.log(logEntry);
   }
 
   private onLocationError(err: { code?: number; message: string }): void {
@@ -510,23 +589,20 @@ export class AppController {
     captureRuntimeError(new Error(err.message), 'geolocation', { code: err.code ?? null });
   }
 
-  private async runRenderTick(): Promise<void> {
-    if (!this.isRunning) return;
-    if (this.renderTickInFlight) {
-      this.renderTickPending = true;
-      return;
-    }
-    this.renderTickInFlight = true;
-    this.renderTickPending = false;
-    try {
-      await this.onRenderTick();
-    } catch (error) {
-      console.warn('[AppController] HUD render tick failed:', error);
-      captureRuntimeError(error, 'hud-render-tick');
-    } finally {
-      this.renderTickInFlight = false;
-      if (this.renderTickPending && this.isRunning) void this.runRenderTick();
-    }
+  private scheduleEstimatorTick(): void {
+    if (!this.isRunning || this.estimatorTickQueued) return;
+    this.estimatorTickQueued = true;
+    void this.enqueueEstimationWork(async () => {
+      try {
+        if (!this.isRunning) return;
+        await this.onRenderTick();
+      } catch (error) {
+        console.warn('[AppController] HUD render tick failed:', error);
+        captureRuntimeError(error, 'hud-render-tick');
+      } finally {
+        this.estimatorTickQueued = false;
+      }
+    });
   }
 
   private async onRenderTick(): Promise<void> {
@@ -560,30 +636,7 @@ export class AppController {
       this.currentJourney.status = 'GPS_UNAVAILABLE';
     }
 
-    this.currentViewModel = this.hudRenderer.createViewModel(
-      this.currentFullSpeedState,
-      this.currentJourney,
-      now
-    );
-
-    // render() is non-blocking for Glass BLE (coalesced flush). Do not let a
-    // slow/hung bridge transfer stall the AppController render loop.
-    void this.evenG2Adapter.render(this.currentViewModel).catch((error) => {
-      console.warn('[AppController] Even G2 render notice:', error);
-      captureRuntimeError(error, 'even-g2-render');
-    });
-
-    const logEntry: EstimationLogEntry = {
-      timestampMs: now,
-      rawLocation: this.latestSample,
-      speedState: this.currentFullSpeedState,
-      match: this.currentMatch,
-      journey: this.currentJourney,
-      hudViewModel: this.currentViewModel,
-      bridgeConnected: this.evenG2Adapter.isBridgeConnected?.() ?? false,
-      lastImageResult: this.evenG2Adapter.getLastImageResult(),
-    };
-    this.logger.log(logEntry);
+    this.publishHudSnapshot(now);
   }
 
   private toNavigationDirection(direction: JourneyState['direction']): 'UP' | 'DOWN' | 'UNKNOWN' {

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -309,10 +309,9 @@ export class AppController {
     // dropped even before its stop() resolves.
     this.locationGeneration++;
     this.locationProvider = newProvider;
-    // Clear the visible/controller state synchronously for the switch contract.
-    // A second reset is queued below so any matcher mutation that is still in
-    // flight cannot leak into the new provider's state.
-    this.resetEstimationState();
+    // Clear only controller-visible state synchronously. Estimator internals may
+    // still be in an async match/update and are reset below, behind that work.
+    this.clearControllerEstimationState();
     // Queue the reset behind any in-flight match, but do not make the provider
     // lifecycle wait for it: callers may need to complete the switch while the
     // outgoing provider's current match is still awaiting an external result.
@@ -449,6 +448,10 @@ export class AppController {
     this.speedEstimator.reset();
     this.journeyEstimator.reset();
     this.mapMatcher.reset();
+    this.clearControllerEstimationState();
+  }
+
+  private clearControllerEstimationState(): void {
     this.latestSample = null;
     this.currentMatch = null;
   }

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -77,8 +77,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
   private lastRenderedSpeedKmh: number | null = null;
   private lastRenderedIsEstimated = false;
-  private lastImageUpdateTimeMs = 0;
-  private readonly SPEED_IMAGE_MIN_INTERVAL_MS = 1000;
+  private lastStatusMode: HudViewModel['statusMode'] | null = null;
   private latestRequestedSpeedKmh: number | null = null;
   private latestRequestedIsEstimated = false;
   private lastModel: HudViewModel | null = null;
@@ -198,7 +197,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         this.lastFooterContent = '';
         this.lastRenderedSpeedKmh = null;
         this.lastRenderedIsEstimated = false;
-        this.lastImageUpdateTimeMs = 0;
+        this.lastStatusMode = null;
         this.flushedGeneration = 0;
         this.pageReady = true;
         this.isConnected = true;
@@ -272,20 +271,11 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
       const generationAtStart = this.renderGeneration;
       const model = this.lastModel;
+      const completed = await this.flushHudModel(model, generationAtStart);
 
-      await this.pushTextContainers(model);
-
-      const rawSpeedVal =
-        model.speed.displaySpeedKmhText === '--' ? null : parseInt(model.speed.displaySpeedKmhText, 10);
-      const speedKmh = isNaN(rawSpeedVal as any) ? null : rawSpeedVal;
-      const isEstimated = model.speed.isEstimated;
-      const now = Date.now();
-      const isSpeedChanged =
-        speedKmh !== this.lastRenderedSpeedKmh || isEstimated !== this.lastRenderedIsEstimated;
-      const isTimeElapsed = now - this.lastImageUpdateTimeMs >= this.SPEED_IMAGE_MIN_INTERVAL_MS;
-
-      if (isSpeedChanged && isTimeElapsed) {
-        await this.pushSpeedImage(speedKmh, isEstimated, false);
+      if (!completed) {
+        if (this.isConnected && this.pageReady) this.queueHudFlush();
+        return;
       }
 
       this.flushedGeneration = generationAtStart;
@@ -300,9 +290,51 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     });
   }
 
-  private async pushTextContainers(model: HudViewModel): Promise<void> {
-    if (!this.bridge || !this.pageReady) return;
+  /**
+   * Apply one HUD model as a sequence of native calls. Returns false when a
+   * newer render generation arrived at a safe await boundary so remaining
+   * stale fields must be abandoned.
+   */
+  private async flushHudModel(model: HudViewModel, generationAtStart: number): Promise<boolean> {
+    const texts = this.buildHudTextContents(model);
+    const { speedKmh, isEstimated } = this.parseHudSpeed(model);
+    const routeStatusCritical =
+      texts.headerContent !== this.lastHeaderContent || model.statusMode !== this.lastStatusMode;
 
+    const sendHeader = () => this.pushTextField(1, 'header', texts.headerContent, 'lastHeaderContent');
+    const sendFooter = () => this.pushTextField(4, 'footer', texts.footerContent, 'lastFooterContent');
+    const sendSegment = () => this.pushTextField(3, 'segment', texts.segmentContent, 'lastSegmentContent');
+    const sendSpeed = () => this.pushSpeedImage(speedKmh, isEstimated, false);
+
+    // Route/status-critical frames must not leave an old line/status visible
+    // while the speed image of the new frame is transferring.
+    const ops = routeStatusCritical
+      ? [sendHeader, sendFooter, sendSegment, sendSpeed]
+      : [sendSpeed, sendHeader, sendSegment, sendFooter];
+
+    for (const op of ops) {
+      if (!this.isFlushGenerationCurrent(generationAtStart)) return false;
+      await op();
+    }
+    if (!this.isFlushGenerationCurrent(generationAtStart)) return false;
+    if (
+      texts.headerContent === this.lastHeaderContent &&
+      texts.footerContent === this.lastFooterContent
+    ) {
+      this.lastStatusMode = model.statusMode;
+    }
+    return true;
+  }
+
+  private isFlushGenerationCurrent(generationAtStart: number): boolean {
+    return this.renderGeneration === generationAtStart && this.isConnected && this.pageReady;
+  }
+
+  private buildHudTextContents(model: HudViewModel): {
+    headerContent: string;
+    segmentContent: string;
+    footerContent: string;
+  } {
     const headerContent = `${model.header.lineName}               ${model.header.serviceOrDirection}`;
 
     let progressBarStr = '━━━━━━━━━━━━';
@@ -318,53 +350,37 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
     const segmentContent = `${model.segment.previousStationName} ${progressBarStr} ${model.segment.nextStationName}`;
     const footerContent = `${model.segment.distanceToNextText}               ${model.footer.statusRight}`;
+    return { headerContent, segmentContent, footerContent };
+  }
 
-    if (headerContent !== this.lastHeaderContent) {
-      try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 1, containerName: 'header', content: headerContent })
-        );
-        if (updated === false) {
-          console.warn('[EvenG2Adapter] header textContainerUpgrade returned false (will retry)');
-        } else {
-          this.lastHeaderContent = headerContent;
-        }
-      } catch (error) {
-        console.warn('[EvenG2Adapter] header textContainerUpgrade error:', error);
-        captureRuntimeError(error, 'even-g2-text-update', { container: 'header' });
-      }
-    }
+  private parseHudSpeed(model: HudViewModel): { speedKmh: number | null; isEstimated: boolean } {
+    const rawSpeedVal =
+      model.speed.displaySpeedKmhText === '--' ? null : parseInt(model.speed.displaySpeedKmhText, 10);
+    const speedKmh = isNaN(rawSpeedVal as any) ? null : rawSpeedVal;
+    return { speedKmh, isEstimated: model.speed.isEstimated };
+  }
 
-    if (segmentContent !== this.lastSegmentContent) {
-      try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 3, containerName: 'segment', content: segmentContent })
-        );
-        if (updated === false) {
-          console.warn('[EvenG2Adapter] segment textContainerUpgrade returned false (will retry)');
-        } else {
-          this.lastSegmentContent = segmentContent;
-        }
-      } catch (error) {
-        console.warn('[EvenG2Adapter] segment textContainerUpgrade error:', error);
-        captureRuntimeError(error, 'even-g2-text-update', { container: 'segment' });
-      }
-    }
+  private async pushTextField(
+    containerID: number,
+    containerName: 'header' | 'segment' | 'footer',
+    content: string,
+    cacheKey: 'lastHeaderContent' | 'lastSegmentContent' | 'lastFooterContent'
+  ): Promise<void> {
+    if (!this.bridge || !this.pageReady) return;
+    if (content === this[cacheKey]) return;
 
-    if (footerContent !== this.lastFooterContent) {
-      try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 4, containerName: 'footer', content: footerContent })
-        );
-        if (updated === false) {
-          console.warn('[EvenG2Adapter] footer textContainerUpgrade returned false (will retry)');
-        } else {
-          this.lastFooterContent = footerContent;
-        }
-      } catch (error) {
-        console.warn('[EvenG2Adapter] footer textContainerUpgrade error:', error);
-        captureRuntimeError(error, 'even-g2-text-update', { container: 'footer' });
+    try {
+      const updated = await this.bridge.textContainerUpgrade(
+        new TextContainerUpgrade({ containerID, containerName, content })
+      );
+      if (updated === false) {
+        console.warn(`[EvenG2Adapter] ${containerName} textContainerUpgrade returned false (will retry)`);
+      } else {
+        this[cacheKey] = content;
       }
+    } catch (error) {
+      console.warn(`[EvenG2Adapter] ${containerName} textContainerUpgrade error:`, error);
+      captureRuntimeError(error, 'even-g2-text-update', { container: containerName });
     }
   }
 
@@ -407,7 +423,6 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
       if (ImageRawDataUpdateResult.isSuccess(result)) {
         this.lastRenderedSpeedKmh = speedKmh;
         this.lastRenderedIsEstimated = isEstimated;
-        this.lastImageUpdateTimeMs = Date.now();
       } else {
         console.warn('[EvenG2Adapter] Speed image update non-success result:', resultStr);
       }
@@ -553,6 +568,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         this.lastFooterContent = '';
         this.lastRenderedSpeedKmh = null;
         this.lastRenderedIsEstimated = false;
+        this.lastStatusMode = null;
         this.flushedGeneration = 0;
         this.pageReady = true;
         this.isConnected = true;

--- a/tests/app/app-controller-hud-latency.test.ts
+++ b/tests/app/app-controller-hud-latency.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppController } from '../../src/app/app-controller';
+import { DEFAULT_TRACKING_CONFIG } from '../../src/config/tracking-config';
+import { RailwayDataRepository } from '../../src/domain/railway/repository';
+import { JourneyState, RailwayLine, RouteMatch, Station, TrackSegment } from '../../src/domain/models/railway';
+import { LocationSample } from '../../src/domain/models/location';
+import { EstimationLogger } from '../../src/infrastructure/logging/logger';
+
+const line: RailwayLine = { id: 'line', operatorId: 'op', name: 'Test Line' };
+const stations: Station[] = [
+  { id: 'a', lineId: 'line', name: 'A', sequence: 1, latitude: 35, longitude: 139 },
+  { id: 'b', lineId: 'line', name: 'B', sequence: 2, latitude: 35.01, longitude: 139 },
+];
+const segment: TrackSegment = {
+  id: 'ab', lineId: 'line', routeId: 'route-line-main', fromStationId: 'a', toStationId: 'b',
+  coordinates: [[35, 139], [35.01, 139]], lengthMeters: 1112, startOffsetMeters: 0,
+};
+const routeMatch: RouteMatch = {
+  selectedLine: line, selectedSegment: segment, confidence: 0.9, candidates: [], timestampMs: 0,
+};
+
+const idleJourney: JourneyState = {
+  line: null,
+  direction: 'UNKNOWN',
+  directionName: null,
+  previousStation: null,
+  nextStation: null,
+  distanceToNextStationMeters: null,
+  progressRatio: null,
+  confidence: 0,
+  status: 'INITIALIZING',
+};
+
+const repository: RailwayDataRepository = {
+  ensureCoverageAround: async () => ({ state: 'bundled', loadedTileCount: 0 }),
+  findSegmentsNear: async () => [segment],
+  getLine: async () => line,
+  getRoute: async () => undefined,
+  getStation: async (id) => stations.find((station) => station.id === id),
+  getStationsByLine: async () => stations,
+  getSegmentsByRoute: async () => [segment],
+  getDataState: () => 'bundled',
+};
+
+function sample(timestampMs: number): LocationSample {
+  return {
+    latitude: 35.005,
+    longitude: 139,
+    accuracyMeters: 5,
+    speedMps: 10,
+    headingDegrees: 0,
+    timestampMs,
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createController(overrides: {
+  mapMatcher?: { match: ReturnType<typeof vi.fn>; reset: ReturnType<typeof vi.fn> };
+  journeyEstimator?: {
+    update: ReturnType<typeof vi.fn>;
+    reset: ReturnType<typeof vi.fn>;
+    invalidateRoute?: ReturnType<typeof vi.fn>;
+  };
+  hudRefreshMs?: number;
+} = {}) {
+  const mapMatcher = overrides.mapMatcher ?? {
+    match: vi.fn().mockResolvedValue(routeMatch),
+    reset: vi.fn(),
+  };
+  const journeyEstimator = overrides.journeyEstimator ?? {
+    update: vi.fn().mockResolvedValue(idleJourney),
+    reset: vi.fn(),
+    invalidateRoute: vi.fn(),
+  };
+  const evenG2Adapter = {
+    connect: async () => true,
+    render: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    getLastImageResult: () => 'none',
+  };
+  const logger = new EstimationLogger();
+  const controller = new AppController(
+    { start: vi.fn(), stop: vi.fn() },
+    mapMatcher as any,
+    journeyEstimator as any,
+    repository,
+    evenG2Adapter,
+    logger,
+    { ...DEFAULT_TRACKING_CONFIG, hudRefreshMs: overrides.hudRefreshMs ?? 1_000_000 }
+  );
+  return { controller, mapMatcher, journeyEstimator, evenG2Adapter, logger };
+}
+
+describe('AppController HUD latency', () => {
+  it('publishes a committed location update immediately even when hudRefreshMs is very large', async () => {
+    const { controller, evenG2Adapter, logger } = createController({ hudRefreshMs: 1_000_000 });
+    const logSpy = vi.spyOn(logger, 'log');
+
+    await controller.onLocationUpdate(sample(1_000));
+
+    expect(evenG2Adapter.render).toHaveBeenCalledTimes(1);
+    expect(evenG2Adapter.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timestampMs: expect.any(Number),
+        speed: expect.objectContaining({ displaySpeedKmhText: expect.any(String) }),
+      })
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawLocation: expect.objectContaining({ timestampMs: 1_000 }),
+        hudViewModel: expect.objectContaining({ timestampMs: expect.any(Number) }),
+      })
+    );
+  });
+
+  it('does not rematch or re-estimate journey when publishing the HUD after a location update', async () => {
+    const mapMatcher = { match: vi.fn().mockResolvedValue(routeMatch), reset: vi.fn() };
+    const journeyEstimator = {
+      update: vi.fn().mockResolvedValue(idleJourney),
+      reset: vi.fn(),
+      invalidateRoute: vi.fn(),
+    };
+    const { controller } = createController({ mapMatcher, journeyEstimator });
+
+    await controller.onLocationUpdate(sample(1_000));
+
+    expect(mapMatcher.match).toHaveBeenCalledTimes(1);
+    expect(journeyEstimator.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes overlapping real GPS updates and processes each fix once', async () => {
+    const resolvers: Array<(value: RouteMatch | null) => void> = [];
+    const mapMatcher = {
+      match: vi.fn().mockImplementation(
+        () =>
+          new Promise<RouteMatch | null>((resolve) => {
+            resolvers.push(resolve);
+          })
+      ),
+      reset: vi.fn(),
+    };
+    const journeyEstimator = {
+      update: vi.fn().mockResolvedValue(idleJourney),
+      reset: vi.fn(),
+      invalidateRoute: vi.fn(),
+    };
+    const { controller } = createController({ mapMatcher, journeyEstimator });
+
+    const first = controller.onLocationUpdate(sample(1_000));
+    const second = controller.onLocationUpdate(sample(2_000));
+    await flush();
+
+    expect(mapMatcher.match).toHaveBeenCalledTimes(1);
+    expect(mapMatcher.match).toHaveBeenCalledWith(expect.objectContaining({ timestampMs: 1_000 }));
+    expect(resolvers).toHaveLength(1);
+
+    resolvers[0](routeMatch);
+    await flush();
+
+    expect(mapMatcher.match).toHaveBeenCalledTimes(2);
+    expect(mapMatcher.match).toHaveBeenCalledWith(expect.objectContaining({ timestampMs: 2_000 }));
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[1](routeMatch);
+    await Promise.all([first, second]);
+
+    expect(mapMatcher.match).toHaveBeenCalledTimes(2);
+    expect(journeyEstimator.update).toHaveBeenCalledTimes(2);
+    expect((controller as any).latestSample?.timestampMs).toBe(2_000);
+  });
+});

--- a/tests/app/app-controller-provider-lifecycle.test.ts
+++ b/tests/app/app-controller-provider-lifecycle.test.ts
@@ -240,12 +240,15 @@ describe('AppController location provider lifecycle', () => {
     expect((controller as any).currentMatch).toBeNull();
 
     await controller.switchLocationProvider(replacement);
-    expect(mapMatcher.reset).toHaveBeenCalled();
+    // The visible state is cleared immediately, while matcher reset waits for
+    // the in-flight match to finish so it cannot mutate matcher state mid-call.
+    expect(mapMatcher.reset).not.toHaveBeenCalled();
     expect((controller as any).currentMatch).toBeNull();
 
     // Map matching for the stale sample completes only now, after the switch.
     resolveMatch(routeMatch);
     await flush();
+    expect(mapMatcher.reset).toHaveBeenCalled();
 
     // It must not resurrect state the switch just cleared, nor feed the (already reset)
     // estimators with the outgoing provider's sample.

--- a/tests/even-g2/even-g2-adapter.test.ts
+++ b/tests/even-g2/even-g2-adapter.test.ts
@@ -42,18 +42,27 @@ vi.mock('../../src/infrastructure/even-g2/speed-png-generator', () => ({
 
 import { HybridEvenG2Adapter } from '../../src/infrastructure/even-g2/even-g2-adapter';
 
-function viewModel(speed: string, lineName = '小田急線'): HudViewModel {
+function viewModel(
+  speed: string,
+  lineName = '小田急線',
+  extras: {
+    nextStationName?: string;
+    distanceToNextText?: string;
+    statusMode?: HudViewModel['statusMode'];
+    statusRight?: string;
+  } = {}
+): HudViewModel {
   return {
     header: { lineName, serviceOrDirection: '上り' },
     speed: { displaySpeedKmhText: speed, unitText: 'km/h', isEstimated: false },
     segment: {
       previousStationName: '海老名',
-      nextStationName: '座間',
+      nextStationName: extras.nextStationName ?? '座間',
       progressRatio: 0.5,
-      distanceToNextText: '次まで 1km',
+      distanceToNextText: extras.distanceToNextText ?? '次まで 1km',
     },
-    footer: { leftInfo: '上り', statusRight: 'GPS' },
-    statusMode: 'GPS',
+    footer: { leftInfo: '上り', statusRight: extras.statusRight ?? 'GPS' },
+    statusMode: extras.statusMode ?? 'GPS',
     rawFormattedText: speed,
     timestampMs: 1000,
   };
@@ -227,5 +236,107 @@ describe('HybridEvenG2Adapter', () => {
     hubEvent?.({ sysEvent: { eventType: 7 } });
     await expect(disconnected).resolves.toBeUndefined();
     expect(adapter.isBridgeConnected()).toBe(false);
+  });
+
+  it('does not skip a speed image just because the previous image completed less than 1000ms ago', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    await adapter.connect();
+    const afterConnect = sdk.bridge.updateImageRawData.mock.calls.length;
+
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+    await adapter.render(viewModel('81'));
+    await flushBridge();
+
+    expect(sdk.bridge.updateImageRawData.mock.calls.length).toBe(afterConnect + 2);
+  });
+
+  it('sends a normal speed change ahead of lower-priority station and distance text', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    await adapter.connect();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    const order: string[] = [];
+    sdk.bridge.updateImageRawData.mockImplementation(async () => {
+      order.push('speed');
+      return 'success';
+    });
+    sdk.bridge.textContainerUpgrade.mockImplementation(async (update) => {
+      order.push(update.containerName);
+      return true;
+    });
+
+    await adapter.render(viewModel('81', '小田急線', {
+      nextStationName: '本厚木',
+      distanceToNextText: '次まで 2km',
+    }));
+    await flushBridge();
+
+    expect(order).toContain('speed');
+    expect(order).toContain('segment');
+    expect(order.indexOf('speed')).toBeLessThan(order.indexOf('segment'));
+    expect(order.indexOf('speed')).toBeLessThan(order.indexOf('footer'));
+  });
+
+  it('sends route/status text before speed when header or statusMode changes', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    await adapter.connect();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    const order: string[] = [];
+    sdk.bridge.updateImageRawData.mockImplementation(async () => {
+      order.push('speed');
+      return 'success';
+    });
+    sdk.bridge.textContainerUpgrade.mockImplementation(async (update) => {
+      order.push(update.containerName);
+      return true;
+    });
+
+    await adapter.render(viewModel('81', '路線判定中', {
+      statusMode: 'UNCERTAIN',
+      statusRight: '判定中',
+    }));
+    await flushBridge();
+
+    expect(order[0]).toBe('header');
+    expect(order).toContain('speed');
+    expect(order.indexOf('header')).toBeLessThan(order.indexOf('speed'));
+    expect(order.indexOf('footer')).toBeLessThan(order.indexOf('speed'));
+  });
+
+  it('abandons remaining stale fields when a newer render arrives mid-flush and then sends the latest model', async () => {
+    const adapter = new HybridEvenG2Adapter();
+    await adapter.connect();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    let releaseSpeed!: (value: string) => void;
+    sdk.bridge.updateImageRawData.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { releaseSpeed = resolve; })
+    );
+
+    await adapter.render(viewModel('10', '小田急線', { nextStationName: '本厚木' }));
+    await flushBridge();
+    expect(releaseSpeed).toBeTypeOf('function');
+
+    const segmentContents: string[] = [];
+    sdk.bridge.textContainerUpgrade.mockImplementation(async (update) => {
+      if (update.containerName === 'segment') {
+        segmentContents.push(update.content);
+      }
+      return true;
+    });
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+
+    await adapter.render(viewModel('99', '小田急線', { nextStationName: '新宿' }));
+    releaseSpeed('success');
+    await flushBridge();
+    await flushBridge();
+
+    expect(segmentContents.some((content) => content.includes('本厚木'))).toBe(false);
+    expect(segmentContents.some((content) => content.includes('新宿'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Publish HUD updates immediately after a committed GPS estimation instead of waiting for the periodic render tick.
- Serialize GPS, manual route operations, and dead-reckoning ticks so PR #42 route-lock history remains consistent.
- Make Even G2 text/image flushing latest-wins and prioritize route/status-critical text without the independent 1s speed-image gate.

## Validation
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test` (31 files, 208 tests)
- `pnpm build`

Stacked on PR #42 (`feature/railglance-route-misclassification-recovery`).