### PR TITLE
fix: don't assert next station when railway data may be sparse

### DIFF
--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -165,6 +165,7 @@ export class AppController {
       nextStation: null,
       distanceToNextStationMeters: null,
       progressRatio: null,
+      stationDataComplete: true,
       confidence: 0,
       status: 'INITIALIZING',
     };

--- a/src/domain/models/railway.ts
+++ b/src/domain/models/railway.ts
@@ -184,6 +184,7 @@ export type JourneyState = {
   nextStation: Station | null;
   distanceToNextStationMeters: number | null;
   progressRatio: number | null; // 0.0 to 1.0
+  stationDataComplete: boolean; // false = station list may be sparse (bundled fallback); previous/nextStation should not be asserted
   confidence: number;
   status: 'INITIALIZING' | 'WAITING_FOR_GPS' | 'MATCHING_ROUTE' | 'TRACKING' | 'GPS_UNAVAILABLE' | 'ROUTE_UNCERTAIN' | 'GPS_LOW_ACCURACY';
   lockState?: RouteLockState;

--- a/src/domain/models/railway.ts
+++ b/src/domain/models/railway.ts
@@ -184,7 +184,7 @@ export type JourneyState = {
   nextStation: Station | null;
   distanceToNextStationMeters: number | null;
   progressRatio: number | null; // 0.0 to 1.0
-  stationDataComplete: boolean; // false = station list may be sparse (bundled fallback); previous/nextStation should not be asserted
+  stationDataComplete: boolean; // false = station list completeness is not confirmed (e.g. sparse bundled fallback data, or remote data not yet available for this line); previous/nextStation should not be asserted
   confidence: number;
   status: 'INITIALIZING' | 'WAITING_FOR_GPS' | 'MATCHING_ROUTE' | 'TRACKING' | 'GPS_UNAVAILABLE' | 'ROUTE_UNCERTAIN' | 'GPS_LOW_ACCURACY';
   lockState?: RouteLockState;

--- a/src/domain/railway/journey-state-estimator.ts
+++ b/src/domain/railway/journey-state-estimator.ts
@@ -116,6 +116,7 @@ export class JourneyStateEstimator {
         nextStation: null,
         distanceToNextStationMeters: null,
         progressRatio: null,
+        stationDataComplete: true,
         confidence: 0.0,
         status: match?.lockState === 'UNRESOLVED' || match?.lockState === 'REACQUIRING' ? 'MATCHING_ROUTE' : 'ROUTE_UNCERTAIN',
         lockState: match?.lockState,
@@ -134,6 +135,7 @@ export class JourneyStateEstimator {
         nextStation: null,
         distanceToNextStationMeters: null,
         progressRatio: null,
+        stationDataComplete: true,
         confidence: 0.0,
         status: sample && sample.accuracyMeters > this.config.maxGpsAccuracyMeters
           ? 'GPS_LOW_ACCURACY'
@@ -159,6 +161,7 @@ export class JourneyStateEstimator {
         nextStation: null,
         distanceToNextStationMeters: null,
         progressRatio: null,
+        stationDataComplete: true,
         confidence: 0.0,
         status: 'ROUTE_UNCERTAIN',
         lockState: match?.lockState,
@@ -204,6 +207,7 @@ export class JourneyStateEstimator {
     }
 
     const lineStations = await this.repository.getStationsByLine(selectedLine.id);
+    const stationDataComplete = (await this.repository.getStationDataCompleteness?.(selectedLine.id)) ?? true;
     if (lineStations.length === 0) {
       return {
         line: selectedLine,
@@ -213,6 +217,7 @@ export class JourneyStateEstimator {
         nextStation: null,
         distanceToNextStationMeters: null,
         progressRatio: null,
+        stationDataComplete,
         confidence: displayableMatch ? displayableMatch.confidence : 0.5,
         status: 'ROUTE_UNCERTAIN',
         lockState: match?.lockState,
@@ -333,6 +338,17 @@ export class JourneyStateEstimator {
       }
     }
 
+    if (!stationDataComplete) {
+      // Bundled/sparse fallback data: do not assert a specific next station,
+      // since intermediate real stations may be missing from this dataset.
+      // Line, direction, and confidence are unaffected — only the specific
+      // station identity/distance/progress claims are suppressed.
+      previousStation = null;
+      nextStation = null;
+      distanceToNextStationMeters = null;
+      progressRatio = null;
+    }
+
     // セグメント長ベースで進捗率を確定できなかった場合のみ、駅間の直線距離で近似する。
     if (progressRatio === null && previousStation && nextStation && distanceToNextStationMeters !== null) {
       const totalSegDist = haversineDistance(
@@ -375,6 +391,7 @@ export class JourneyStateEstimator {
       nextStation,
       distanceToNextStationMeters,
       progressRatio,
+      stationDataComplete,
       confidence,
       status,
       lockState: match?.lockState,

--- a/src/domain/railway/repository.ts
+++ b/src/domain/railway/repository.ts
@@ -48,4 +48,14 @@ export interface RailwayDataRepository {
   ): Promise<TrackSegment[]>;
 
   getDataState(): RailwayDataState;
+
+  /**
+   * Best-effort signal for whether the station list for this line is known
+   * to be complete (backed by synced remote data) vs. potentially sparse
+   * (served only from the bundled dev/fallback dataset). Optional — callers
+   * should treat a missing implementation as "complete" (fail-open) since
+   * most RailwayDataRepository implementations (e.g. test mocks) use fixture
+   * data that is complete by construction.
+   */
+  getStationDataCompleteness?(lineId: string): Promise<boolean>;
 }

--- a/src/infrastructure/storage/dexie-railway-database.ts
+++ b/src/infrastructure/storage/dexie-railway-database.ts
@@ -443,9 +443,9 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
       return false;
     }
     const remoteCount = await this.remoteStations
-      .where('datasetVersion')
-      .equals(this.activeVersion)
-      .filter((station) => station.lineId === lineId)
+      .where('lineId')
+      .equals(lineId)
+      .filter((station) => station.datasetVersion === this.activeVersion)
       .count();
     return remoteCount > 0;
   }

--- a/src/infrastructure/storage/dexie-railway-database.ts
+++ b/src/infrastructure/storage/dexie-railway-database.ts
@@ -429,6 +429,27 @@ export class DexieRailwayDatabase extends Dexie implements RailwayDataRepository
     return this.mergeById(bundled, remote).sort((a, b) => a.sequence - b.sequence);
   }
 
+  public async getStationDataCompleteness(lineId: string): Promise<boolean> {
+    const bundledCount = await this.stations.where('lineId').equals(lineId).count();
+    if (bundledCount > 0) {
+      // This line ID exists in the local bundled/sample table. The ETL build
+      // republishes that same sparse sample data into the R2 dataset under
+      // identical IDs, so the presence of remote rows for this exact lineId
+      // does not prove the station list is dense — treat it as permanently
+      // unreliable for next-station assertions.
+      return false;
+    }
+    if (!this.activeVersion) {
+      return false;
+    }
+    const remoteCount = await this.remoteStations
+      .where('datasetVersion')
+      .equals(this.activeVersion)
+      .filter((station) => station.lineId === lineId)
+      .count();
+    return remoteCount > 0;
+  }
+
   public async getSegmentsByRoute(routeId: string): Promise<TrackSegment[]> {
     const bundled = await this.trackSegments.where('routeId').equals(routeId).toArray();
     const remote = this.activeVersion

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -1,3 +1,4 @@
+import { RailwayDataState } from '../domain/railway/repository';
 import { EstimationLogEntry } from '../infrastructure/logging/logger';
 import { DatasetSyncStatus } from '../infrastructure/storage/dexie-railway-database';
 import { escapeHtml, escapeHtmlValue } from './html';
@@ -29,15 +30,18 @@ export class DebugPanel {
 
     const gpsAgeMs = rawLocation ? timestampMs - rawLocation.timestampMs : 'N/A';
 
-    const renderSyncBadge = (status?: string) => {
+    const renderSyncBadge = (status?: RailwayDataState) => {
       switch (status) {
-        case 'READY_R2':
-          return '<span style="color: #00FF00; background: #004400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✓ Ready (R2 H3 Streaming)</span>';
-        case 'SYNCING':
-          return '<span style="color: #FFFF00; background: #444400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">⚡ Connecting R2...</span>';
-        case 'ERROR':
+        case 'cloud':
+          return '<span style="color: #00FF00; background: #004400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✓ Ready</span>';
+        case 'cached':
+          return '<span style="color: #88FF88; background: #223322; padding: 2px 6px; border-radius: 4px; font-weight: bold;">Cached (Offline)</span>';
+        case 'downloading':
+          return '<span style="color: #FFFF00; background: #444400; padding: 2px 6px; border-radius: 4px; font-weight: bold;">⚡ Connecting...</span>';
+        case 'error':
+        case 'unavailable':
           return '<span style="color: #FF6666; background: #440000; padding: 2px 6px; border-radius: 4px; font-weight: bold;">✕ Error</span>';
-        case 'LOCAL_SAMPLE':
+        case 'bundled':
         default:
           return '<span style="color: #AAAAAA; background: #222222; padding: 2px 6px; border-radius: 4px;">Local Sample</span>';
       }
@@ -90,6 +94,7 @@ export class DebugPanel {
           <div>次駅まで距離: ${journey.distanceToNextStationMeters !== null ? `${journey.distanceToNextStationMeters} m` : 'なし'}</div>
           <div>路線判定信頼度: <strong>${(journey.confidence * 100).toFixed(0)}% (${journey.confidence.toFixed(2)})</strong></div>
           <div>ステータス: <span class="badge ${escapeHtml(journey.status)}">${escapeHtml(journey.status)}</span></div>
+          <div>駅データ完全性: ${journey.stationDataComplete ? '✓ 完全 (同期済み)' : '⚠ 不完全 (bundled fallback)'}</div>
         </div>
 
         <div class="debug-card">

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -94,7 +94,7 @@ export class DebugPanel {
           <div>次駅まで距離: ${journey.distanceToNextStationMeters !== null ? `${journey.distanceToNextStationMeters} m` : 'なし'}</div>
           <div>路線判定信頼度: <strong>${(journey.confidence * 100).toFixed(0)}% (${journey.confidence.toFixed(2)})</strong></div>
           <div>ステータス: <span class="badge ${escapeHtml(journey.status)}">${escapeHtml(journey.status)}</span></div>
-          <div>駅データ完全性: ${journey.stationDataComplete ? '✓ 完全 (同期済み)' : '⚠ 不完全 (bundled fallback)'}</div>
+          <div>駅データ完全性: ${journey.stationDataComplete ? '✓ 完全 (同期済み)' : '⚠ 不完全 (未確認)'}</div>
         </div>
 
         <div class="debug-card">

--- a/tests/app/app-controller-provider-lifecycle.test.ts
+++ b/tests/app/app-controller-provider-lifecycle.test.ts
@@ -122,6 +122,7 @@ function createJourneyEstimator() {
       nextStation: null,
       distanceToNextStationMeters: null,
       progressRatio: null,
+      stationDataComplete: true,
       confidence: 0,
       status: 'INITIALIZING',
     }),

--- a/tests/even-g2/hud-renderer.test.ts
+++ b/tests/even-g2/hud-renderer.test.ts
@@ -23,6 +23,7 @@ const journeyState = (overrides: Partial<JourneyState> = {}): JourneyState => ({
   nextStation: station('ebina', '海老名', 2),
   distanceToNextStationMeters: 1200,
   progressRatio: 0.5,
+  stationDataComplete: true,
   confidence: 0.9,
   status: 'TRACKING',
   ...overrides,

--- a/tests/railway/journey-state-estimator.test.ts
+++ b/tests/railway/journey-state-estimator.test.ts
@@ -594,3 +594,277 @@ describe('direction normalization', () => {
     expect(isUpDirection('UNKNOWN')).toBe(false);
   });
 });
+
+describe('JourneyStateEstimator - station data completeness', () => {
+  const ODAKYU: RailwayLine = {
+    id: 'odakyu-odawara',
+    operatorId: 'odakyu',
+    name: '小田急小田原線',
+    directionAName: '上り',
+    directionBName: '下り',
+  };
+
+  const MACHIDA: Station = {
+    id: 'st-machida',
+    lineId: 'odakyu-odawara',
+    name: '町田',
+    sequence: 7,
+    latitude: 35.5424,
+    longitude: 139.4456,
+  };
+
+  const SHINYURIGAOKA: Station = {
+    id: 'st-shinyurigaoka',
+    lineId: 'odakyu-odawara',
+    name: '新百合ヶ丘',
+    sequence: 8,
+    latitude: 35.6038,
+    longitude: 139.5076,
+  };
+
+  // Mirrors bundled `seg-machida-shinyurigaoka`, which skips 玉川学園前 / 鶴川 / 柿生.
+  const SPARSE_SEGMENT: TrackSegment = {
+    id: 'seg-machida-shinyurigaoka',
+    lineId: 'odakyu-odawara',
+    fromStationId: 'st-machida',
+    toStationId: 'st-shinyurigaoka',
+    coordinates: [
+      [35.5424, 139.4456],
+      [35.5700, 139.4750],
+      [35.6038, 139.5076],
+    ],
+    lengthMeters: 8800,
+    startOffsetMeters: 0,
+  };
+
+  class CompletenessRepository implements RailwayDataRepository {
+    getStationDataCompleteness?: (lineId: string) => Promise<boolean>;
+
+    constructor(
+      private stations: Station[],
+      completeness?: boolean
+    ) {
+      if (completeness !== undefined) {
+        this.getStationDataCompleteness = async () => completeness;
+      }
+    }
+
+    async ensureCoverageAround(): Promise<RailwayCoverageResult> {
+      return { state: 'bundled', loadedTileCount: 0 };
+    }
+    async findSegmentsNear(): Promise<TrackSegment[]> {
+      return [];
+    }
+    async getLine(lineId: string): Promise<RailwayLine | undefined> {
+      return { ...ODAKYU, id: lineId };
+    }
+    async getRoute(): Promise<RailwayRoute | undefined> {
+      return undefined;
+    }
+    async getStation(id: string): Promise<Station | undefined> {
+      return this.stations.find((station) => station.id === id);
+    }
+    async getStationsByLine(): Promise<Station[]> {
+      return this.stations;
+    }
+    async getSegmentsByRoute(): Promise<TrackSegment[]> {
+      return [];
+    }
+    getDataState(): RailwayDataState {
+      return 'bundled';
+    }
+  }
+
+  function sparseMatch(): RouteMatch {
+    return {
+      selectedLine: ODAKYU,
+      selectedSegment: SPARSE_SEGMENT,
+      confidence: 0.9,
+      candidates: [],
+      timestampMs: 10000,
+    };
+  }
+
+  function sparseSample(): LocationSample {
+    return {
+      latitude: 35.56,
+      longitude: 139.46,
+      accuracyMeters: 10,
+      speedMps: 25,
+      headingDegrees: 45,
+      timestampMs: 10000,
+    };
+  }
+
+  function sparseSpeedState(): FullSpeedState {
+    const selectedEst: SpeedEstimate = {
+      speedKmh: 90,
+      confidence: 0.9,
+      source: 'os-geolocation',
+      timestamp: 10000,
+    };
+    return {
+      selectedEstimate: selectedEst,
+      smoothedSpeedKmh: 90,
+      isStopped: false,
+      isValid: true,
+      candidates: {
+        osSpeed: selectedEst,
+        positionDeltaSpeed: null,
+        trackDistanceSpeed: null,
+        deadReckoningSpeed: null,
+        sensorFusionSpeed: null,
+      },
+      navState: {
+        lineId: 'odakyu-odawara',
+        routeId: null,
+        segmentId: SPARSE_SEGMENT.id,
+        direction: 'UP',
+        trackPositionMeters: 2000,
+        velocityMps: 25,
+        accelerationMps2: 0,
+        accelerationBiasMps2: 0,
+        lastObservationTimestampMs: 10000,
+        lastPredictionTimestampMs: 10000,
+        mode: 'gps-locked',
+        confidence: 0.9,
+      },
+    };
+  }
+
+  async function estimateSparse(
+    repository: RailwayDataRepository
+  ) {
+    const estimator = new JourneyStateEstimator(repository, DEFAULT_TRACKING_CONFIG);
+    const speedState = sparseSpeedState();
+    return estimator.update(
+      sparseSample(),
+      sparseMatch(),
+      speedState,
+      speedState.navState,
+      SPARSE_SEGMENT
+    );
+  }
+
+  it('suppresses next station when station data is marked incomplete', async () => {
+    const state = await estimateSparse(
+      new CompletenessRepository([MACHIDA, SHINYURIGAOKA], false)
+    );
+
+    expect(state.stationDataComplete).toBe(false);
+    expect(state.previousStation).toBeNull();
+    expect(state.nextStation).toBeNull();
+    expect(state.distanceToNextStationMeters).toBeNull();
+    expect(state.progressRatio).toBeNull();
+
+    expect(state.line?.id).toBe('odakyu-odawara');
+    expect(state.direction).toBe('UP');
+    expect(state.directionName).toBe('上り');
+    expect(state.confidence).toBe(0.9);
+    expect(state.status).toBe('TRACKING');
+  });
+
+  it('still resolves next station when station data is marked complete', async () => {
+    const state = await estimateSparse(
+      new CompletenessRepository([MACHIDA, SHINYURIGAOKA], true)
+    );
+
+    expect(state.stationDataComplete).toBe(true);
+    expect(state.previousStation?.id).toBe('st-machida');
+    expect(state.nextStation?.id).toBe('st-shinyurigaoka');
+    expect(state.previousStation?.name).toBe('町田');
+    expect(state.nextStation?.name).toBe('新百合ヶ丘');
+    expect(state.distanceToNextStationMeters).toBe(6800);
+    expect(state.progressRatio).toBe(2000 / 8800);
+    expect(state.line?.id).toBe('odakyu-odawara');
+    expect(state.direction).toBe('UP');
+    expect(state.confidence).toBe(0.9);
+  });
+
+  it('defaults to complete when the repository does not implement completeness reporting', async () => {
+    const estimator = new JourneyStateEstimator(new MockStationDatabase(), DEFAULT_TRACKING_CONFIG);
+
+    const state = await estimateAt(estimator, 'UP', 1500, SEG_1);
+
+    expect(state.stationDataComplete).toBe(true);
+    expect(state.previousStation?.name).toBe('海老名');
+    expect(state.nextStation?.name).toBe('座間');
+    expect(state.distanceToNextStationMeters).toBe(1700);
+    expect(state.progressRatio).toBe(1500 / 3200);
+  });
+
+  it('walks through intermediate stations in order on a complete dataset without skipping', async () => {
+    const stations: Station[] = [
+      { id: 'st-machida', lineId: 'odakyu-odawara', name: '町田', sequence: 1, latitude: 35.5424, longitude: 139.4456 },
+      { id: 'st-tamagawagakuenmae', lineId: 'odakyu-odawara', name: '玉川学園前', sequence: 2, latitude: 35.5630, longitude: 139.4620 },
+      { id: 'st-tsurukawa', lineId: 'odakyu-odawara', name: '鶴川', sequence: 3, latitude: 35.5830, longitude: 139.4810 },
+      { id: 'st-kakio', lineId: 'odakyu-odawara', name: '柿生', sequence: 4, latitude: 35.5940, longitude: 139.4960 },
+      { id: 'st-shinyurigaoka', lineId: 'odakyu-odawara', name: '新百合ヶ丘', sequence: 5, latitude: 35.6038, longitude: 139.5076 },
+    ];
+
+    const lengths = [2500, 2300, 1800, 2200];
+    const pairs: Array<[string, string]> = [
+      ['st-machida', 'st-tamagawagakuenmae'],
+      ['st-tamagawagakuenmae', 'st-tsurukawa'],
+      ['st-tsurukawa', 'st-kakio'],
+      ['st-kakio', 'st-shinyurigaoka'],
+    ];
+    let offset = 0;
+    const segments: TrackSegment[] = pairs.map(([fromStationId, toStationId], index) => {
+      const from = stations[index];
+      const to = stations[index + 1];
+      const segment: TrackSegment = {
+        id: `seg-${fromStationId}-${toStationId}`,
+        lineId: 'odakyu-odawara',
+        fromStationId,
+        toStationId,
+        coordinates: [
+          [from.latitude, from.longitude],
+          [to.latitude, to.longitude],
+        ],
+        lengthMeters: lengths[index],
+        startOffsetMeters: offset,
+      };
+      offset += lengths[index];
+      return segment;
+    });
+
+    const estimator = new JourneyStateEstimator(
+      new CompletenessRepository(stations, true),
+      DEFAULT_TRACKING_CONFIG
+    );
+
+    const expectedNext = ['玉川学園前', '鶴川', '柿生', '新百合ヶ丘'];
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      const midPosition = (segment.startOffsetMeters ?? 0) + lengths[i] / 2;
+      const navState = {
+        lineId: 'odakyu-odawara',
+        routeId: null,
+        segmentId: segment.id,
+        direction: 'UP' as const,
+        trackPositionMeters: midPosition,
+        velocityMps: 25,
+        accelerationMps2: 0,
+        accelerationBiasMps2: 0,
+        lastObservationTimestampMs: 10000 + i * 1000,
+        lastPredictionTimestampMs: 10000 + i * 1000,
+        mode: 'gps-locked' as const,
+        confidence: 0.9,
+      };
+
+      const state = await estimator.update(null, null, DUMMY_SPEED_STATE, navState, segment);
+
+      expect(state.stationDataComplete).toBe(true);
+      expect(state.nextStation?.name).toBe(expectedNext[i]);
+      expect(state.previousStation?.name).toBe(stations[i].name);
+      if (i === 0) {
+        expect(state.nextStation?.name).not.toBe('鶴川');
+        expect(state.nextStation?.name).not.toBe('新百合ヶ丘');
+      }
+      if (i < segments.length - 1) {
+        expect(state.nextStation?.name).not.toBe('新百合ヶ丘');
+      }
+    }
+  });
+});

--- a/tests/speed/track-dead-reckoning.test.ts
+++ b/tests/speed/track-dead-reckoning.test.ts
@@ -100,11 +100,14 @@ describe('Track-Constrained Dead Reckoning & Segment Crossing', () => {
     const journey = await journeyEstimator.update(null, null, dummySpeedState, state, navEstimator.getCurrentSegment());
 
     expect(journey.line?.id).toBe('odakyu-odawara');
-    expect(journey.previousStation?.name).toBe('座間');
-    expect(journey.nextStation?.name).toBe('相武台前');
-    expect(journey.distanceToNextStationMeters).toBeGreaterThanOrEqual(0);
-    expect(journey.progressRatio).toBeGreaterThan(0.0);
-    expect(journey.progressRatio).toBeLessThanOrEqual(1.0);
+    // Bundled sample data is sparse: station identity/distance/progress must not be asserted.
+    expect(journey.stationDataComplete).toBe(false);
+    expect(journey.previousStation).toBeNull();
+    expect(journey.nextStation).toBeNull();
+    expect(journey.distanceToNextStationMeters).toBeNull();
+    expect(journey.progressRatio).toBeNull();
+    expect(journey.direction).not.toBe('UNKNOWN');
+    expect(journey.confidence).toBeGreaterThan(0);
   });
 
   it('moves backward and transitions to previousSegmentId during DOWN dead reckoning', () => {

--- a/tests/storage/railway-repository-completeness.test.ts
+++ b/tests/storage/railway-repository-completeness.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DexieRailwayDatabase } from '../../src/infrastructure/storage/dexie-railway-database';
+import { H3Tiler } from '../../src/etl/h3-tiler';
+
+const baseUrl = 'https://data.example.test';
+const version = '2.0.0';
+const coverageLat = 35.5424;
+const coverageLon = 139.4456;
+
+let db: DexieRailwayDatabase;
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+  });
+}
+
+function latest() {
+  return {
+    version,
+    schemaVersion: '1.1.0',
+    releasedAt: '2026-08-04T00:00:00.000Z',
+    manifestUrl: `/datasets/v${version}/manifest.json`,
+  };
+}
+
+function manifest() {
+  return {
+    version,
+    schemaVersion: '1.1.0',
+    generatedAt: '2026-08-04T00:00:00.000Z',
+    area: 'test',
+    totalLines: 2,
+    totalRoutes: 0,
+    totalStations: 4,
+    totalSegments: 0,
+    totalTiles: 1,
+  };
+}
+
+beforeEach(async () => {
+  db = new DexieRailwayDatabase({
+    databaseName: `RailGlanceCompletenessTest-${crypto.randomUUID()}`,
+    remoteBaseUrl: null,
+  });
+  await db.initialize();
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await db.delete();
+});
+
+describe('DexieRailwayDatabase getStationDataCompleteness', () => {
+  it('returns false for a bundled line when no remote manifest is connected', async () => {
+    expect(await db.getStationDataCompleteness('odakyu-odawara')).toBe(false);
+  });
+
+  describe('after a successful remote tile load', () => {
+    beforeEach(async () => {
+      const cellId = new H3Tiler(6).latLonToCellId(coverageLat, coverageLon);
+      vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest());
+        if (url.endsWith(`/datasets/v${version}/manifest.json`)) return jsonResponse(manifest());
+        if (url.includes('/h3/6/')) {
+          const requestedCell = url.match(/\/([^/]+)\.json$/)?.[1];
+          if (requestedCell !== cellId) return jsonResponse({}, 404);
+          return jsonResponse({
+            cellId,
+            resolution: 6,
+            lines: [
+              { id: 'odakyu-odawara', operatorId: 'odakyu', name: '小田急小田原線' },
+              { id: 'mlit-line-test', operatorId: 'mlit', name: 'MLIT Test Line' },
+            ],
+            routes: [],
+            stations: [
+              {
+                id: 'st-machida',
+                lineId: 'odakyu-odawara',
+                name: '町田',
+                sequence: 7,
+                latitude: 35.5424,
+                longitude: 139.4456,
+              },
+              {
+                id: 'st-shinyurigaoka',
+                lineId: 'odakyu-odawara',
+                name: '新百合ヶ丘',
+                sequence: 8,
+                latitude: 35.6038,
+                longitude: 139.5076,
+              },
+              {
+                id: 'mlit-station-a',
+                lineId: 'mlit-line-test',
+                name: 'MLIT A',
+                sequence: 1,
+                latitude: 35.5424,
+                longitude: 139.4456,
+              },
+              {
+                id: 'mlit-station-b',
+                lineId: 'mlit-line-test',
+                name: 'MLIT B',
+                sequence: 2,
+                latitude: 35.55,
+                longitude: 139.45,
+              },
+            ],
+            segments: [],
+          });
+        }
+        return jsonResponse({}, 404);
+      }));
+
+      await db.connectRemoteManifest(baseUrl);
+      await db.ensureCoverageAround(coverageLat, coverageLon);
+    });
+
+    it('returns false for a bundled line id even when remote rows exist under the same id', async () => {
+      const remoteBundledLineCount = await db.remoteStations
+        .where('datasetVersion')
+        .equals(version)
+        .filter((station) => station.lineId === 'odakyu-odawara')
+        .count();
+      expect(remoteBundledLineCount).toBeGreaterThan(0);
+      expect(await db.getStationDataCompleteness('odakyu-odawara')).toBe(false);
+    });
+
+    it('returns true for a remote-only line id that is not in the bundled sample table', async () => {
+      const bundledMlitCount = await db.stations.where('lineId').equals('mlit-line-test').count();
+      expect(bundledMlitCount).toBe(0);
+
+      const remoteMlitCount = await db.remoteStations
+        .where('datasetVersion')
+        .equals(version)
+        .filter((station) => station.lineId === 'mlit-line-test')
+        .count();
+      expect(remoteMlitCount).toBeGreaterThan(0);
+      expect(await db.getStationDataCompleteness('mlit-line-test')).toBe(true);
+    });
+  });
+});

--- a/tests/telemetry/telemetry.test.ts
+++ b/tests/telemetry/telemetry.test.ts
@@ -85,6 +85,7 @@ function entry(timestampMs: number, mode: FullSpeedState['navState']['mode'], ro
     nextStation: null,
     distanceToNextStationMeters: 1000,
     progressRatio: 0.5,
+    stationDataComplete: true,
     confidence: 0.8,
     status: 'TRACKING',
   };


### PR DESCRIPTION
## Summary

Fixes #45. During a real test ride on the Odakyu Odawara line, a Cloudflare R2 fetch failure fell the app back to the bundled/embedded sample dataset, which only carries a curated subset of stations per line. The estimator asserted the next *curated* station ("次駅: 新百合ヶ丘") with full confidence while three real intermediate stations (玉川学園前, 鶴川, 柿生) — absent from the bundled data — were actually still ahead.

- `RailwayDataRepository` gains an optional `getStationDataCompleteness(lineId)` signal.
- `DexieRailwayDatabase` implements it: a `lineId` that exists in the local bundled `stations` table is always reported incomplete, regardless of what shows up under that same ID in the synced remote dataset — the ETL build republishes the bundled sample verbatim into R2 under identical IDs, so "a remote row exists for this line" is not proof the station list is dense. Only lines that never appear in the bundled table (genuine MLIT-sourced lines, which use a disjoint ID namespace) are eligible for the remote-row check.
- `JourneyStateEstimator` now carries `stationDataComplete` on `JourneyState` and nulls out `previousStation` / `nextStation` / `distanceToNextStationMeters` / `progressRatio` when it's `false` — `line`, `direction`, `directionName`, `confidence`, and `status` are untouched. The existing HUD renderer already has "前駅不明" / "次駅推定中" fallback text for null stations and drives GPS/speed independently of journey state, so no HUD changes were needed.
- `DebugPanel` gets a `駅データ完全性` row, and a real bug fix along the way: its sync-status badge switched on string literals (`'READY_R2'`, `'SYNCING'`, …) that never matched the actual `RailwayDataState` values ever passed to it, so it always silently fell through to "Local Sample" regardless of real state.

## Completion criteria from the issue

- [x] 町田→玉川学園前→鶴川→柿生→新百合ヶ丘 が正しい順序で判定される — covered for complete data by a new regression test (`journey-state-estimator.test.ts`, "walks through intermediate stations in order without skipping").
- [x] Remote dataset利用時に途中駅が飛ばされない — same test, plus the completeness check no longer suppresses valid dense data.
- [x] bundled fallbackが疎な場合に誤った「次駅」を断定表示しない — core fix; covered by the suppression tests.
- [x] データソースと駅データ完全性をDebugPanelで確認できる — new completeness row + fixed sync badge.
- [x] GPS/速度表示は駅データ不完全時も継続する — `stationDataComplete` only affects station-specific `JourneyState` fields; `HudRenderer` derives speed from `speedState`/`navState`, not journey station fields.
- [x] 回帰テスト（小田急相模原〜新百合ヶ丘） — modeled with a synthetic fixture matching the reported segment (`seg-machida-shinyurigaoka`, 8800m, skipping 3 real stations) rather than a raw GPS log replay; `tests/speed/track-dead-reckoning.test.ts` also now exercises this against a real `DexieRailwayDatabase` seeded with only bundled data.

## Known limitations (intentional trade-offs, not follow-up bugs)

1. **Permanent suppression for curated lines.** All 7 bundled/curated lines (`odakyu-odawara`, `keikyu-main-line`, `sotetsu-main-line`, `jreast-yokohama-line`, and 3 Shinkansen lines) now report `stationDataComplete: false` unconditionally, synced or not — because their remote-published rows share IDs with the sparse bundled data and can't be trusted. If the currently-deployed R2 dataset is sample-derived only (no MLIT data merged under a distinct line entity), next-station display is effectively off app-wide until an MLIT-sourced dataset ships under its own `mlit-line-*` IDs. This is intended fail-safe behavior per the issue, not a regression.
2. **Line-global, not position-local.** The completeness signal is per-line, not per-position. A genuinely MLIT-sourced line that loses R2 connectivity mid-ride (tile fetch error) after `activeVersion` was already set will still report `stationDataComplete: true`, since some other tile on the line synced successfully earlier in the session. A fully precise fix would need a position-local signal (e.g., are the specific stations bracketing the current track position remote-sourced), which is a larger change left out of scope here.
3. **Local dev without `VITE_RAILWAY_DATA_BASE_URL`** now permanently shows 前駅不明/次駅推定中 instead of the (possibly wrong) bundled station names — expected given the fix, but a visible behavior change worth knowing about.
4. **Pre-existing, unrelated quirk left untouched**: the lat/lon-only station-scan fallback branch in `JourneyStateEstimator` (used when no segment/from-to station IDs are available) returns `orderedStations[0]` on its first loop iteration rather than the nearest station by position. Out of scope for this fix; noted here for visibility.
5. **Suggested follow-up** (not done here): stop republishing the bundled sample dataset into the R2/remote dataset under identical IDs during the ETL build, or mark those lines as sample-grade in the manifest, so a real MLIT-sourced densification of these lines becomes possible under the same ID in the future.

## Process

Implementation by Grok (xAI Grok Build), two rounds — initial implementation, then a fix for a real gap an independent review found (the ID-collision issue described above). Reviewed by Claude Opus (independent agent, full-context code review) both rounds; findings were verified against the repo, not taken at face value, before being sent back for a fix.

## Test plan

- [x] `pnpm test` — 237/237 passing (34 files, +3 new)
- [x] `pnpm build` — `tsc` + vite build clean
- [x] `pnpm lint` — `eslint . --max-warnings=0` clean
- [x] New tests directly exercise the real `DexieRailwayDatabase` (not just mocks) against seeded IndexedDB data, proving the ID-collision protection actually works (`tests/storage/railway-repository-completeness.test.ts`)

https://claude.ai/code/session_018veMFYVEwqQhueHPMzBkJ1