### PR TITLE
fix: R2 manifest debug status badge and add fetch-step diagnostics (#44)

### DIFF
--- a/src/infrastructure/storage/dexie-railway-database.ts
+++ b/src/infrastructure/storage/dexie-railway-database.ts
@@ -16,6 +16,8 @@ import sampleTrackSegments from '../../data/sample/track-segments.json';
 import sampleMetadata from '../../data/sample/metadata.json';
 import { addRuntimeBreadcrumb, captureRuntimeError } from '../observability/sentry';
 
+export type FetchStepStatus = 'ok' | 'failed' | number;
+
 export type DatasetSyncStatus = {
   status: RailwayDataState;
   version?: string;
@@ -26,6 +28,12 @@ export type DatasetSyncStatus = {
   totalLines?: number;
   totalStations?: number;
   errorMessage?: string;
+  manifestUrl?: string;
+  latestFetchStatus?: FetchStepStatus;
+  manifestFetchStatus?: FetchStepStatus;
+  lastTileUrl?: string;
+  lastTileFetchStatus?: FetchStepStatus;
+  lastSuccessfulFetchAtMs?: number;
 };
 
 export type DexieRailwayDatabaseOptions = {
@@ -124,27 +132,19 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
       console.log('[H3 Tile Streamer] VITE_RAILWAY_DATA_BASE_URL detected:', this.activeBaseUrl);
       this.connectRemoteManifest(this.activeBaseUrl).catch((err) => {
         console.warn('[H3 Tile Streamer Error]:', err);
-        this.currentState = 'bundled';
-        this.syncStatus = {
-          status: 'bundled',
-          baseUrl: this.activeBaseUrl,
-          version: sampleMetadata.version,
-          schemaVersion: targetSchemaVersion,
-          errorMessage: err instanceof Error ? err.message : String(err),
-        };
         captureRuntimeError(err, 'dataset-manifest-fetch', { baseUrl: this.activeBaseUrl });
         addRuntimeBreadcrumb('railglance.dataset', 'Dataset manifest fetch failed', {}, 'warning');
       });
     } else {
       this.currentState = 'bundled';
-      this.syncStatus = {
+      this.updateSyncStatus({
         status: 'bundled',
         version: sampleMetadata.version,
         schemaVersion: targetSchemaVersion,
         loadedTileCount: 0,
         totalLines: await this.lines.count(),
         totalStations: await this.stations.count(),
-      };
+      });
     }
   }
 
@@ -152,20 +152,24 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
     this.activeBaseUrl = baseUrl.replace(/\/+$/, '');
     baseUrl = this.activeBaseUrl;
     this.currentState = 'downloading';
-    this.syncStatus = {
+    this.updateSyncStatus({
       status: 'downloading',
       baseUrl,
       version: 'Checking Manifest...',
-    };
+    });
 
     try {
-      const latestRes = await fetch(`${baseUrl}/datasets/latest.json`, { mode: 'cors' });
+      const latestRes = await this.fetchWithStatus(
+        `${baseUrl}/datasets/latest.json`,
+        'latestFetchStatus'
+      );
       if (!latestRes.ok) throw new Error(`HTTP ${latestRes.status} on latest.json`);
       const latestInfo = parseLatestDatasetPointer(await latestRes.json());
       this.activeVersion = latestInfo.version;
 
       const manifestUrl = `${baseUrl}${latestInfo.manifestUrl}`;
-      const manifestRes = await fetch(manifestUrl, { mode: 'cors' });
+      this.updateSyncStatus({ manifestUrl });
+      const manifestRes = await this.fetchWithStatus(manifestUrl, 'manifestFetchStatus');
       if (!manifestRes.ok) throw new Error(`HTTP ${manifestRes.status} on manifest.json`);
       const manifest = parseRailwayDatasetManifest(await manifestRes.json());
       if (manifest.version !== latestInfo.version || manifest.schemaVersion !== latestInfo.schemaVersion) {
@@ -177,7 +181,7 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
       console.log(`[H3 Tile Streamer] Manifest connected! Dataset Version: ${manifest.version}, Schema: ${manifest.schemaVersion}`);
 
       this.currentState = this.loadedCells.size > 0 ? 'cloud' : 'cached';
-      this.syncStatus = {
+      this.updateSyncStatus({
         status: this.currentState,
         baseUrl,
         version: manifest.version,
@@ -185,18 +189,19 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
         loadedTileCount: this.loadedCells.size,
         totalLines: manifest.totalLines,
         totalStations: manifest.totalStations,
-      };
+        errorMessage: undefined,
+      });
     } catch (err) {
       console.warn('[H3 Tile Streamer Manifest Error]:', err);
       this.activeVersion = undefined;
       this.currentState = 'bundled';
-      this.syncStatus = {
+      this.updateSyncStatus({
         status: 'bundled',
         baseUrl,
         version: sampleMetadata.version,
         schemaVersion: RAILWAY_DATASET_SCHEMA_VERSION,
         errorMessage: err instanceof Error ? err.message : String(err),
-      };
+      });
       captureRuntimeError(err, 'dataset-manifest-fetch', { baseUrl });
       addRuntimeBreadcrumb('railglance.dataset', 'Dataset manifest fetch failed', {}, 'warning');
       throw err;
@@ -204,25 +209,25 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
   }
 
   public async ensureCoverageAround(latitude: number, longitude: number): Promise<RailwayCoverageResult> {
+    const cellId = this.h3Tiler.latLonToCellId(latitude, longitude);
+    this.updateSyncStatus({ currentCellId: cellId });
+
     if (!this.activeBaseUrl || !this.activeVersion) {
       return {
         state: this.currentState,
+        cellId,
         loadedTileCount: this.loadedCells.size,
       };
     }
-
-    const cellId = this.h3Tiler.latLonToCellId(latitude, longitude);
-    this.syncStatus.currentCellId = cellId;
 
     try {
       const coverageCells = this.h3Tiler.coverageCellIds(latitude, longitude, 1);
       await Promise.all(coverageCells.map((coverageCellId) => this.loadTile(coverageCellId)));
 
-      this.syncStatus = {
-        ...this.syncStatus,
+      this.updateSyncStatus({
         status: this.currentState,
         loadedTileCount: this.loadedCells.size,
-      };
+      });
 
       return {
         state: this.currentState,
@@ -252,7 +257,7 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
 
     const request = (async () => {
       const tileUrl = `${this.activeBaseUrl}/datasets/v${requestVersion}/h3/6/${cellId}.json`;
-      const res = await fetch(tileUrl, { mode: 'cors' });
+      const res = await this.fetchWithStatus(tileUrl, 'lastTileFetchStatus');
       if (res.status === 404) {
         if (this.activeVersion === requestVersion) this.loadedCells.add(cellId);
         return;
@@ -446,5 +451,31 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
     const merged = new Map(bundled.map((item) => [item.id, item]));
     for (const item of remote) merged.set(item.id, item);
     return [...merged.values()];
+  }
+
+  private updateSyncStatus(patch: Partial<DatasetSyncStatus>): void {
+    this.syncStatus = { ...this.syncStatus, ...patch };
+  }
+
+  private async fetchWithStatus(
+    url: string,
+    statusField: 'latestFetchStatus' | 'manifestFetchStatus' | 'lastTileFetchStatus'
+  ): Promise<Response> {
+    const urlPatch = statusField === 'lastTileFetchStatus' ? { lastTileUrl: url } : {};
+    try {
+      const res = await fetch(url, { mode: 'cors' });
+      this.updateSyncStatus({
+        ...urlPatch,
+        [statusField]: res.ok ? 'ok' : res.status,
+        ...(res.ok ? { lastSuccessfulFetchAtMs: Date.now() } : {}),
+      });
+      return res;
+    } catch (err) {
+      this.updateSyncStatus({
+        ...urlPatch,
+        [statusField]: 'failed',
+      });
+      throw err;
+    }
   }
 }

--- a/src/infrastructure/storage/dexie-railway-database.ts
+++ b/src/infrastructure/storage/dexie-railway-database.ts
@@ -28,6 +28,7 @@ export type DatasetSyncStatus = {
   totalLines?: number;
   totalStations?: number;
   errorMessage?: string;
+  latestUrl?: string;
   manifestUrl?: string;
   latestFetchStatus?: FetchStepStatus;
   manifestFetchStatus?: FetchStepStatus;
@@ -159,10 +160,9 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
     });
 
     try {
-      const latestRes = await this.fetchWithStatus(
-        `${baseUrl}/datasets/latest.json`,
-        'latestFetchStatus'
-      );
+      const latestUrl = `${baseUrl}/datasets/latest.json`;
+      this.updateSyncStatus({ latestUrl });
+      const latestRes = await this.fetchWithStatus(latestUrl, 'latestFetchStatus');
       if (!latestRes.ok) throw new Error(`HTTP ${latestRes.status} on latest.json`);
       const latestInfo = parseLatestDatasetPointer(await latestRes.json());
       this.activeVersion = latestInfo.version;

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -62,8 +62,9 @@ export class DebugPanel {
           <div>オンデマンド取得済みタイル数: <strong>${datasetSyncStatus?.loadedTileCount ?? 0} 個</strong></div>
           <div>キャッシュ内規模: <strong>${datasetSyncStatus?.totalLines ?? 0} 路線 / ${datasetSyncStatus?.totalStations ?? 0} 駅</strong></div>
           <div>ベースURL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.baseUrl, '(ローカル内蔵データ)')}</small></div>
-          <div>Manifest URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.manifestUrl, 'なし')}</small></div>
+          <div>Latest URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.latestUrl, 'なし')}</small></div>
           <div>Latest fetch status: <strong>${escapeHtmlValue(datasetSyncStatus?.latestFetchStatus, '--')}</strong></div>
+          <div>Manifest URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.manifestUrl, 'なし')}</small></div>
           <div>Manifest fetch status: <strong>${escapeHtmlValue(datasetSyncStatus?.manifestFetchStatus, '--')}</strong></div>
           <div>Last tile URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.lastTileUrl, 'なし')}</small> (${escapeHtmlValue(datasetSyncStatus?.lastTileFetchStatus, '--')})</div>
           <div>Last successful fetch: <strong>${lastSuccessfulFetchLabel}</strong></div>

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -1,6 +1,25 @@
+import { RailwayDataState } from '../domain/railway/repository';
 import { EstimationLogEntry } from '../infrastructure/logging/logger';
 import { DatasetSyncStatus } from '../infrastructure/storage/dexie-railway-database';
 import { escapeHtml, escapeHtmlValue } from './html';
