### PR TITLE
Even Hub 画面にバージョンとビルド日時を表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
   <body>
     <div id="app">
       <header class="app-header">
-        <h1>RailGlance - Even G2 HUD</h1>
+        <div class="app-identity">
+          <h1>RailGlance - Even G2 HUD</h1>
+          <p id="build-info" class="build-info">バージョン情報を読み込み中…</p>
+        </div>
         <div class="controls">
           <button id="btn-start" class="btn btn-primary">実機GPS開始</button>
           <button id="btn-stop" class="btn">停止</button>

--- a/src/config/build-info.ts
+++ b/src/config/build-info.ts
@@ -1,5 +1,5 @@
 export type BuildInfo = {
-  version: string;
+  version: string | null;
   buildTimeIso: string | null;
 };
 
@@ -8,12 +8,13 @@ const UNKNOWN_LABEL = '不明';
 /**
  * Reads the constants Vite injects at build time. The guards keep this usable from
  * plain `tsx` scripts and other non-bundled contexts where the constants are absent.
+ * Missing values become null so that this module owns every user-facing fallback.
  */
 export function readBuildInfo(): BuildInfo {
   const version = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__.trim() : '';
   const buildTimeIso = typeof __BUILD_TIME__ === 'string' ? __BUILD_TIME__.trim() : '';
   return {
-    version: version || UNKNOWN_LABEL,
+    version: version || null,
     buildTimeIso: buildTimeIso || null,
   };
 }
@@ -29,11 +30,14 @@ export function formatBuildTime(buildTimeIso: string | null, timeZone?: string):
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false,
+    // hourCycle rather than hour12: older WebViews resolve `hour12: false` to h24
+    // for ja-JP, which renders midnight as 24:00. hour12 would override this.
+    hourCycle: 'h23',
     timeZone,
   }).format(date);
 }
 
 export function formatBuildInfo(info: BuildInfo, timeZone?: string): string {
-  return `v${info.version} · ビルド ${formatBuildTime(info.buildTimeIso, timeZone)}`;
+  const version = info.version ? `v${info.version}` : `バージョン${UNKNOWN_LABEL}`;
+  return `${version} · ビルド ${formatBuildTime(info.buildTimeIso, timeZone)}`;
 }

