### PR TITLE
Bump app package to 0.1.1 for Even Hub beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ R2_CORS_ALLOWED_ORIGINS=https://railglance.example,https://railglance-preview.ex
 # Error tracking. The DSN is intentionally a browser-visible project endpoint, not a secret.
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
-VITE_APP_RELEASE=railglance@0.1.0
+VITE_APP_RELEASE=railglance@0.1.1
 VITE_APP_ENVIRONMENT=prototype
 
 # Build-time source map upload (CI/build environment only; never VITE_-prefixed).

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "package_id": "com.railglance.traintracker",
   "edition": "202601",
   "name": "RailGlance Train HUD",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "min_app_version": "2.0.0",
   "min_sdk_version": "0.0.12",
   "entrypoint": "index.html",

--- a/infra/cloudflare/telemetry-worker/wrangler.toml
+++ b/infra/cloudflare/telemetry-worker/wrangler.toml
@@ -46,7 +46,7 @@ dead_letter_queue = "railglance-telemetry-dlq"
 TELEMETRY_ALLOWED_ORIGINS = "http://localhost:5173"
 TELEMETRY_CAMPAIGN_ID = "railglance-beta-2026"
 TELEMETRY_QUALIFICATION_DAYS = "14"
-TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0"
+TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1"
 TELEMETRY_TOKEN_TTL_SECONDS = "900"
 
 # Set with `wrangler secret put`; never place either value in this file or the .ehpk.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "railglance",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently -k -s first \"vite\" \"wait-on http://localhost:5173 && evenhub-simulator http://localhost:5173\"",


### PR DESCRIPTION
## Summary

Even App does not treat the current 0.1.0 package as a new update. This raises the app package to 0.1.1 so `Build Even Hub Beta Package` can emit a distinct release.

- `package.json` and `app.json` both become `0.1.1` (the workflow requires them to match)
- `.env.example` shows `VITE_APP_RELEASE=railglance@0.1.1`
- Telemetry allowlist keeps `0.1.0` and adds `0.1.1`

## After merge

1. Set GitHub Environment `evenhub-beta` variable `VITE_APP_RELEASE` to `railglance@0.1.1`. The workflow fails if this still says `railglance@0.1.0`.
2. Redeploy the telemetry worker so production `TELEMETRY_ALLOWED_RELEASES` includes `railglance@0.1.1`.
3. Run `Actions` → `Build Even Hub Beta Package` on **main**.
4. Register the `out.ehpk` artifact in Even Hub Private Testing.

## Test plan

- [x] `package.json` and `app.json` versions match
- [x] `pnpm exec vitest run tests/config/build-info.test.ts`
- [ ] Merge to main, update `VITE_APP_RELEASE`, run the beta package workflow
- [ ] Confirm the Even Hub header shows `v0.1.1` after install