+
+export function renderSyncBadge(status?: RailwayDataState): string {
+  switch (status) {
+    case 'cloud':
+      return '<span style="color: #00FF00; background: #004400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✓ Ready (R2 H3 Streaming)</span>';
+    case 'cached':
+      return '<span style="color: #00D4C8; background: #003833; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✓ Ready (Cached)</span>';
+    case 'downloading':
+      return '<span style="color: #FFFF00; background: #444400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">⚡ Connecting R2...</span>';
+    case 'error':
+      return '<span style="color: #FF6666; background: #440000; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✕ Error</span>';
+    case 'unavailable':
+      return '<span style="color: #FF6666; background: #440000; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✕ Unavailable</span>';
+    case 'bundled':
+    default:
+      return '<span style="color: #AAAAAA; background: #222222; padding: 2px 6px; border-radius: 4px;">Local Sample</span>';
+  }
+}
 
 export class DebugPanel {
   private container: HTMLElement;
@@ -29,19 +48,9 @@ export class DebugPanel {
 
     const gpsAgeMs = rawLocation ? timestampMs - rawLocation.timestampMs : 'N/A';
 
-    const renderSyncBadge = (status?: string) => {
-      switch (status) {
-        case 'READY_R2':
-          return '<span style="color: #00FF00; background: #004400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✓ Ready (R2 H3 Streaming)</span>';
-        case 'SYNCING':
-          return '<span style="color: #FFFF00; background: #444400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">⚡ Connecting R2...</span>';
-        case 'ERROR':
-          return '<span style="color: #FF6666; background: #440000; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✕ Error</span>';
-        case 'LOCAL_SAMPLE':
-        default:
-          return '<span style="color: #AAAAAA; background: #222222; padding: 2px 6px; border-radius: 4px;">Local Sample</span>';
-      }
-    };
+    const lastSuccessfulFetchLabel = datasetSyncStatus?.lastSuccessfulFetchAtMs
+      ? escapeHtml(new Date(datasetSyncStatus.lastSuccessfulFetchAtMs).toLocaleTimeString())
+      : '--';
 
     const html = `
       <div class="debug-grid">
@@ -53,6 +62,11 @@ export class DebugPanel {
           <div>オンデマンド取得済みタイル数: <strong>${datasetSyncStatus?.loadedTileCount ?? 0} 個</strong></div>
           <div>キャッシュ内規模: <strong>${datasetSyncStatus?.totalLines ?? 0} 路線 / ${datasetSyncStatus?.totalStations ?? 0} 駅</strong></div>
           <div>ベースURL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.baseUrl, '(ローカル内蔵データ)')}</small></div>
+          <div>Manifest URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.manifestUrl, 'なし')}</small></div>
+          <div>Latest fetch status: <strong>${escapeHtmlValue(datasetSyncStatus?.latestFetchStatus, '--')}</strong></div>
+          <div>Manifest fetch status: <strong>${escapeHtmlValue(datasetSyncStatus?.manifestFetchStatus, '--')}</strong></div>
+          <div>Last tile URL: <small style="color: #88CCFF;">${escapeHtmlValue(datasetSyncStatus?.lastTileUrl, 'なし')}</small> (${escapeHtmlValue(datasetSyncStatus?.lastTileFetchStatus, '--')})</div>
+          <div>Last successful fetch: <strong>${lastSuccessfulFetchLabel}</strong></div>
           ${datasetSyncStatus?.errorMessage ? `<div style="color: #FF8888; font-size: 11px; margin-top: 4px;">Error: ${escapeHtml(datasetSyncStatus.errorMessage)}</div>` : ''}
         </div>
 

--- a/tests/storage/railway-dataset-sync.test.ts
+++ b/tests/storage/railway-dataset-sync.test.ts
@@ -135,6 +135,7 @@ describe('railway dataset remote sync', () => {
 
     expect(status.latestFetchStatus).toBe('ok');
     expect(status.manifestFetchStatus).toBe('ok');
+    expect(status.latestUrl).toBe(`${baseUrl}/datasets/latest.json`);
     expect(status.manifestUrl).toBe(`${baseUrl}/datasets/v2.0.0/manifest.json`);
     expect(status.lastSuccessfulFetchAtMs).toBeGreaterThanOrEqual(before);
     expect(status.lastSuccessfulFetchAtMs).toBeLessThanOrEqual(after);

--- a/tests/storage/railway-dataset-sync.test.ts
+++ b/tests/storage/railway-dataset-sync.test.ts
@@ -107,4 +107,200 @@ describe('railway dataset remote sync', () => {
     expect(await db.remoteLines.where('datasetVersion').equals('2.0.0').count()).toBe(0);
     expect(await db.getLine('odakyu-odawara')).toBeDefined();
   });
+
+  it('computes the H3 cellId even when no remote is configured', async () => {
+    const latitude = 35.6812;
+    const longitude = 139.7671;
+    const expectedCellId = new H3Tiler(6).latLonToCellId(latitude, longitude);
+
+    const result = await db.ensureCoverageAround(latitude, longitude);
+
+    expect(result.cellId).toBe(expectedCellId);
+    expect(db.getSyncStatus().currentCellId).toBe(expectedCellId);
+  });
+
+  it('records latest and manifest fetch diagnostics on a successful connect', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) return jsonResponse(manifest('2.0.0'));
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const before = Date.now();
+    await db.connectRemoteManifest(baseUrl);
+    const after = Date.now();
+    const status = db.getSyncStatus();
+
+    expect(status.latestFetchStatus).toBe('ok');
+    expect(status.manifestFetchStatus).toBe('ok');
+    expect(status.manifestUrl).toBe(`${baseUrl}/datasets/v2.0.0/manifest.json`);
+    expect(status.lastSuccessfulFetchAtMs).toBeGreaterThanOrEqual(before);
+    expect(status.lastSuccessfulFetchAtMs).toBeLessThanOrEqual(after);
+  });
+
+  it('records the HTTP status when latest.json returns a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({ error: 'nope' }, 503)));
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow(/HTTP 503/);
+    expect(db.getSyncStatus()).toMatchObject({
+      latestFetchStatus: 503,
+      status: 'bundled',
+      baseUrl,
+    });
+  });
+
+  it('records the HTTP status when manifest.json returns a non-2xx response', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) return jsonResponse({ error: 'nope' }, 503);
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow(/HTTP 503/);
+    expect(db.getSyncStatus()).toMatchObject({
+      latestFetchStatus: 'ok',
+      manifestUrl: `${baseUrl}/datasets/v2.0.0/manifest.json`,
+      manifestFetchStatus: 503,
+      status: 'bundled',
+      baseUrl,
+    });
+  });
+
+  it('records latestFetchStatus as failed when latest.json fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Load failed')));
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow('Load failed');
+    expect(db.getSyncStatus()).toMatchObject({
+      latestFetchStatus: 'failed',
+      status: 'bundled',
+      baseUrl,
+    });
+  });
+
+  it('records lastTileUrl and lastTileFetchStatus together from the tile that settled last', async () => {
+    const latitude = 35.6812;
+    const longitude = 139.7671;
+    const coverageCells = new H3Tiler(6).coverageCellIds(latitude, longitude, 1);
+    expect(coverageCells.length).toBeGreaterThan(1);
+
+    const delayedCell = coverageCells[0];
+    const delayedUrl = `${baseUrl}/datasets/v2.0.0/h3/6/${delayedCell}.json`;
+    let releaseDelayed!: () => void;
+    const delayedGate = new Promise<void>((resolve) => {
+      releaseDelayed = resolve;
+    });
+    const settled: Array<{ url: string; status: 'ok' | 404 }> = [];
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) return jsonResponse(manifest('2.0.0'));
+      if (url.includes('/h3/6/')) {
+        const requestedCell = url.match(/\/([^/]+)\.json$/)?.[1];
+        if (requestedCell === delayedCell) {
+          await delayedGate;
+          settled.push({ url, status: 404 });
+          return jsonResponse({}, 404);
+        }
+        settled.push({ url, status: 'ok' });
+        return jsonResponse({
+          cellId: requestedCell,
+          resolution: 6,
+          lines: [{ id: `remote-${requestedCell}`, operatorId: 'remote', name: `Remote ${requestedCell}` }],
+          routes: [],
+          stations: [],
+          segments: [],
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await db.connectRemoteManifest(baseUrl);
+    const coverage = db.ensureCoverageAround(latitude, longitude);
+    await vi.waitFor(() => {
+      expect(settled.length).toBe(coverageCells.length - 1);
+    });
+    releaseDelayed();
+    await coverage;
+
+    const lastSettled = settled[settled.length - 1];
+    expect(lastSettled).toEqual({ url: delayedUrl, status: 404 });
+    expect(db.getSyncStatus()).toMatchObject({
+      lastTileUrl: delayedUrl,
+      lastTileFetchStatus: 404,
+    });
+  });
+
+  it('preserves tile fetch diagnostics after a later manifest reconnect failure', async () => {
+    const cellId = new H3Tiler(6).latLonToCellId(35.6812, 139.7671);
+    let failNextLatest = false;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) {
+        if (failNextLatest) throw new TypeError('Load failed');
+        return jsonResponse(latest('2.0.0'));
+      }
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) return jsonResponse(manifest('2.0.0'));
+      if (url.includes('/h3/6/')) {
+        const requestedCell = url.match(/\/([^/]+)\.json$/)?.[1];
+        if (requestedCell !== cellId) return jsonResponse({}, 404);
+        return jsonResponse({
+          cellId,
+          resolution: 6,
+          lines: [{ id: 'remote-2.0.0', operatorId: 'remote', name: 'Remote 2.0.0' }],
+          routes: [],
+          stations: [],
+          segments: [],
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await db.connectRemoteManifest(baseUrl);
+    await db.ensureCoverageAround(35.6812, 139.7671);
+    const afterTile = db.getSyncStatus();
+    const cellFromUrl = afterTile.lastTileUrl?.match(/\/h3\/6\/([^/]+)\.json$/)?.[1];
+    expect(cellFromUrl).toEqual(expect.any(String));
+    expect(afterTile.lastTileUrl).toBe(`${baseUrl}/datasets/v2.0.0/h3/6/${cellFromUrl}.json`);
+    expect(afterTile.lastTileFetchStatus).toBe(cellFromUrl === cellId ? 'ok' : 404);
+    expect(afterTile.lastSuccessfulFetchAtMs).toEqual(expect.any(Number));
+
+    failNextLatest = true;
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow('Load failed');
+
+    const afterFail = db.getSyncStatus();
+    expect(afterFail.lastTileUrl).toBe(afterTile.lastTileUrl);
+    expect(afterFail.lastTileFetchStatus).toBe(afterTile.lastTileFetchStatus);
+    expect(afterFail.lastSuccessfulFetchAtMs).toBe(afterTile.lastSuccessfulFetchAtMs);
+    expect(afterFail.latestFetchStatus).toBe('failed');
+  });
+
+  it('keeps fetch diagnostics when initialize handles a remote connect failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Load failed')));
+    const remoteDb = new DexieRailwayDatabase({
+      databaseName: `RailGlanceTest-${crypto.randomUUID()}`,
+      remoteBaseUrl: baseUrl,
+    });
+
+    try {
+      await remoteDb.initialize();
+      await vi.waitFor(() => {
+        expect(remoteDb.getSyncStatus().latestFetchStatus).toBe('failed');
+      });
+      expect(remoteDb.getSyncStatus()).toMatchObject({
+        status: 'bundled',
+        baseUrl,
+        latestFetchStatus: 'failed',
+      });
+    } finally {
+      await remoteDb.delete();
+    }
+  });
 });
+

--- a/tests/ui/debug-panel.test.ts
+++ b/tests/ui/debug-panel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { renderSyncBadge } from '../../src/ui/debug-panel';
+
+describe('renderSyncBadge', () => {
+  it('renders cloud as ready R2 H3 streaming', () => {
+    const html = renderSyncBadge('cloud');
+    expect(html).toContain('✓ Ready (R2 H3 Streaming)');
+    expect(html).toContain('#00FF00');
+  });
+
+  it('renders cached as ready cached', () => {
+    const html = renderSyncBadge('cached');
+    expect(html).toContain('✓ Ready (Cached)');
+  });
+
+  it('renders downloading as connecting R2', () => {
+    const html = renderSyncBadge('downloading');
+    expect(html).toContain('⚡ Connecting R2...');
+    expect(html).toContain('#FFFF00');
+  });
+
+  it('renders error as an error badge', () => {
+    const html = renderSyncBadge('error');
+    expect(html).toContain('✕ Error');
+    expect(html).toContain('#FF6666');
+  });
+
+  it('renders unavailable as an unavailable badge', () => {
+    const html = renderSyncBadge('unavailable');
+    expect(html).toContain('✕ Unavailable');
+    expect(html).toContain('#FF6666');
+  });
+
+  it('renders bundled as local sample', () => {
+    const html = renderSyncBadge('bundled');
+    expect(html).toContain('Local Sample');
+    expect(html).toContain('#AAAAAA');
+  });
+
+  it('renders undefined as local sample', () => {
+    const html = renderSyncBadge(undefined);
+    expect(html).toContain('Local Sample');
+    expect(html).toContain('#AAAAAA');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two code-level bugs behind the symptom reported in #44 (debug panel stuck showing `同期ステータス: Local Sample` / `現在地 H3 Cell: 未検出` throughout a real-device test run, with an undiagnosable `Error: Load failed`), and adds the step-by-step fetch diagnostics the issue explicitly asked for.

- **Sync-status badge bug (root cause of the reported display):** `renderSyncBadge()` in `src/ui/debug-panel.ts` switched on stale literals (`'READY_R2' | 'SYNCING' | 'ERROR' | 'LOCAL_SAMPLE'`) that never matched the real `RailwayDataState` values (`'bundled' | 'cached' | 'cloud' | 'downloading' | 'unavailable' | 'error'`). Every real status silently fell through to the default "Local Sample" label. Now extracted as a pure, exported, DOM-free function switching on the real enum — a future regression to the wrong literal set is now a TypeScript compile error, not just a silent fallthrough.
- **H3 cell gated behind remote connectivity:** `ensureCoverageAround()` returned before computing `cellId` whenever the remote wasn't connected, so "現在地 H3 Cell" stayed "未検出" any time R2 wasn't reachable — exactly when you'd most want to see it. `cellId` is now computed unconditionally, per the issue's own note that it "can be computed regardless of remote manifest connection success."
- **Per-step fetch diagnostics:** `DatasetSyncStatus` now records, for each of latest.json / manifest.json / the most recent H3 tile request: `'ok'` (2xx), the numeric HTTP status (non-2xx response received), or `'failed'` (fetch threw before any response — network/CORS-level failure), plus the resolved `manifestUrl`, `lastTileUrl`, and `lastSuccessfulFetchAtMs`. The debug panel renders all of these. This turns a bare `Error: Load failed` into something that says *which* step failed and *how*.

## Process note

Implementation was done by Grok (xAI), reviewed independently by an Opus-backed reviewer agent in two rounds. Round 1 caught a real race: `lastTileUrl` was written synchronously when a tile request started while `lastTileFetchStatus` was written asynchronously at settlement, across a ~7-cell concurrent fan-out — so the displayed (URL, status) pair could describe two different cells. Fixed by writing both fields atomically in one update at settlement time, with a new test that deliberately forces one cell to settle last and asserts the exact pair. Round 2 re-reviewed the fix against the committed diff and signed off with no remaining blockers.

## Issue #44 completion criteria — status

Addressed in this PR (code-level):
- [x] H3 Cell表示は remote接続成否と無関係に算出・表示される
- [x] エラー時に manifest / tile / HTTPステータス を区別できる（latest.json / manifest.json / tile それぞれの成否・HTTPステータスを記録）
- [x] remote接続失敗時も bundled fallback は維持される（既存挙動、退行なし）
- [x] デバッグ表示改善（Manifest URL, Latest/Manifest fetch status, Last tile URL/status, Last successful fetch time を追加）

Still requires real-device/infrastructure verification (out of scope for this PR — no Even App hardware or live R2 bucket access from this environment):
- [ ] Even App実機からR2 manifestへ接続できる
- [ ] 実機GPS位置に応じてH3 Cellが表示される（ロジックは修正済み、実機確認は未実施）
- [ ] H3 tileがオンデマンド取得され、loadedTileCountが増える
- [ ] Cloud / cachedデータがMapMatcherから利用される
- [ ] 実走再確認（小田急相模原〜新百合ヶ丘）

`src/scripts/deploy-r2.ts`, R2 bucket CORS configuration, and `src/config/evenhub-manifest.ts` were intentionally left untouched — the new diagnostics exist precisely so the next field run can show where in that chain the failure actually is (CORS block vs. wrong URL vs. missing manifest, etc.), rather than requiring code changes to guess blind.

## Test plan

- [x] `pnpm test` — 245/245 passed (10 new/updated cases in `tests/storage/railway-dataset-sync.test.ts`, 7 new in `tests/ui/debug-panel.test.ts`)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] Manual verification on Even App hardware against a live R2 deployment (tracked separately, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Km878Mo47nqEEXqi5qLGt