--- a/src/config/build-info.ts
+++ b/src/config/build-info.ts
@@ -1,0 +1,39 @@
+export type BuildInfo = {
+  version: string;
+  buildTimeIso: string | null;
+};
+
+const UNKNOWN_LABEL = '不明';
+
+/**
+ * Reads the constants Vite injects at build time. The guards keep this usable from
+ * plain `tsx` scripts and other non-bundled contexts where the constants are absent.
+ */
+export function readBuildInfo(): BuildInfo {
+  const version = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__.trim() : '';
+  const buildTimeIso = typeof __BUILD_TIME__ === 'string' ? __BUILD_TIME__.trim() : '';
+  return {
+    version: version || UNKNOWN_LABEL,
+    buildTimeIso: buildTimeIso || null,
+  };
+}
+
+/** Formats the UTC build stamp in the viewer's own timezone, so testers read local time. */
+export function formatBuildTime(buildTimeIso: string | null, timeZone?: string): string {
+  if (!buildTimeIso) return UNKNOWN_LABEL;
+  const date = new Date(buildTimeIso);
+  if (Number.isNaN(date.getTime())) return UNKNOWN_LABEL;
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone,
+  }).format(date);
+}
+
+export function formatBuildInfo(info: BuildInfo, timeZone?: string): string {
+  return `v${info.version} · ビルド ${formatBuildTime(info.buildTimeIso, timeZone)}`;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,19 @@ body {
   padding-bottom: 12px;
 }
 
+.app-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Build stamp: testers use this to confirm the Even Hub package actually updated. */
+.build-info {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: #8b949e;
+}
+
 .controls {
   display: flex;
   flex-wrap: wrap;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { HudViewModel } from './domain/models/hud';
 import { captureRuntimeError } from './infrastructure/observability/sentry';
 import type { DiagnosticStatus } from './infrastructure/telemetry/runtime-telemetry';
 import { DEFAULT_TRACKING_CONFIG } from './config/tracking-config';
+import { formatBuildInfo, readBuildInfo } from './config/build-info';
 
 class DemoGpsReplayerProvider implements LocationProvider {
   private listener: ((sample: LocationSample) => void) | null = null;
@@ -104,7 +105,15 @@ function updateViewportDOM(model: HudViewModel): void {
   if (footerRightEl) footerRightEl.textContent = model.footer.statusRight;
 }
 
+function renderBuildInfo(): void {
+  const el = document.getElementById('build-info');
+  if (el) el.textContent = formatBuildInfo(readBuildInfo());
+}
+
 async function init() {
+  // Rendered before any await so the stamp is visible even when bootstrap fails.
+  renderBuildInfo();
+
   const debugPanel = new DebugPanel('debug-panel');
   const motionSensorProvider = new DeviceMotionSensorFusionProvider();
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+/** Injected by `define` in vite.config.ts — the Even Hub package version from app.json. */
+declare const __APP_VERSION__: string;
+/** Injected by `define` in vite.config.ts — ISO 8601 UTC timestamp of the build. */
+declare const __BUILD_TIME__: string;

--- a/tests/config/build-info.test.ts
+++ b/tests/config/build-info.test.ts
@@ -7,6 +7,7 @@ describe('formatBuildTime', () => {
     expect(formatBuildTime('2026-08-19T07:48:00.000Z', 'Asia/Tokyo')).toBe('2026/08/19 16:48');
   });
 
+  // ja-JP resolves to h24 on some WebViews unless hourCycle is pinned, printing 24:00.
   it('renders midnight as 00 rather than 24', () => {
     expect(formatBuildTime('2026-08-19T15:00:00.000Z', 'Asia/Tokyo')).toBe('2026/08/20 00:00');
   });
@@ -22,6 +23,10 @@ describe('formatBuildInfo', () => {
     expect(
       formatBuildInfo({ version: '0.1.0', buildTimeIso: '2026-08-19T07:48:00.000Z' }, 'Asia/Tokyo')
     ).toBe('v0.1.0 · ビルド 2026/08/19 16:48');
+  });
+
+  it('falls back in Japanese rather than printing a bare v prefix', () => {
+    expect(formatBuildInfo({ version: null, buildTimeIso: null })).toBe('バージョン不明 · ビルド 不明');
   });
 });
 

--- a/tests/config/build-info.test.ts
+++ b/tests/config/build-info.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { formatBuildInfo, formatBuildTime, readBuildInfo } from '../../src/config/build-info';
 
@@ -26,8 +27,9 @@ describe('formatBuildInfo', () => {
 
 describe('readBuildInfo', () => {
   it('reads the constants Vite injects at build time', () => {
+    const { version } = JSON.parse(readFileSync(new URL('../../app.json', import.meta.url), 'utf8'));
     const info = readBuildInfo();
-    expect(info.version).toBe('0.1.0');
+    expect(info.version).toBe(version);
     expect(info.buildTimeIso).not.toBeNull();
     expect(Number.isNaN(new Date(info.buildTimeIso as string).getTime())).toBe(false);
   });

--- a/tests/config/build-info.test.ts
+++ b/tests/config/build-info.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatBuildInfo, formatBuildTime, readBuildInfo } from '../../src/config/build-info';
+
+describe('formatBuildTime', () => {
+  it('renders the UTC build stamp in the requested timezone', () => {
+    expect(formatBuildTime('2026-08-19T07:48:00.000Z', 'Asia/Tokyo')).toBe('2026/08/19 16:48');
+  });
+
+  it('renders midnight as 00 rather than 24', () => {
+    expect(formatBuildTime('2026-08-19T15:00:00.000Z', 'Asia/Tokyo')).toBe('2026/08/20 00:00');
+  });
+
+  it('falls back when the stamp is missing or unparseable', () => {
+    expect(formatBuildTime(null)).toBe('不明');
+    expect(formatBuildTime('not-a-date')).toBe('不明');
+  });
+});
+
+describe('formatBuildInfo', () => {
+  it('shows the version and the build time together', () => {
+    expect(
+      formatBuildInfo({ version: '0.1.0', buildTimeIso: '2026-08-19T07:48:00.000Z' }, 'Asia/Tokyo')
+    ).toBe('v0.1.0 · ビルド 2026/08/19 16:48');
+  });
+});
+
+describe('readBuildInfo', () => {
+  it('reads the constants Vite injects at build time', () => {
+    const info = readBuildInfo();
+    expect(info.version).toBe('0.1.0');
+    expect(info.buildTimeIso).not.toBeNull();
+    expect(Number.isNaN(new Date(info.buildTimeIso as string).getTime())).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,8 @@ export default defineConfig(({ mode }) => {
         ]
       : [],
     define: {
-      __APP_VERSION__: JSON.stringify(appManifest.version ?? 'unknown'),
+      // Empty rather than a placeholder: build-info.ts owns the user-facing fallback.
+      __APP_VERSION__: JSON.stringify(appManifest.version ?? ''),
       __BUILD_TIME__: JSON.stringify(buildTimeIso),
     },
     build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig, loadEnv } from 'vite';
+import { readFileSync } from 'node:fs';
 import path from 'path';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+
+// The Even Hub package manifest is the version testers actually install, so the
+// on-screen stamp reads from app.json rather than package.json.
+const appManifest = JSON.parse(readFileSync(path.resolve(__dirname, './app.json'), 'utf8')) as {
+  version?: string;
+};
+const buildTimeIso = new Date().toISOString();
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -24,6 +32,10 @@ export default defineConfig(({ mode }) => {
           }),
         ]
       : [],
+    define: {
+      __APP_VERSION__: JSON.stringify(appManifest.version ?? 'unknown'),
+      __BUILD_TIME__: JSON.stringify(buildTimeIso),
+    },
     build: {
       sourcemap: sentryUploadEnabled ? 'hidden' : false,
     },


### PR DESCRIPTION
## 背景

Even Hub で開くデバッグ画面を見ても、パッケージが更新されたのかどうか分からなかった。

## 変更内容

- `vite.config.ts` の `define` で `__APP_VERSION__`（`app.json` の `version`）と `__BUILD_TIME__`（ビルド時刻の ISO 8601 UTC）をコンパイル時定数として埋め込む
- `src/config/build-info.ts` に DOM 非依存の整形ヘルパーを追加。UTC で埋め込んだ時刻を端末のローカルタイムゾーンで `ja-JP` 表記に整形する
- ヘッダーのタイトル直下に `v0.1.0 · ビルド 2026/08/19 16:52` を表示

バージョンの出典は `package.json` ではなく `app.json` にした。Even Hub にインストールされるパッケージのバージョンがこちらのため。

表示は `init()` の最初の `await` より前に実行するので、**bootstrap が失敗したビルドでもスタンプは出る**。更新確認が一番必要なのは新ビルドが壊れている時なので、デバッグパネル内のカードではなくヘッダーに置いた。

`app.json` / `package.json` のバージョンは普段動かないため、実質の判別材料はビルド日時。

## 検証

- `pnpm lint` — 通過
- `pnpm test` — 36 ファイル / 257 テスト通過（新規 `tests/config/build-info.test.ts` 5 件を含む）
- `pnpm build` 後、`dist/assets/*.js` にバージョンとビルド時刻が実際にインライン化されていることを確認
- `pnpm preview` を Playwright で開き、モバイル幅（390px）でスクロールなしに表示されることを確認。`v0.1.0 · ビルド 2026/08/19 16:52`（JST 表示）

## 補足

git のコミットハッシュ表示は入れていない。依頼はバージョンとビルド日時であり、日時だけで更新判別の目的は満たせるため。必要であれば追加可能（`vite.config.ts` で `execSync` が必要になり、リポジトリ外でのビルドが失敗し得る点は要検討）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSd35KQjCjapcCJX7UyNet