### PR TITLE
fix: recover Even G2 HUD when a native SDK transfer never settles (#50)

### DIFF
--- a/docs/EVEN_G2_HUD_TRANSPORT_RECOVERY.md
+++ b/docs/EVEN_G2_HUD_TRANSPORT_RECOVERY.md
@@ -63,7 +63,7 @@ stall 扱いになり、不要なページ再構築が増える。
    以後は AppController の再接続ループ（1s → 10s）が `connect()` をやり直す。
    `connect()` の `createStartUpPageContainer` も watchdog 付きなので、
    アダプタ自身が再構築を無限に回し続けない。
-4. 連続失敗カウンタは、HUD flush が 60 秒間健全に完了した時点でリセットする。
+4. 連続失敗カウンタは、回復の成功そのものではリセットせず、HUD flush が 60 秒間健全に完了した時点でリセットする。
 
 `FOREGROUND_ENTER` の既存回復は残す。初回失敗で即 disconnect するのは
 フォアグラウンド復帰経路だけ。transport-stall 経路は上記バックオフが担当する。

--- a/docs/EVEN_G2_HUD_TRANSPORT_RECOVERY.md
+++ b/docs/EVEN_G2_HUD_TRANSPORT_RECOVERY.md
@@ -1,0 +1,101 @@
+# Even G2 HUD 転送フリーズからの回復
+
+実機の Even G2 グラス HUD だけが固まり、スマートフォン側（GPS、速度推定、路線マッチング、
+JourneyState、DebugPanel）は更新され続ける、という症状への対策。
+
+## 症状
+
+グラスの速度画像・テキストが途中から更新されない。スマートフォンの Web プレビューと
+DebugPanel の `G2 PNG Update Status` は `success` のまま進む。アプリ再起動以外に回復手段がない。
+
+## 原因
+
+`HybridEvenG2Adapter` のネイティブ Even Hub SDK 呼び出し（`updateImageRawData`、
+`textContainerUpgrade`、ページ作成/再構築/終了）を、完了期限なしで `await` していた。
+すべての BLE 操作は単一の `bridgeQueue` で直列化されているため、どれか 1 本が
+resolve も reject もしないと、以降の HUD 更新がグラスへ届かない。
+
+`lastImageResult` は最後に *完了した* 転送だけを記録するので、ハング中は DebugPanel に
+手がかりが出ない。SDK にキャンセル API はなく、`Promise.race` でラッパーだけ切って
+次の通常 BLE 操作を始めると、未完了の転送と次の転送が電波上で重なる。
+
+## Watchdog の設計
+
+すべてのネイティブ呼び出しを `runNativeOperation()` 経由にする。
+
+- 操作種別ごとに `setTimeout` を武装する（text / image / page）。
+- SDK の Promise 自体は放棄しない。キャンセルできないため、遅延完了は
+  epoch ガード付きの継続としてテレメトリとログだけに使う。
+- Watchdog が先に発火したら、ラッパーは `{ status: 'stalled' }` で解決する。
+  呼び出し元（`connect()` / `recoverPage()` / `clear()` / HUD flush）と
+  回復バックオフが進めるようにするため。
+- ラッパーが解決する時点で `handleTransportStall()` はすでに
+  セッション epoch を進め、キューを切断し、`pageReady` を落としている。
+  タイムアウトを理由に *次の通常 HUD 操作* が始まることはない。
+
+古いセッションの完了が新しいセッションのテキストキャッシュ、
+`lastImageResult`、`lastRenderedSpeedKmh` を上書きしない。
+
+## タイムアウト既定値
+
+| 操作 | 既定 | オプション |
+| --- | --- | --- |
+| テキスト（header / segment / footer） | 5,000 ms | `textOperationTimeoutMs` |
+| 速度画像 | 8,000 ms | `imageOperationTimeoutMs` |
+| ページ作成 / 再構築 / 終了 | 10,000 ms | `pageOperationTimeoutMs` |
+| テキスト遅延警告 | 1,000 ms | `textSlowWarnMs` |
+| 画像・ページ遅延警告 | 3,000 ms | `imageSlowWarnMs` |
+| 回復前の settle grace | 2,000 ms | `stallSettleGraceMs` |
+
+値の検証は `resolvePositiveTimeoutMs` に統一している。非有限・0 以下は既定へ戻し、
+`2,147,483,647` 超は `setTimeout` が即発火しないようクランプする。
+実機で転送が恒常的に遅い場合はオプションを延ばす。短くしすぎると健全な転送まで
+stall 扱いになり、不要なページ再構築が増える。
+
+## 回復とバックオフ
+
+1. ハングしたネイティブ操作に `stallSettleGraceMs` だけ完了の猶予を与える。
+   永遠に待たないための妥協であり、grace 後も未完了なら 1 本の SDK Promise が
+   残ったまま新しい BLE を出す可能性がある。
+2. 再構築を `[0, 1,000, 3,000]` ms のバックオフで最大 3 回試す（1 回目は即時）。
+   成功したらキャッシュを無効化し、最新の ViewModel をフル flush する。
+3. 3 回連続で失敗したら `markDisconnected('transport stall recovery exhausted')`。
+   以後は AppController の再接続ループ（1s → 10s）が `connect()` をやり直す。
+   `connect()` の `createStartUpPageContainer` も watchdog 付きなので、
+   アダプタ自身が再構築を無限に回し続けない。
+4. 連続失敗カウンタは、HUD flush が 60 秒間健全に完了した時点でリセットする。
+
+`FOREGROUND_ENTER` の既存回復は残す。初回失敗で即 disconnect するのは
+フォアグラウンド復帰経路だけ。transport-stall 経路は上記バックオフが担当する。
+
+## DebugPanel
+
+既存の `G2 PNG Update Status` は動かさない。新しいカード
+「Even G2 Bridge Transport」に次を出す。
+
+G2 Connection status、Page Ready、Session Epoch、Current Native Operation、
+Operation Age（秒、小数 1 桁。画像タイムアウト超過時は赤 `#FF6666`）、
+Last Completed Operation、Last Completed、Last Operation Duration、
+Last Image Result、Last Image Completed、Render Generation、Flushed Generation、
+HUD Flush Scheduled、HUD Flush In Flight、HUD Dirty、Recovery Count、
+Last Recovery Reason。
+
+## テレメトリ
+
+- `bridge-operation` イベント: すべてのネイティブ操作の完了 / エラー / stall。
+  `SentryTelemetrySink` は `state-transition` 以外を捨て、診断シンクは診断モード中だけ
+  記録するので本番コストは小さい。診断キャプチャで所要時間の分布を取れる。
+- `state-transition`（category `bridge`）はライフサイクルだけ:
+  `bridge-page-ready`、`bridge-operation-slow`、`bridge-operation-stalled`、
+  `bridge-recovery-start`、`bridge-recovery-success`、`bridge-recovery-failed`。
+- 既存の `addRuntimeBreadcrumb` はそのまま。stall 時に warning breadcrumb を 1 本足す。
+- `estimation.bridge` に任意フィールド `stalled` / `currentOperation` /
+  `sessionEpoch` / `recoveryCount` を足す。`TELEMETRY_SCHEMA_VERSION = 1` のまま。
+
+## 既知の制約
+
+SDK にキャンセルがないため、本当に固まったネイティブ呼び出しは
+未解決の Promise を 1 本残す。回復後の新しい BLE と時間的に重なり得る。
+アダプタはそれをセッション epoch で隔離し、古い完了が新しい HUD 状態へ
+書き戻らないことだけを保証する。アプリ再起動や速度画像の恒久無効化、
+キューの並列化は行わない。

--- a/infra/cloudflare/telemetry-worker/src/index.ts
+++ b/infra/cloudflare/telemetry-worker/src/index.ts
@@ -206,6 +206,11 @@ function optionalStringField(source: JsonObject, key: string): JsonObject {
   return value === undefined ? {} : { [key]: value };
 }
 
+function optionalBooleanField(source: JsonObject, key: string): JsonObject {
+  if (!(key in source)) return {};
+  return typeof source[key] === 'boolean' ? { [key]: source[key] } : {};
+}
+
 function sanitizeBase(value: JsonObject): JsonObject | null {
   const timestampMs = finiteNumber(value.timestampMs);
   const datasetVersion = value.datasetVersion === undefined ? null : nullableString(value.datasetVersion);
@@ -338,7 +343,42 @@ function sanitizeEstimation(value: JsonObject, base: JsonObject): JsonObject | n
       ...optionalStringField(match, 'switchReason'),
     },
     journey: { previousStationId, nextStationId, ...journeyNumbers },
-    bridge: { connected: bridge.connected, lastImageResult: bridge.lastImageResult.slice(0, 500) },
+    bridge: {
+      connected: bridge.connected,
+      lastImageResult: bridge.lastImageResult.slice(0, 500),
+      ...optionalBooleanField(bridge, 'stalled'),
+      ...optionalStringField(bridge, 'currentOperation'),
+      ...optionalNumberField(bridge, 'sessionEpoch'),
+      ...optionalNumberField(bridge, 'recoveryCount'),
+    },
+  };
+}
+
+function sanitizeBridgeOperation(value: JsonObject, base: JsonObject): JsonObject | null {
+  if (typeof value.operation !== 'string' || value.operation.length === 0 || value.operation.length > 80) {
+    return null;
+  }
+  const sequence = finiteNumber(value.sequence);
+  const sessionEpoch = finiteNumber(value.sessionEpoch);
+  const startedAtMs = finiteNumber(value.startedAtMs);
+  if (sequence === null || sessionEpoch === null || startedAtMs === null) return null;
+  const result = value.result === undefined ? undefined : nullableString(value.result, 500);
+  const error = value.error === undefined ? undefined : nullableString(value.error, 500);
+  if (value.result !== undefined && result === undefined) return null;
+  if (value.error !== undefined && error === undefined) return null;
+  return {
+    ...base,
+    type: 'bridge-operation',
+    operation: value.operation,
+    sequence,
+    sessionEpoch,
+    startedAtMs,
+    ...optionalNumberField(value, 'completedAtMs'),
+    ...optionalNumberField(value, 'elapsedMs'),
+    ...(result !== undefined ? { result } : {}),
+    ...optionalBooleanField(value, 'stalled'),
+    ...optionalBooleanField(value, 'slow'),
+    ...(error !== undefined ? { error } : {}),
   };
 }
 
@@ -369,6 +409,7 @@ export function sanitizeEvent(value: unknown): JsonObject | null {
   if (source.type === 'gps-observation') return sanitizeGps(source, base);
   if (source.type === 'estimation') return sanitizeEstimation(source, base);
   if (source.type === 'state-transition') return sanitizeTransition(source, base);
+  if (source.type === 'bridge-operation') return sanitizeBridgeOperation(source, base);
   return null;
 }
 

--- a/src/app/app-controller.ts
+++ b/src/app/app-controller.ts
@@ -586,6 +586,7 @@ export class AppController {
       captureRuntimeError(error, 'even-g2-render');
     });
 
+    const bridge = this.evenG2Adapter.getBridgeDiagnostics?.();
     const logEntry: EstimationLogEntry = {
       timestampMs: now,
       rawLocation: this.latestSample,
@@ -595,6 +596,10 @@ export class AppController {
       hudViewModel: this.currentViewModel,
       bridgeConnected: this.evenG2Adapter.isBridgeConnected?.() ?? false,
       lastImageResult: this.evenG2Adapter.getLastImageResult(),
+      bridgeStalled: bridge?.operation.stalled,
+      bridgeCurrentOperation: bridge?.operation.currentOperation,
+      bridgeSessionEpoch: bridge?.sessionEpoch,
+      bridgeRecoveryCount: bridge?.recoveryCount,
     };
     this.logger.log(logEntry);
   }

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -49,7 +49,9 @@ export async function bootstrapApp(
 
   // AdaptiveLocationProvider tries Even App location first (for Prototype mode & native app), falling back to Browser Geolocation
   const locationProvider = customLocationProvider ?? new AdaptiveLocationProvider();
-  const evenG2Adapter = new HybridEvenG2Adapter(onHudRender);
+  const evenG2Adapter = new HybridEvenG2Adapter(onHudRender, {
+    telemetry: { sink: telemetryManager, identity: telemetryIdentity },
+  });
   const logger = new EstimationLogger(
     telemetryIdentity,
     telemetryManager,

--- a/src/infrastructure/even-app/bridge-ready.ts
+++ b/src/infrastructure/even-app/bridge-ready.ts
@@ -19,15 +19,50 @@ export const DEFAULT_BRIDGE_READY_TIMEOUT_MS = 10_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
- * Resolves a caller-supplied handshake bound to a delay `setTimeout` can honour.
+ * Resolves a caller-supplied delay to a value `setTimeout` can honour.
  *
  * `setTimeout` never rejects a bad delay, it quietly substitutes 1ms:
  * `Infinity`, `NaN` and negatives all fire on the next tick. Passing one
- * through would not restore the unbounded wait this bound exists to prevent —
- * it causes the opposite failure, a handshake that expires before the bridge
- * can ever answer, leaving the caller permanently unable to connect. Values
- * over {@link MAX_TIMER_DELAY_MS} overflow into the same instant-fire
- * behaviour, so they are clamped rather than rejected.
+ * through would not restore the unbounded wait a timeout exists to prevent —
+ * it causes the opposite failure, a timer that expires before the work can
+ * ever finish. Values over {@link MAX_TIMER_DELAY_MS} overflow into the same
+ * instant-fire behaviour, so they are clamped rather than rejected.
+ *
+ * @param optionName Field name used in the warning, e.g. `bridgeReadyTimeoutMs`.
+ * @param logPrefix Owner tag for the warning, e.g. `[EvenG2Adapter]`.
+ */
+export function resolvePositiveTimeoutMs(
+  value: number | undefined,
+  fallbackMs: number,
+  optionName: string,
+  logPrefix: string
+): number {
+  if (value === undefined) return fallbackMs;
+
+  if (!Number.isFinite(value) || value <= 0) {
+    console.warn(
+      `${logPrefix} Ignoring invalid ${optionName} (${value}); ` +
+        `falling back to ${fallbackMs}ms.`
+    );
+    return fallbackMs;
+  }
+
+  if (value > MAX_TIMER_DELAY_MS) {
+    console.warn(
+      `${logPrefix} Clamping ${optionName} (${value}) to ` +
+        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+
+  return value;
+}
+
+/**
+ * Resolves a caller-supplied handshake bound to a delay `setTimeout` can honour.
+ *
+ * See {@link resolvePositiveTimeoutMs} for why invalid values must not reach
+ * `setTimeout` unchanged.
  *
  * @param logPrefix Owner tag for the warning, e.g. `[EvenG2Adapter]`.
  */
@@ -35,25 +70,12 @@ export function resolveBridgeReadyTimeoutMs(
   value: number | undefined,
   logPrefix: string
 ): number {
-  if (value === undefined) return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
-
-  if (!Number.isFinite(value) || value <= 0) {
-    console.warn(
-      `${logPrefix} Ignoring invalid bridgeReadyTimeoutMs (${value}); ` +
-        `falling back to ${DEFAULT_BRIDGE_READY_TIMEOUT_MS}ms.`
-    );
-    return DEFAULT_BRIDGE_READY_TIMEOUT_MS;
-  }
-
-  if (value > MAX_TIMER_DELAY_MS) {
-    console.warn(
-      `${logPrefix} Clamping bridgeReadyTimeoutMs (${value}) to ` +
-        `${MAX_TIMER_DELAY_MS}ms, the longest delay setTimeout can hold.`
-    );
-    return MAX_TIMER_DELAY_MS;
-  }
-
-  return value;
+  return resolvePositiveTimeoutMs(
+    value,
+    DEFAULT_BRIDGE_READY_TIMEOUT_MS,
+    'bridgeReadyTimeoutMs',
+    logPrefix
+  );
 }
 
 let pendingHandshake: Promise<EvenAppBridge> | null = null;

--- a/src/infrastructure/even-g2/bridge-operation.ts
+++ b/src/infrastructure/even-g2/bridge-operation.ts
@@ -1,0 +1,68 @@
+export type BridgeOperationKind =
+  | 'text-header'
+  | 'text-segment'
+  | 'text-footer'
+  | 'speed-image'
+  | 'page-create'
+  | 'page-recover'
+  | 'page-shutdown';
+
+export type BridgeTransportStatus = 'DISCONNECTED' | 'CONNECTED' | 'STALLED' | 'RECOVERING';
+
+export type BridgeRecoveryReason = 'foreground-enter' | 'transport-stall';
+
+export type BridgeOperationState = {
+  sequence: number;
+  currentOperation: BridgeOperationKind | null;
+  currentStartedAtMs: number | null;
+  lastCompletedOperation: BridgeOperationKind | null;
+  lastCompletedAtMs: number | null;
+  lastElapsedMs: number | null;
+  lastResult: string | null;
+  lastError: string | null;
+  stalled: boolean;
+};
+
+export type BridgeDiagnosticsSnapshot = {
+  status: BridgeTransportStatus;
+  pageReady: boolean;
+  sessionEpoch: number;
+  operation: BridgeOperationState;
+  operationAgeMs: number | null;
+  lastImageResult: string;
+  lastImageCompletedAtMs: number | null;
+  renderGeneration: number;
+  flushedGeneration: number;
+  hudFlushScheduled: boolean;
+  hudFlushInFlight: boolean;
+  hudDirty: boolean;
+  recoveryCount: number;
+  stallRecoveryFailures: number;
+  lastRecoveryReason: string | null;
+  lastRecoveryAtMs: number | null;
+};
+
+export const DEFAULT_TEXT_OPERATION_TIMEOUT_MS = 5_000;
+export const DEFAULT_IMAGE_OPERATION_TIMEOUT_MS = 8_000;
+export const DEFAULT_PAGE_OPERATION_TIMEOUT_MS = 10_000;
+export const DEFAULT_TEXT_SLOW_WARN_MS = 1_000;
+export const DEFAULT_IMAGE_SLOW_WARN_MS = 3_000;
+/** Bounded wait for a stalled native op to settle before recovery issues new BLE traffic. */
+export const DEFAULT_STALL_SETTLE_GRACE_MS = 2_000;
+
+export const STALL_RECOVERY_BACKOFF_MS = [0, 1_000, 3_000] as const;
+export const RECOVERY_HEALTH_RESET_MS = 60_000;
+
+export function emptyBridgeOperationState(): BridgeOperationState {
+  return {
+    sequence: 0,
+    currentOperation: null,
+    currentStartedAtMs: null,
+    lastCompletedOperation: null,
+    lastCompletedAtMs: null,
+    lastElapsedMs: null,
+    lastResult: null,
+    lastError: null,
+    stalled: false,
+  };
+}

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -309,6 +309,13 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     this.pageReady = false;
     this.transportStatus = 'DISCONNECTED';
     this.healthyStreakStartedAtMs = null;
+    // An unsettled native promise may still exist, but it is no longer
+    // attributable to any live session. The epoch-guarded late continuation
+    // still reports it when/if it settles.
+    this.operationState.currentOperation = null;
+    this.operationState.currentStartedAtMs = null;
+    this.operationState.stalled = false;
+    this.stalledEpoch = null;
     if (wasConnected) {
       console.warn(`[EvenG2Adapter] Disconnected: ${reason}`);
       addRuntimeBreadcrumb('railglance.bridge', 'Even G2 disconnected', { reason }, 'warning');
@@ -1127,7 +1134,6 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
           this.operationState.stalled = false;
           this.stalledEpoch = null;
           this.transportStatus = 'CONNECTED';
-          this.stallRecoveryFailures = 0;
           this.emitBridgeLifecycle('bridge-recovery-success', {
             reason: 'transport-stall',
             sessionEpoch: this.sessionEpoch,

--- a/src/infrastructure/even-g2/even-g2-adapter.ts
+++ b/src/infrastructure/even-g2/even-g2-adapter.ts
@@ -13,12 +13,36 @@ import { HudViewModel } from '../../domain/models/hud';
 import {
   DEFAULT_BRIDGE_READY_TIMEOUT_MS,
   resolveBridgeReadyTimeoutMs,
+  resolvePositiveTimeoutMs,
   waitForEvenAppBridgeWithin,
 } from '../even-app/bridge-ready';
 import { createSpeedPng } from './speed-png-generator';
 import { addRuntimeBreadcrumb, captureRuntimeError } from '../observability/sentry';
+import type { TelemetryIdentity } from '../telemetry/types';
+import {
+  createBridgeOperationTelemetryEvent,
+  createStateTransitionTelemetryEvent,
+} from '../telemetry/types';
+import type { TelemetrySink } from '../telemetry/sinks';
+import {
+  type BridgeDiagnosticsSnapshot,
+  type BridgeOperationKind,
+  type BridgeOperationState,
+  type BridgeRecoveryReason,
+  type BridgeTransportStatus,
+  DEFAULT_IMAGE_OPERATION_TIMEOUT_MS,
+  DEFAULT_IMAGE_SLOW_WARN_MS,
+  DEFAULT_PAGE_OPERATION_TIMEOUT_MS,
+  DEFAULT_STALL_SETTLE_GRACE_MS,
+  DEFAULT_TEXT_OPERATION_TIMEOUT_MS,
+  DEFAULT_TEXT_SLOW_WARN_MS,
+  emptyBridgeOperationState,
+  RECOVERY_HEALTH_RESET_MS,
+  STALL_RECOVERY_BACKOFF_MS,
+} from './bridge-operation';
 
 export { DEFAULT_BRIDGE_READY_TIMEOUT_MS };
+export type { BridgeDiagnosticsSnapshot };
 
 const BRIDGE_TIMEOUT_LOG_PREFIX = '[EvenG2Adapter]';
 
@@ -31,6 +55,13 @@ export interface HybridEvenG2AdapterOptions {
    * are clamped.
    */
   bridgeReadyTimeoutMs?: number;
+  textOperationTimeoutMs?: number;
+  imageOperationTimeoutMs?: number;
+  pageOperationTimeoutMs?: number;
+  textSlowWarnMs?: number;
+  imageSlowWarnMs?: number;
+  stallSettleGraceMs?: number;
+  telemetry?: { sink: TelemetrySink; identity: TelemetryIdentity };
 }
 
 export interface EvenG2Adapter {
@@ -45,15 +76,37 @@ export interface EvenG2Adapter {
    * Optional — AppController uses it for auto-reconnect when present.
    */
   waitUntilDisconnected?(): Promise<void>;
+  getBridgeDiagnostics?(): BridgeDiagnosticsSnapshot;
 }
+
+type NativeOperationOutcome<T> =
+  | { status: 'completed'; value: T }
+  | { status: 'stale' }
+  | { status: 'stalled' };
+
+type BridgeOperationTelemetryPayload = {
+  operation: BridgeOperationKind;
+  sequence: number;
+  sessionEpoch: number;
+  startedAtMs: number;
+  completedAtMs?: number;
+  elapsedMs?: number;
+  result?: string;
+  stalled?: boolean;
+  slow?: boolean;
+  error?: string;
+};
 
 /**
  * Hybrid Even G2 adapter.
  *
  * Design constraints (Even Hub SDK):
  * - Native BLE ops must stay strictly serial (single bridgeQueue).
- * - Never Promise.race-timeout a native image transfer and start another one
- *   while the first is still in flight (no cancel API).
+ * - Never Promise.race-timeout a native image transfer and start another
+ *   *normal* BLE op while the first is still in flight (no cancel API).
+ *   A watchdog timeout means the transport session is broken: the wrapper
+ *   settles so callers can recover, but the SDK promise is never abandoned
+ *   and the queue is amputated so the next HUD op cannot start on it.
  *
  * Freeze-resistance:
  * - render() is non-blocking for callers (web preview updates immediately).
@@ -67,6 +120,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   private isConnected = false;
   private pageReady = false;
   private lastImageResult = 'none';
+  private lastImageCompletedAtMs: number | null = null;
   private unsubscribeHubEvents: (() => void) | null = null;
 
   private bridgeQueue: Promise<void> = Promise.resolve();
@@ -86,8 +140,14 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   /** Monotonic generation of lastModel; used for latest-wins coalescing. */
   private renderGeneration = 0;
   private flushedGeneration = 0;
-  /** True when a coalesced HUD flush is already queued on bridgeQueue. */
-  private hudFlushQueued = false;
+  /** A flush sits on bridgeQueue, not started yet. */
+  private hudFlushScheduled = false;
+  /** The flush body is running. */
+  private hudFlushInFlight = false;
+  /** lastModel is newer than flushedGeneration. */
+  private hudDirty = false;
+  private scheduledGeneration = 0;
+  private inFlightGeneration = 0;
 
   private disconnectWaiters: Array<() => void> = [];
 
@@ -101,7 +161,31 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
    */
   private sessionEpoch = 0;
 
+  /**
+   * Stall is tracked per session epoch, not as a plain boolean.
+   *
+   * Recovery rebuilds run under epoch N+1. A boolean "already stalled" flag
+   * set by the original stall would swallow the rebuild's own stall and leave
+   * that newer session wedged with no recovery.
+   */
+  private stalledEpoch: number | null = null;
+  private transportStatus: BridgeTransportStatus = 'DISCONNECTED';
+  private operationState: BridgeOperationState = emptyBridgeOperationState();
+  private isRecoveringTransport = false;
+  private recoveryCount = 0;
+  private stallRecoveryFailures = 0;
+  private lastRecoveryReason: string | null = null;
+  private lastRecoveryAtMs: number | null = null;
+  private healthyStreakStartedAtMs: number | null = null;
+
   private readonly bridgeReadyTimeoutMs: number;
+  private readonly textOperationTimeoutMs: number;
+  private readonly imageOperationTimeoutMs: number;
+  private readonly pageOperationTimeoutMs: number;
+  private readonly textSlowWarnMs: number;
+  private readonly imageSlowWarnMs: number;
+  private readonly stallSettleGraceMs: number;
+  private readonly telemetry?: { sink: TelemetrySink; identity: TelemetryIdentity };
 
   constructor(
     onRender?: (formattedText: string, model: HudViewModel) => void,
@@ -112,6 +196,43 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
       options.bridgeReadyTimeoutMs,
       BRIDGE_TIMEOUT_LOG_PREFIX
     );
+    this.textOperationTimeoutMs = resolvePositiveTimeoutMs(
+      options.textOperationTimeoutMs,
+      DEFAULT_TEXT_OPERATION_TIMEOUT_MS,
+      'textOperationTimeoutMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.imageOperationTimeoutMs = resolvePositiveTimeoutMs(
+      options.imageOperationTimeoutMs,
+      DEFAULT_IMAGE_OPERATION_TIMEOUT_MS,
+      'imageOperationTimeoutMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.pageOperationTimeoutMs = resolvePositiveTimeoutMs(
+      options.pageOperationTimeoutMs,
+      DEFAULT_PAGE_OPERATION_TIMEOUT_MS,
+      'pageOperationTimeoutMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.textSlowWarnMs = resolvePositiveTimeoutMs(
+      options.textSlowWarnMs,
+      DEFAULT_TEXT_SLOW_WARN_MS,
+      'textSlowWarnMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.imageSlowWarnMs = resolvePositiveTimeoutMs(
+      options.imageSlowWarnMs,
+      DEFAULT_IMAGE_SLOW_WARN_MS,
+      'imageSlowWarnMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.stallSettleGraceMs = resolvePositiveTimeoutMs(
+      options.stallSettleGraceMs,
+      DEFAULT_STALL_SETTLE_GRACE_MS,
+      'stallSettleGraceMs',
+      BRIDGE_TIMEOUT_LOG_PREFIX
+    );
+    this.telemetry = options.telemetry;
   }
 
   public getLastImageResult(): string {
@@ -120,6 +241,28 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
   public isBridgeConnected(): boolean {
     return this.isConnected && this.pageReady;
+  }
+
+  public getBridgeDiagnostics(): BridgeDiagnosticsSnapshot {
+    const currentStartedAtMs = this.operationState.currentStartedAtMs;
+    return {
+      status: this.transportStatus,
+      pageReady: this.pageReady,
+      sessionEpoch: this.sessionEpoch,
+      operation: { ...this.operationState },
+      operationAgeMs: currentStartedAtMs === null ? null : Date.now() - currentStartedAtMs,
+      lastImageResult: this.lastImageResult,
+      lastImageCompletedAtMs: this.lastImageCompletedAtMs,
+      renderGeneration: this.renderGeneration,
+      flushedGeneration: this.flushedGeneration,
+      hudFlushScheduled: this.hudFlushScheduled,
+      hudFlushInFlight: this.hudFlushInFlight,
+      hudDirty: this.hudDirty,
+      recoveryCount: this.recoveryCount,
+      stallRecoveryFailures: this.stallRecoveryFailures,
+      lastRecoveryReason: this.lastRecoveryReason,
+      lastRecoveryAtMs: this.lastRecoveryAtMs,
+    };
   }
 
   /**
@@ -136,13 +279,24 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   /**
    * Enqueues all BLE bridge operations into a single strict sequential execution queue.
    * Previous failures never poison the queue.
+   *
+   * `epoch` is captured at enqueue time (default: the live session). After a
+   * stall amputates the queue, operations already chained behind the hung
+   * promise still exist on the old chain — they must self-skip when they
+   * finally run, or they would emit BLE traffic for a dead session.
    */
-  private enqueueBridgeOperation(operation: () => Promise<void>): Promise<void> {
+  private enqueueBridgeOperation(
+    operation: () => Promise<void>,
+    epoch: number = this.sessionEpoch
+  ): Promise<void> {
     const next = this.bridgeQueue
       .catch((error) => {
         console.warn('[EvenG2Adapter] Previous bridge operation failed:', error);
       })
-      .then(operation);
+      .then(async () => {
+        if (this.sessionEpoch !== epoch) return;
+        await operation();
+      });
 
     // Keep the chain void-typed even when operation rejects.
     this.bridgeQueue = next.catch(() => {});
@@ -153,6 +307,8 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     const wasConnected = this.isConnected;
     this.isConnected = false;
     this.pageReady = false;
+    this.transportStatus = 'DISCONNECTED';
+    this.healthyStreakStartedAtMs = null;
     if (wasConnected) {
       console.warn(`[EvenG2Adapter] Disconnected: ${reason}`);
       addRuntimeBreadcrumb('railglance.bridge', 'Even G2 disconnected', { reason }, 'warning');
@@ -173,14 +329,29 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
 
       if (this.bridge) {
         const definition = this.createPageDefinition();
+        const epoch = this.sessionEpoch;
 
-        const result = await this.bridge.createStartUpPageContainer(
-          new CreateStartUpPageContainer({
-            containerTotalNum: 4,
-            ...definition,
-          })
+        const outcome = await this.runNativeOperation('page-create', epoch, () =>
+          this.bridge.createStartUpPageContainer(
+            new CreateStartUpPageContainer({
+              containerTotalNum: 4,
+              ...definition,
+            })
+          )
         );
 
+        if (outcome.status !== 'completed') {
+          // A hung createStartUpPageContainer must not park AppController's
+          // reconnect loop. The wrapper settled; treat this as a normal
+          // connect failure so backoff can retry.
+          throw new Error(
+            outcome.status === 'stalled'
+              ? 'createStartUpPageContainer stalled'
+              : 'createStartUpPageContainer became stale'
+          );
+        }
+
+        const result = outcome.value;
         console.log('[EvenG2Adapter] createStartUpPageContainer result:', {
           result,
           type: typeof result,
@@ -193,17 +364,22 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
           throw new Error(`createStartUpPageContainer failed with code: ${String(result)}`);
         }
 
-        this.lastHeaderContent = '';
-        this.lastSegmentContent = '';
-        this.lastFooterContent = '';
-        this.lastRenderedSpeedKmh = null;
-        this.lastRenderedIsEstimated = false;
-        this.lastImageUpdateTimeMs = 0;
+        this.resetHudCaches();
         this.flushedGeneration = 0;
+        this.hudFlushScheduled = false;
+        this.hudFlushInFlight = false;
+        this.hudDirty = false;
+        this.operationState.stalled = false;
+        this.stalledEpoch = null;
         this.pageReady = true;
         this.isConnected = true;
+        this.transportStatus = 'CONNECTED';
         this.sessionEpoch += 1;
         addRuntimeBreadcrumb('railglance.bridge', 'Even G2 page initialized');
+        this.emitBridgeLifecycle('bridge-page-ready', {
+          sessionEpoch: this.sessionEpoch,
+          reason: 'connect',
+        });
         this.subscribeToLifecycleEvents();
 
         // Initial image after page is ready (must stay on bridgeQueue). Failures must not block text/GPS.
@@ -233,6 +409,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   public async render(model: HudViewModel): Promise<void> {
     this.lastModel = model;
     this.renderGeneration += 1;
+    this.hudDirty = true;
 
     const rawSpeedVal =
       model.speed.displaySpeedKmhText === '--' ? null : parseInt(model.speed.displaySpeedKmhText, 10);
@@ -241,15 +418,16 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     this.latestRequestedSpeedKmh = speedKmh;
     this.latestRequestedIsEstimated = isEstimated;
 
-    // Web / console preview must never wait on BLE.
+    // Web / console preview must never wait on BLE — including when the glass
+    // transport is stalled. GPS / speed / route matching keep moving.
     const formattedText = model.rawFormattedText;
     console.log('[EvenG2 HUD Output]:\n' + formattedText);
     if (this.onRenderCallback) {
       this.onRenderCallback(formattedText, model);
     }
 
-    if (this.bridge && this.isConnected && this.pageReady) {
-      this.queueHudFlush();
+    if (this.bridge && this.isConnected && this.pageReady && !this.operationState.stalled) {
+      this.scheduleHudFlush();
     }
   }
 
@@ -257,51 +435,93 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
    * Schedule at most one pending HUD flush on the bridge queue. When it runs it
    * always applies the latest model; if newer renders arrived mid-flight, it
    * reschedules once.
+   *
+   * Invariant: at most 1 in-flight + at most 1 scheduled flush, no matter how
+   * many renders arrive (including during a stall). The dirty flag records that
+   * another flush is owed; it does not enqueue a new BLE op.
    */
-  private queueHudFlush(): void {
-    if (this.hudFlushQueued) return;
-    if (!this.bridge || !this.isConnected || !this.pageReady) return;
+  private scheduleHudFlush(): void {
+    if (this.hudFlushScheduled || this.hudFlushInFlight) return;
+    if (!this.bridge || !this.isConnected || !this.pageReady || this.operationState.stalled) return;
 
-    this.hudFlushQueued = true;
+    this.hudFlushScheduled = true;
+    this.scheduledGeneration = this.renderGeneration;
+    const epoch = this.sessionEpoch;
     void this.enqueueBridgeOperation(async () => {
-      this.hudFlushQueued = false;
+      this.hudFlushScheduled = false;
+      this.hudFlushInFlight = true;
+      this.inFlightGeneration = Math.max(this.scheduledGeneration, this.renderGeneration);
+      this.hudDirty = false;
+      try {
+        if (
+          !this.bridge ||
+          !this.isConnected ||
+          !this.pageReady ||
+          this.operationState.stalled ||
+          !this.lastModel ||
+          this.sessionEpoch !== epoch
+        ) {
+          return;
+        }
 
-      if (!this.bridge || !this.isConnected || !this.pageReady || !this.lastModel) {
-        return;
+        const model = this.lastModel;
+
+        await this.pushTextContainers(model);
+
+        if (
+          !this.pageReady ||
+          this.operationState.stalled ||
+          this.sessionEpoch !== epoch
+        ) {
+          return;
+        }
+
+        const rawSpeedVal =
+          model.speed.displaySpeedKmhText === '--' ? null : parseInt(model.speed.displaySpeedKmhText, 10);
+        const speedKmh = isNaN(rawSpeedVal as any) ? null : rawSpeedVal;
+        const isEstimated = model.speed.isEstimated;
+        const now = Date.now();
+        const isSpeedChanged =
+          speedKmh !== this.lastRenderedSpeedKmh || isEstimated !== this.lastRenderedIsEstimated;
+        const isTimeElapsed = now - this.lastImageUpdateTimeMs >= this.SPEED_IMAGE_MIN_INTERVAL_MS;
+
+        if (isSpeedChanged && isTimeElapsed) {
+          await this.pushSpeedImage(speedKmh, isEstimated, false);
+        }
+
+        if (
+          !this.pageReady ||
+          this.operationState.stalled ||
+          this.sessionEpoch !== epoch
+        ) {
+          return;
+        }
+
+        this.flushedGeneration = this.inFlightGeneration;
+        this.noteHealthyFlush();
+      } finally {
+        this.hudFlushInFlight = false;
       }
 
-      const generationAtStart = this.renderGeneration;
-      const model = this.lastModel;
-
-      await this.pushTextContainers(model);
-
-      const rawSpeedVal =
-        model.speed.displaySpeedKmhText === '--' ? null : parseInt(model.speed.displaySpeedKmhText, 10);
-      const speedKmh = isNaN(rawSpeedVal as any) ? null : rawSpeedVal;
-      const isEstimated = model.speed.isEstimated;
-      const now = Date.now();
-      const isSpeedChanged =
-        speedKmh !== this.lastRenderedSpeedKmh || isEstimated !== this.lastRenderedIsEstimated;
-      const isTimeElapsed = now - this.lastImageUpdateTimeMs >= this.SPEED_IMAGE_MIN_INTERVAL_MS;
-
-      if (isSpeedChanged && isTimeElapsed) {
-        await this.pushSpeedImage(speedKmh, isEstimated, false);
+      // Keep this tail synchronous: an await here would open a gap where
+      // render() can set hudDirty and see hudFlushInFlight still true, then
+      // the check below would miss it and drop the frame.
+      if (
+        this.hudDirty &&
+        this.isConnected &&
+        this.pageReady &&
+        !this.operationState.stalled
+      ) {
+        this.scheduleHudFlush();
       }
-
-      this.flushedGeneration = generationAtStart;
-
-      // Latest-wins: if render() advanced the generation while we were flushing, schedule again.
-      if (this.renderGeneration !== this.flushedGeneration && this.isConnected && this.pageReady) {
-        this.queueHudFlush();
-      }
-    }).catch((error) => {
+    }, epoch).catch((error) => {
       console.warn('[EvenG2Adapter] HUD flush failed:', error);
       captureRuntimeError(error, 'even-g2-hud-flush');
     });
   }
 
   private async pushTextContainers(model: HudViewModel): Promise<void> {
-    if (!this.bridge || !this.pageReady) return;
+    if (!this.bridge || !this.pageReady || this.operationState.stalled) return;
 
     const headerContent = `${model.header.lineName}               ${model.header.serviceOrDirection}`;
 
@@ -320,11 +540,15 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     const footerContent = `${model.segment.distanceToNextText}               ${model.footer.statusRight}`;
 
     if (headerContent !== this.lastHeaderContent) {
+      if (!this.pageReady || this.operationState.stalled) return;
       try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 1, containerName: 'header', content: headerContent })
+        const outcome = await this.runNativeOperation('text-header', this.sessionEpoch, () =>
+          this.bridge.textContainerUpgrade(
+            new TextContainerUpgrade({ containerID: 1, containerName: 'header', content: headerContent })
+          )
         );
-        if (updated === false) {
+        if (outcome.status !== 'completed') return;
+        if (outcome.value === false) {
           console.warn('[EvenG2Adapter] header textContainerUpgrade returned false (will retry)');
         } else {
           this.lastHeaderContent = headerContent;
@@ -336,11 +560,15 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
 
     if (segmentContent !== this.lastSegmentContent) {
+      if (!this.pageReady || this.operationState.stalled) return;
       try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 3, containerName: 'segment', content: segmentContent })
+        const outcome = await this.runNativeOperation('text-segment', this.sessionEpoch, () =>
+          this.bridge.textContainerUpgrade(
+            new TextContainerUpgrade({ containerID: 3, containerName: 'segment', content: segmentContent })
+          )
         );
-        if (updated === false) {
+        if (outcome.status !== 'completed') return;
+        if (outcome.value === false) {
           console.warn('[EvenG2Adapter] segment textContainerUpgrade returned false (will retry)');
         } else {
           this.lastSegmentContent = segmentContent;
@@ -352,11 +580,15 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     }
 
     if (footerContent !== this.lastFooterContent) {
+      if (!this.pageReady || this.operationState.stalled) return;
       try {
-        const updated = await this.bridge.textContainerUpgrade(
-          new TextContainerUpgrade({ containerID: 4, containerName: 'footer', content: footerContent })
+        const outcome = await this.runNativeOperation('text-footer', this.sessionEpoch, () =>
+          this.bridge.textContainerUpgrade(
+            new TextContainerUpgrade({ containerID: 4, containerName: 'footer', content: footerContent })
+          )
         );
-        if (updated === false) {
+        if (outcome.status !== 'completed') return;
+        if (outcome.value === false) {
           console.warn('[EvenG2Adapter] footer textContainerUpgrade returned false (will retry)');
         } else {
           this.lastFooterContent = footerContent;
@@ -377,7 +609,7 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     isEstimated: boolean,
     force: boolean
   ): Promise<void> {
-    if (!this.bridge || !this.isConnected || !this.pageReady) return;
+    if (!this.bridge || !this.isConnected || !this.pageReady || this.operationState.stalled) return;
 
     if (!force && speedKmh === this.lastRenderedSpeedKmh && isEstimated === this.lastRenderedIsEstimated) {
       return;
@@ -392,28 +624,30 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         imageData: pngUint8Array,
       });
 
-      const startedAt = Date.now();
-      const result = await this.bridge.updateImageRawData(updateModel);
-      const elapsedMs = Date.now() - startedAt;
+      const outcome = await this.runNativeOperation(
+        'speed-image',
+        this.sessionEpoch,
+        () => this.bridge.updateImageRawData(updateModel) as Promise<ImageRawDataUpdateResult>
+      );
+      if (outcome.status !== 'completed') return;
+
+      const result = outcome.value;
       const resultStr = String(result);
       this.lastImageResult = resultStr;
-
-      if (elapsedMs >= 3000) {
-        console.warn(`[EvenG2Adapter] Slow image transfer: ${elapsedMs}ms result=${resultStr}`);
-      } else {
-        console.log('[Speed PNG Update Result]:', resultStr, `(${elapsedMs}ms)`);
-      }
+      this.lastImageCompletedAtMs = Date.now();
 
       if (ImageRawDataUpdateResult.isSuccess(result)) {
         this.lastRenderedSpeedKmh = speedKmh;
         this.lastRenderedIsEstimated = isEstimated;
         this.lastImageUpdateTimeMs = Date.now();
+        console.log('[Speed PNG Update Result]:', resultStr, `(${this.operationState.lastElapsedMs ?? 0}ms)`);
       } else {
         console.warn('[EvenG2Adapter] Speed image update non-success result:', resultStr);
       }
     } catch (err: any) {
       const errMessage = err?.message || String(err);
       this.lastImageResult = `error: ${errMessage}`;
+      this.lastImageCompletedAtMs = Date.now();
       console.warn('[EvenG2Adapter] Error in speed image update operation:', errMessage);
       captureRuntimeError(err, 'even-g2-image-update');
       addRuntimeBreadcrumb('railglance.bridge', 'Even G2 image update failed', {}, 'error');
@@ -434,8 +668,11 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
   public async clear(): Promise<void> {
     await this.enqueueBridgeOperation(async () => {
       if (this.bridge && typeof this.bridge.shutDownPageContainer === 'function') {
-        const closed = await this.bridge.shutDownPageContainer(0);
-        if (!closed) throw new Error('shutDownPageContainer failed');
+        const outcome = await this.runNativeOperation('page-shutdown', this.sessionEpoch, () =>
+          this.bridge.shutDownPageContainer(0)
+        );
+        if (outcome.status !== 'completed') return;
+        if (!outcome.value) throw new Error('shutDownPageContainer failed');
       }
     }).catch((err) => {
       console.warn('[EvenG2Adapter] Error shutting down page container:', err);
@@ -515,7 +752,10 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
         addRuntimeBreadcrumb('railglance.lifecycle', 'Even Hub foreground exit');
       } else if (eventType === OsEventTypeList.FOREGROUND_ENTER_EVENT) {
         addRuntimeBreadcrumb('railglance.lifecycle', 'Even Hub foreground enter');
-        void this.recoverPage();
+        // A stall already owns rebuild + backoff. A parallel FOREGROUND_ENTER
+        // recover would issue a second rebuild against the same page.
+        if (this.isRecoveringTransport || this.operationState.stalled) return;
+        void this.recoverPage('foreground-enter');
       } else if (
         eventType === OsEventTypeList.SYSTEM_EXIT_EVENT ||
         eventType === OsEventTypeList.ABNORMAL_EXIT_EVENT
@@ -525,65 +765,89 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     });
   }
 
-  private async recoverPage(): Promise<void> {
+  private async recoverPage(
+    reason: BridgeRecoveryReason = 'foreground-enter'
+  ): Promise<boolean> {
     // Once disconnected, the reconnect loop owns recovery: never resurrect the
     // session from a stale foreground event.
-    if (!this.bridge || !this.isConnected) return;
+    if (!this.bridge || !this.isConnected) return false;
     // Bind this recovery to the session that is live right now. A slow BLE op can
     // hold bridgeQueue long enough for this session to die and the reconnect loop
     // to build a replacement, and createStartUpPageContainer does not go through
     // the queue — so by the time we run, `isConnected` may be true for a session
     // that was never ours.
     const epoch = this.sessionEpoch;
-    console.log('[EvenG2Adapter] FOREGROUND_ENTER — rebuilding page containers');
+    this.recoveryCount += 1;
+    this.lastRecoveryReason = reason;
+    console.log(
+      reason === 'foreground-enter'
+        ? '[EvenG2Adapter] FOREGROUND_ENTER — rebuilding page containers'
+        : '[EvenG2Adapter] transport-stall — rebuilding page containers'
+    );
 
     let rebuiltThisSession = false;
+    let stalledDuringRebuild = false;
     try {
       await this.enqueueBridgeOperation(async () => {
         // A disconnect — or a whole disconnect/reconnect cycle — may have landed
         // while this rebuild waited in the queue.
         if (!this.isConnected || this.sessionEpoch !== epoch) return;
-        const rebuilt = await this.bridge.rebuildPageContainer(
-          new RebuildPageContainer({ containerTotalNum: 4, ...this.createPageDefinition() })
+        const outcome = await this.runNativeOperation('page-recover', epoch, () =>
+          this.bridge.rebuildPageContainer(
+            new RebuildPageContainer({ containerTotalNum: 4, ...this.createPageDefinition() })
+          )
         );
-        if (!rebuilt) throw new Error('rebuildPageContainer failed');
+        if (outcome.status === 'stalled') {
+          stalledDuringRebuild = true;
+          return;
+        }
+        if (outcome.status !== 'completed') return;
+        if (!outcome.value) throw new Error('rebuildPageContainer failed');
         if (!this.isConnected || this.sessionEpoch !== epoch) return;
-        this.lastHeaderContent = '';
-        this.lastSegmentContent = '';
-        this.lastFooterContent = '';
-        this.lastRenderedSpeedKmh = null;
-        this.lastRenderedIsEstimated = false;
+        this.resetHudCaches();
         this.flushedGeneration = 0;
+        this.operationState.stalled = false;
+        this.stalledEpoch = null;
         this.pageReady = true;
         this.isConnected = true;
+        this.transportStatus = 'CONNECTED';
         rebuiltThisSession = true;
-      });
+      }, epoch);
     } catch (error) {
       console.warn('[EvenG2Adapter] Page recovery failed:', error);
       captureRuntimeError(error, 'even-g2-page-recovery');
       // Only our own session's failure means "no usable page". If a newer session
       // already owns the bridge, tearing it down here would resolve its disconnect
       // waiter and cost a spurious reconnect cycle for a page we never built.
-      if (this.sessionEpoch === epoch) {
-        // A failed rebuild leaves no usable page: transition to the disconnected
-        // state so waitUntilDisconnected() resolves and AppController reconnects.
+      // Stall-triggered failures are retried by runStallRecovery's backoff
+      // instead of disconnecting on the first attempt.
+      if (this.sessionEpoch === epoch && reason === 'foreground-enter') {
         this.markDisconnected('page recovery failed');
       }
-      return;
+      return false;
     }
+
+    if (stalledDuringRebuild) return false;
 
     if (!rebuiltThisSession) {
       // Either the session was torn down outright, or it was torn down and a new
       // one took its place; both leave this recovery with no page of its own.
       console.log('[EvenG2Adapter] Skipped page recovery (its session is no longer current)');
-      return;
+      return false;
     }
+
+    this.emitBridgeLifecycle('bridge-page-ready', {
+      sessionEpoch: this.sessionEpoch,
+      reason,
+    });
+    this.lastRecoveryAtMs = Date.now();
 
     if (this.lastModel) {
       // Force a fresh flush of the latest HUD after rebuild.
       this.renderGeneration += 1;
-      this.queueHudFlush();
-      return;
+      this.hudDirty = true;
+      this.scheduleHudFlush();
+      return true;
     }
 
     // Mirrors connect(): the image push is a soft failure and must never drop a
@@ -597,7 +861,358 @@ export class HybridEvenG2Adapter implements EvenG2Adapter {
     } catch (imgErr) {
       console.warn('[EvenG2Adapter] Recovery speed PNG update notice:', imgErr);
     }
+    return true;
   }
+
+  /**
+   * Watchdog around a single native SDK call.
+   *
+   * The SDK has no cancel API, so the underlying promise is never abandoned:
+   * a late settlement is attached as an epoch-guarded continuation for
+   * telemetry only. The *wrapper* does settle on timeout — otherwise a hung
+   * page-create / page-recover / page-shutdown would park connect(), the
+   * recovery backoff, or AppController.stop() forever. By the time the
+   * wrapper settles with `stalled`, handleTransportStall has already bumped
+   * the session epoch and amputated the queue, so the next HUD op cannot
+   * start because of the timeout.
+   */
+  private runNativeOperation<T>(
+    kind: BridgeOperationKind,
+    epoch: number,
+    run: () => Promise<T>
+  ): Promise<NativeOperationOutcome<T>> {
+    this.operationState.sequence += 1;
+    const sequence = this.operationState.sequence;
+    const startedAtMs = Date.now();
+    this.operationState.currentOperation = kind;
+    this.operationState.currentStartedAtMs = startedAtMs;
+
+    const pendingPromise = run();
+    let watchdogFired = false;
+    let wrapperSettled = false;
+
+    return new Promise<NativeOperationOutcome<T>>((resolve, reject) => {
+      const settle = (outcome: NativeOperationOutcome<T>): void => {
+        if (wrapperSettled) return;
+        wrapperSettled = true;
+        resolve(outcome);
+      };
+
+      const timer = setTimeout(() => {
+        watchdogFired = true;
+        void this.handleTransportStall(kind, sequence, epoch, pendingPromise);
+        settle({ status: 'stalled' });
+        this.attachLateContinuation(pendingPromise, kind, sequence, epoch, startedAtMs);
+      }, this.timeoutMsFor(kind));
+
+      pendingPromise.then(
+        (value) => {
+          if (watchdogFired) return;
+          clearTimeout(timer);
+          if (epoch !== this.sessionEpoch) {
+            // A newer session owns the bridge. Recording lastResult / caches
+            // here would leak the dead session's outcome into the live one.
+            this.emitBridgeOperation({
+              operation: kind,
+              sequence,
+              sessionEpoch: epoch,
+              startedAtMs,
+              completedAtMs: Date.now(),
+              elapsedMs: Date.now() - startedAtMs,
+              result: String(value),
+            });
+            settle({ status: 'stale' });
+            return;
+          }
+          this.recordNativeCompletion(kind, sequence, epoch, startedAtMs, {
+            ok: true,
+            value,
+          });
+          settle({ status: 'completed', value });
+        },
+        (error) => {
+          if (watchdogFired) return;
+          clearTimeout(timer);
+          if (epoch !== this.sessionEpoch) {
+            this.emitBridgeOperation({
+              operation: kind,
+              sequence,
+              sessionEpoch: epoch,
+              startedAtMs,
+              completedAtMs: Date.now(),
+              elapsedMs: Date.now() - startedAtMs,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            settle({ status: 'stale' });
+            return;
+          }
+          this.recordNativeCompletion(kind, sequence, epoch, startedAtMs, {
+            ok: false,
+            error,
+          });
+          if (wrapperSettled) return;
+          wrapperSettled = true;
+          reject(error);
+        }
+      );
+    });
+  }
+
+  private attachLateContinuation<T>(
+    pendingPromise: Promise<T>,
+    kind: BridgeOperationKind,
+    sequence: number,
+    epoch: number,
+    startedAtMs: number
+  ): void {
+    void pendingPromise.then(
+      (value) => {
+        const elapsedMs = Date.now() - startedAtMs;
+        console.warn(
+          `[EvenG2Adapter] Late native completion after stall: ${kind} seq=${sequence} elapsed=${elapsedMs}ms result=${String(value)}`
+        );
+        this.emitBridgeOperation({
+          operation: kind,
+          sequence,
+          sessionEpoch: epoch,
+          startedAtMs,
+          completedAtMs: Date.now(),
+          elapsedMs,
+          result: String(value),
+          stalled: true,
+        });
+      },
+      (error) => {
+        const elapsedMs = Date.now() - startedAtMs;
+        console.warn(
+          `[EvenG2Adapter] Late native error after stall: ${kind} seq=${sequence} elapsed=${elapsedMs}ms`,
+          error
+        );
+        this.emitBridgeOperation({
+          operation: kind,
+          sequence,
+          sessionEpoch: epoch,
+          startedAtMs,
+          completedAtMs: Date.now(),
+          elapsedMs,
+          stalled: true,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    );
+  }
+
+  private recordNativeCompletion(
+    kind: BridgeOperationKind,
+    sequence: number,
+    epoch: number,
+    startedAtMs: number,
+    result: { ok: true; value: unknown } | { ok: false; error: unknown }
+  ): void {
+    const completedAtMs = Date.now();
+    const elapsedMs = completedAtMs - startedAtMs;
+    this.operationState.lastCompletedOperation = kind;
+    this.operationState.lastCompletedAtMs = completedAtMs;
+    this.operationState.lastElapsedMs = elapsedMs;
+    this.operationState.currentOperation = null;
+    this.operationState.currentStartedAtMs = null;
+
+    const slow = elapsedMs >= this.slowWarnMsFor(kind);
+    if (result.ok) {
+      this.operationState.lastResult = String(result.value);
+      this.operationState.lastError = null;
+    } else {
+      this.operationState.lastError =
+        result.error instanceof Error ? result.error.message : String(result.error);
+    }
+
+    if (slow) {
+      console.warn(
+        `[EvenG2Adapter] Slow ${kind}: ${elapsedMs}ms` +
+          (result.ok ? ` result=${String(result.value)}` : '')
+      );
+      this.emitBridgeLifecycle('bridge-operation-slow', {
+        operation: kind,
+        sequence,
+        sessionEpoch: epoch,
+        elapsedMs,
+      });
+    }
+
+    this.emitBridgeOperation({
+      operation: kind,
+      sequence,
+      sessionEpoch: epoch,
+      startedAtMs,
+      completedAtMs,
+      elapsedMs,
+      ...(result.ok ? { result: String(result.value) } : {}),
+      ...(result.ok ? {} : { error: this.operationState.lastError ?? 'error' }),
+      ...(slow ? { slow: true } : {}),
+    });
+  }
+
+  private handleTransportStall(
+    kind: BridgeOperationKind,
+    sequence: number,
+    epoch: number,
+    pendingPromise: Promise<unknown>
+  ): void {
+    if (epoch !== this.sessionEpoch) return;
+    if (this.stalledEpoch === epoch) return;
+
+    this.stalledEpoch = epoch;
+    this.operationState.stalled = true;
+    this.transportStatus = 'STALLED';
+    this.pageReady = false;
+    this.lastRecoveryReason = 'transport-stall';
+    this.healthyStreakStartedAtMs = null;
+
+    // A flush that was scheduled or mid-body when the stall hit is skipped
+    // by the epoch guard, so its body never runs its own cleanup — leaving
+    // these flags stuck would make every later scheduleHudFlush() no-op.
+    this.hudFlushScheduled = false;
+    this.hudFlushInFlight = false;
+    this.hudDirty = true;
+
+    this.sessionEpoch += 1;
+    this.bridgeQueue = Promise.resolve();
+
+    this.emitBridgeOperation({
+      operation: kind,
+      sequence,
+      sessionEpoch: epoch,
+      startedAtMs: this.operationState.currentStartedAtMs ?? Date.now(),
+      stalled: true,
+    });
+    this.emitBridgeLifecycle('bridge-operation-stalled', {
+      operation: kind,
+      sequence,
+      sessionEpoch: epoch,
+    });
+    addRuntimeBreadcrumb(
+      'railglance.bridge',
+      'Even G2 transport stalled',
+      { kind, sequence, epoch },
+      'warning'
+    );
+
+    void this.runStallRecovery(pendingPromise);
+  }
+
+  private async runStallRecovery(pendingPromise: Promise<unknown>): Promise<void> {
+    if (this.isRecoveringTransport) return;
+    this.isRecoveringTransport = true;
+    try {
+      // Do not overlap old and new BLE work, but never depend on a promise
+      // that may never settle. If the hung op finishes inside the grace
+      // window we proceed with a quiet radio; if it does not, we rebuild
+      // anyway and accept that one SDK promise may still be outstanding.
+      await Promise.race([pendingPromise.then(() => {}, () => {}), delay(this.stallSettleGraceMs)]);
+
+      for (const backoffMs of STALL_RECOVERY_BACKOFF_MS) {
+        if (backoffMs > 0) await delay(backoffMs);
+        if (!this.isConnected || !this.bridge) return;
+
+        this.transportStatus = 'RECOVERING';
+        const recoveredPromise = this.recoverPage('transport-stall');
+        this.emitBridgeLifecycle('bridge-recovery-start', {
+          reason: 'transport-stall',
+          attempt: this.recoveryCount,
+          sessionEpoch: this.sessionEpoch,
+        });
+
+        const recovered = await recoveredPromise;
+        if (recovered) {
+          this.operationState.stalled = false;
+          this.stalledEpoch = null;
+          this.transportStatus = 'CONNECTED';
+          this.stallRecoveryFailures = 0;
+          this.emitBridgeLifecycle('bridge-recovery-success', {
+            reason: 'transport-stall',
+            sessionEpoch: this.sessionEpoch,
+            recoveryCount: this.recoveryCount,
+          });
+          return;
+        }
+
+        this.stallRecoveryFailures += 1;
+        this.emitBridgeLifecycle('bridge-recovery-failed', {
+          reason: 'transport-stall',
+          sessionEpoch: this.sessionEpoch,
+          failures: this.stallRecoveryFailures,
+        });
+      }
+
+      this.markDisconnected('transport stall recovery exhausted');
+    } finally {
+      this.isRecoveringTransport = false;
+    }
+  }
+
+  private noteHealthyFlush(): void {
+    const now = Date.now();
+    if (this.healthyStreakStartedAtMs === null) {
+      this.healthyStreakStartedAtMs = now;
+    }
+    if (
+      this.stallRecoveryFailures > 0 &&
+      now - this.healthyStreakStartedAtMs >= RECOVERY_HEALTH_RESET_MS
+    ) {
+      this.stallRecoveryFailures = 0;
+    }
+  }
+
+  private resetHudCaches(): void {
+    this.lastHeaderContent = '';
+    this.lastSegmentContent = '';
+    this.lastFooterContent = '';
+    this.lastRenderedSpeedKmh = null;
+    this.lastRenderedIsEstimated = false;
+    this.lastImageUpdateTimeMs = 0;
+  }
+
+  private timeoutMsFor(kind: BridgeOperationKind): number {
+    switch (kind) {
+      case 'speed-image':
+        return this.imageOperationTimeoutMs;
+      case 'page-create':
+      case 'page-recover':
+      case 'page-shutdown':
+        return this.pageOperationTimeoutMs;
+      default:
+        return this.textOperationTimeoutMs;
+    }
+  }
+
+  private slowWarnMsFor(kind: BridgeOperationKind): number {
+    return kind === 'text-header' || kind === 'text-segment' || kind === 'text-footer'
+      ? this.textSlowWarnMs
+      : this.imageSlowWarnMs;
+  }
+
+  private emitBridgeOperation(payload: BridgeOperationTelemetryPayload): void {
+    const telemetry = this.telemetry;
+    if (!telemetry) return;
+    telemetry.sink.write(
+      createBridgeOperationTelemetryEvent(telemetry.identity, Date.now(), payload)
+    );
+  }
+
+  private emitBridgeLifecycle(
+    message: string,
+    data: Record<string, string | number | boolean | null>
+  ): void {
+    const telemetry = this.telemetry;
+    if (!telemetry) return;
+    telemetry.sink.write(
+      createStateTransitionTelemetryEvent(telemetry.identity, Date.now(), 'bridge', message, data)
+    );
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export const MockEvenG2Adapter = HybridEvenG2Adapter;

--- a/src/infrastructure/logging/logger.ts
+++ b/src/infrastructure/logging/logger.ts
@@ -19,6 +19,10 @@ export type EstimationLogEntry = {
   hudViewModel: HudViewModel;
   bridgeConnected?: boolean;
   lastImageResult?: string;
+  bridgeStalled?: boolean;
+  bridgeCurrentOperation?: string | null;
+  bridgeSessionEpoch?: number;
+  bridgeRecoveryCount?: number;
 };
 
 export class EstimationLogger {

--- a/src/infrastructure/telemetry/types.ts
+++ b/src/infrastructure/telemetry/types.ts
@@ -79,7 +79,25 @@ export type EstimationTelemetryEvent = TelemetryEventBase & {
   bridge: {
     connected: boolean;
     lastImageResult: string;
+    stalled?: boolean;
+    currentOperation?: string | null;
+    sessionEpoch?: number;
+    recoveryCount?: number;
   };
+};
+
+export type BridgeOperationTelemetryEvent = TelemetryEventBase & {
+  type: 'bridge-operation';
+  operation: string;
+  sequence: number;
+  sessionEpoch: number;
+  startedAtMs: number;
+  completedAtMs?: number;
+  elapsedMs?: number;
+  result?: string;
+  stalled?: boolean;
+  slow?: boolean;
+  error?: string;
 };
 
 export type StateTransitionTelemetryEvent = TelemetryEventBase & {
@@ -92,7 +110,8 @@ export type StateTransitionTelemetryEvent = TelemetryEventBase & {
 export type TelemetryEvent =
   | GpsTelemetryEvent
   | EstimationTelemetryEvent
-  | StateTransitionTelemetryEvent;
+  | StateTransitionTelemetryEvent
+  | BridgeOperationTelemetryEvent;
 
 export type TelemetryIdentity = {
   sessionId: string;
@@ -205,8 +224,35 @@ export function createEstimationTelemetryEvent(
     bridge: {
       connected: entry.bridgeConnected ?? false,
       lastImageResult: entry.lastImageResult ?? 'unknown',
+      ...(entry.bridgeStalled !== undefined ? { stalled: entry.bridgeStalled } : {}),
+      ...(entry.bridgeCurrentOperation !== undefined
+        ? { currentOperation: entry.bridgeCurrentOperation }
+        : {}),
+      ...(entry.bridgeSessionEpoch !== undefined ? { sessionEpoch: entry.bridgeSessionEpoch } : {}),
+      ...(entry.bridgeRecoveryCount !== undefined ? { recoveryCount: entry.bridgeRecoveryCount } : {}),
     },
   };
+}
+
+export type BridgeOperationTelemetryPayload = {
+  operation: string;
+  sequence: number;
+  sessionEpoch: number;
+  startedAtMs: number;
+  completedAtMs?: number;
+  elapsedMs?: number;
+  result?: string;
+  stalled?: boolean;
+  slow?: boolean;
+  error?: string;
+};
+
+export function createBridgeOperationTelemetryEvent(
+  identity: TelemetryIdentity,
+  timestampMs: number,
+  payload: BridgeOperationTelemetryPayload
+): BridgeOperationTelemetryEvent {
+  return { ...base(identity, timestampMs), type: 'bridge-operation', ...payload };
 }
 
 export function createStateTransitionTelemetryEvent(

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,8 @@ async function init() {
   logger.subscribe((entry) => {
     const lastImageResult = evenG2Adapter.getLastImageResult ? evenG2Adapter.getLastImageResult() : 'none';
     const syncStatus = db.getSyncStatus ? db.getSyncStatus() : undefined;
-    debugPanel.update(entry, lastImageResult, syncStatus);
+    const bridge = evenG2Adapter.getBridgeDiagnostics?.();
+    debugPanel.update(entry, lastImageResult, syncStatus, bridge);
     renderRouteControls();
   });
 

--- a/src/ui/debug-panel.ts
+++ b/src/ui/debug-panel.ts
@@ -1,6 +1,10 @@
 import { RailwayDataState } from '../domain/railway/repository';
 import { EstimationLogEntry } from '../infrastructure/logging/logger';
 import { DatasetSyncStatus } from '../infrastructure/storage/dexie-railway-database';
+import {
+  type BridgeDiagnosticsSnapshot,
+  DEFAULT_IMAGE_OPERATION_TIMEOUT_MS,
+} from '../infrastructure/even-g2/bridge-operation';
 import { escapeHtml, escapeHtmlValue } from './html';
 
 export function renderSyncBadge(status?: RailwayDataState): string {
@@ -38,7 +42,8 @@ export class DebugPanel {
   public update(
     entry: EstimationLogEntry,
     lastImageResult?: string,
-    datasetSyncStatus?: DatasetSyncStatus
+    datasetSyncStatus?: DatasetSyncStatus,
+    bridge?: BridgeDiagnosticsSnapshot
   ): void {
     const { rawLocation, speedState, match, journey, timestampMs } = entry;
     const { selectedEstimate, smoothedSpeedKmh, isStopped, isValid, candidates, navState } = speedState;
@@ -50,6 +55,23 @@ export class DebugPanel {
 
     const lastSuccessfulFetchLabel = datasetSyncStatus?.lastSuccessfulFetchAtMs
       ? escapeHtml(new Date(datasetSyncStatus.lastSuccessfulFetchAtMs).toLocaleTimeString())
+      : '--';
+
+    const operationAgeMs = bridge?.operationAgeMs ?? null;
+    const operationAgeLabel =
+      operationAgeMs === null ? '--' : `${(operationAgeMs / 1000).toFixed(1)}`;
+    const operationAgeColor =
+      operationAgeMs !== null && operationAgeMs > DEFAULT_IMAGE_OPERATION_TIMEOUT_MS
+        ? '#FF6666'
+        : 'inherit';
+    const operationStartedLabel = bridge?.operation.currentStartedAtMs
+      ? escapeHtml(new Date(bridge.operation.currentStartedAtMs).toLocaleTimeString())
+      : '--';
+    const lastCompletedAtLabel = bridge?.operation.lastCompletedAtMs
+      ? escapeHtml(new Date(bridge.operation.lastCompletedAtMs).toLocaleTimeString())
+      : '--';
+    const lastImageCompletedLabel = bridge?.lastImageCompletedAtMs
+      ? escapeHtml(new Date(bridge.lastImageCompletedAtMs).toLocaleTimeString())
       : '--';
 
     const html = `
@@ -80,6 +102,29 @@ export class DebugPanel {
           <div>Predicted Speed (1D): ${formatSpeed(navState.velocityMps * 3.6)}</div>
           <div>Acceleration: ${navState.accelerationMps2.toFixed(3)} m/s²</div>
           <div>Overall Confidence: <strong>${(navState.confidence * 100).toFixed(0)}% (${navState.confidence.toFixed(2)})</strong></div>
+        </div>
+
+        <div class="debug-card" style="border-left: 4px solid #FFAA00;">
+          <h3>Even G2 Bridge Transport</h3>
+          <div>G2 Connection status: <strong>${escapeHtmlValue(bridge?.status, '--')}</strong></div>
+          <div>Page Ready: <strong>${bridge ? String(bridge.pageReady) : '--'}</strong></div>
+          <div>Session Epoch: <strong>${bridge ? String(bridge.sessionEpoch) : '--'}</strong></div>
+          <div>Current Native Operation: <strong>${escapeHtmlValue(bridge?.operation.currentOperation, '--')}</strong></div>
+          <div>Operation Started: <strong>${operationStartedLabel}</strong></div>
+          <div>Operation Age: <strong style="color: ${operationAgeColor};">${operationAgeLabel}${operationAgeMs === null ? '' : 's'}</strong></div>
+          <div>Last Completed Operation: <strong>${escapeHtmlValue(bridge?.operation.lastCompletedOperation, '--')}</strong></div>
+          <div>Last Completed: <strong>${lastCompletedAtLabel}</strong></div>
+          <div>Last Operation Duration: <strong>${bridge?.operation.lastElapsedMs !== null && bridge?.operation.lastElapsedMs !== undefined ? `${bridge.operation.lastElapsedMs} ms` : '--'}</strong></div>
+          <div>Last Image Result: <strong>${escapeHtmlValue(bridge?.lastImageResult, '--')}</strong></div>
+          <div>Last Image Completed: <strong>${lastImageCompletedLabel}</strong></div>
+          <div>Render Generation: <strong>${bridge ? String(bridge.renderGeneration) : '--'}</strong></div>
+          <div>Flushed Generation: <strong>${bridge ? String(bridge.flushedGeneration) : '--'}</strong></div>
+          <div>HUD Flush Scheduled: <strong>${bridge ? String(bridge.hudFlushScheduled) : '--'}</strong></div>
+          <div>HUD Flush In Flight: <strong>${bridge ? String(bridge.hudFlushInFlight) : '--'}</strong></div>
+          <div>HUD Dirty: <strong>${bridge ? String(bridge.hudDirty) : '--'}</strong></div>
+          <div>Recovery Count: <strong>${bridge ? String(bridge.recoveryCount) : '--'}</strong></div>
+          <div>Recovery Failures: <strong>${bridge ? String(bridge.stallRecoveryFailures) : '--'}</strong></div>
+          <div>Last Recovery Reason: <strong>${escapeHtmlValue(bridge?.lastRecoveryReason, '--')}</strong></div>
         </div>
 
         <div class="debug-card">

--- a/tests/even-g2/even-g2-adapter-transport-watchdog.test.ts
+++ b/tests/even-g2/even-g2-adapter-transport-watchdog.test.ts
@@ -353,6 +353,42 @@ describe('HybridEvenG2Adapter transport watchdog', () => {
     expect(adapter.getBridgeDiagnostics().status).toBe('DISCONNECTED');
     expect(adapter.getBridgeDiagnostics().recoveryCount).toBe(3);
     expect(sdk.bridge.rebuildPageContainer.mock.calls.length).toBe(3);
+    expect(adapter.getBridgeDiagnostics().operation.currentOperation).toBeNull();
+    expect(adapter.getBridgeDiagnostics().operation.currentStartedAtMs).toBeNull();
+    expect(adapter.getBridgeDiagnostics().operation.stalled).toBe(false);
+    expect(adapter.getBridgeDiagnostics().operationAgeMs).toBeNull();
+  }, 10_000);
+
+  it('keeps stallRecoveryFailures after a successful recovery until a healthy flush streak', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    sdk.bridge.rebuildPageContainer
+      .mockRejectedValueOnce(new Error('rebuild failed'))
+      .mockResolvedValue(true);
+
+    now += 1_000;
+    await adapter.render(viewModel('90'));
+    await flushBridge();
+
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+    await flushBridge();
+
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(1);
+    expect(adapter.getBridgeDiagnostics().operation.stalled).toBe(false);
+
+    await adapter.render(viewModel('91'));
+    await flushBridge();
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(1);
+
+    now += RECOVERY_HEALTH_RESET_MS;
+    await adapter.render(viewModel('92'));
+    await flushBridge();
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(0);
   }, 10_000);
 
   it('resets stallRecoveryFailures after a sustained healthy flush streak', async () => {

--- a/tests/even-g2/even-g2-adapter-transport-watchdog.test.ts
+++ b/tests/even-g2/even-g2-adapter-transport-watchdog.test.ts
@@ -1,0 +1,416 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HudViewModel } from '../../src/domain/models/hud';
+
+const sdk = vi.hoisted(() => ({
+  bridge: {
+    createStartUpPageContainer: vi.fn(),
+    rebuildPageContainer: vi.fn(),
+    updateImageRawData: vi.fn(),
+    textContainerUpgrade: vi.fn(),
+    shutDownPageContainer: vi.fn(),
+    onEvenHubEvent: vi.fn(),
+  },
+  waitForEvenAppBridge: vi.fn(),
+}));
+
+vi.mock('@evenrealities/even_hub_sdk', () => {
+  class Model {
+    constructor(data: Record<string, unknown>) { Object.assign(this, data); }
+  }
+  return {
+    waitForEvenAppBridge: sdk.waitForEvenAppBridge,
+    ImageContainerProperty: Model,
+    ImageRawDataUpdate: Model,
+    TextContainerProperty: Model,
+    TextContainerUpgrade: Model,
+    CreateStartUpPageContainer: Model,
+    RebuildPageContainer: Model,
+    StartUpPageCreateResult: { success: 'success' },
+    ImageRawDataUpdateResult: { isSuccess: (value: string) => value === 'success' },
+    OsEventTypeList: {
+      FOREGROUND_ENTER_EVENT: 4,
+      FOREGROUND_EXIT_EVENT: 5,
+      ABNORMAL_EXIT_EVENT: 6,
+      SYSTEM_EXIT_EVENT: 7,
+    },
+  };
+});
+
+vi.mock('../../src/infrastructure/even-g2/speed-png-generator', () => ({
+  createSpeedPng: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+}));
+
+import { HybridEvenG2Adapter } from '../../src/infrastructure/even-g2/even-g2-adapter';
+import { RECOVERY_HEALTH_RESET_MS } from '../../src/infrastructure/even-g2/bridge-operation';
+
+const SHORT_TIMEOUTS = {
+  textOperationTimeoutMs: 40,
+  imageOperationTimeoutMs: 50,
+  pageOperationTimeoutMs: 60,
+  stallSettleGraceMs: 10,
+};
+
+function viewModel(speed: string, lineName = '小田急線'): HudViewModel {
+  return {
+    header: { lineName, serviceOrDirection: '上り' },
+    speed: { displaySpeedKmhText: speed, unitText: 'km/h', isEstimated: false },
+    segment: {
+      previousStationName: '海老名',
+      nextStationName: '座間',
+      progressRatio: 0.5,
+      distanceToNextText: '次まで 1km',
+    },
+    footer: { leftInfo: '上り', statusRight: 'GPS' },
+    statusMode: 'GPS',
+    rawFormattedText: speed,
+    timestampMs: 1000,
+  };
+}
+
+/** Drain microtasks + any queued bridge flushes. */
+async function flushBridge(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1_500,
+  stepMs = 5
+): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+}
+
+function neverSettling<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}
+
+describe('HybridEvenG2Adapter transport watchdog', () => {
+  let now = 1_000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    sdk.waitForEvenAppBridge.mockResolvedValue(sdk.bridge);
+    sdk.bridge.createStartUpPageContainer.mockResolvedValue('success');
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(true);
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
+    sdk.bridge.shutDownPageContainer.mockResolvedValue(true);
+    sdk.bridge.onEvenHubEvent.mockImplementation(() => vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function connectedAdapter(
+    timeouts: Partial<typeof SHORT_TIMEOUTS> = SHORT_TIMEOUTS
+  ): Promise<HybridEvenG2Adapter> {
+    const adapter = new HybridEvenG2Adapter(undefined, timeouts);
+    expect(await adapter.connect()).toBe(true);
+    now += 1_000;
+    return adapter;
+  }
+
+  it('recovers from a hung updateImageRawData and resends the newest ViewModel', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    sdk.bridge.textContainerUpgrade.mockClear();
+    sdk.bridge.rebuildPageContainer.mockClear();
+
+    const epochBefore = adapter.getBridgeDiagnostics().sessionEpoch;
+    now += 1_000;
+    await adapter.render(viewModel('90'));
+    await flushBridge();
+
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+    expect(adapter.getBridgeDiagnostics().pageReady).toBe(false);
+    expect(adapter.getBridgeDiagnostics().sessionEpoch).toBeGreaterThan(epochBefore);
+
+    await waitFor(() => sdk.bridge.rebuildPageContainer.mock.calls.length >= 1);
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+    await flushBridge();
+
+    const headerCalls = sdk.bridge.textContainerUpgrade.mock.calls.filter(
+      ([update]) => update.containerName === 'header'
+    );
+    expect(headerCalls.length).toBeGreaterThan(0);
+    expect(headerCalls.some(([update]) => String(update.content).includes('小田急線'))).toBe(true);
+    expect(adapter.getBridgeDiagnostics().operation.stalled).toBe(false);
+    expect(adapter.getBridgeDiagnostics().pageReady).toBe(true);
+  });
+
+  it.each([
+    {
+      containerName: 'header' as const,
+      next: { ...viewModel('80', '中央線') },
+      marker: '中央線',
+    },
+    {
+      containerName: 'segment' as const,
+      next: {
+        ...viewModel('80'),
+        segment: {
+          ...viewModel('80').segment,
+          previousStationName: '新宿',
+          nextStationName: '四ツ谷',
+        },
+      },
+      marker: '新宿',
+    },
+    {
+      containerName: 'footer' as const,
+      next: {
+        ...viewModel('80'),
+        segment: { ...viewModel('80').segment, distanceToNextText: '次まで 9km' },
+        footer: { leftInfo: '上り', statusRight: 'DR' },
+      },
+      marker: '次まで 9km',
+    },
+  ])(
+    'recovers when textContainerUpgrade hangs on $containerName',
+    async ({ containerName, next, marker }) => {
+      const adapter = await connectedAdapter();
+      await adapter.render(viewModel('80', '小田急線'));
+      await flushBridge();
+
+      sdk.bridge.textContainerUpgrade.mockImplementation((update: { containerName: string }) => {
+        if (update.containerName === containerName) return neverSettling();
+        return Promise.resolve(true);
+      });
+      sdk.bridge.rebuildPageContainer.mockClear();
+
+      const epochBefore = adapter.getBridgeDiagnostics().sessionEpoch;
+      await adapter.render(next);
+      await flushBridge();
+
+      await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+      expect(adapter.getBridgeDiagnostics().pageReady).toBe(false);
+      expect(adapter.getBridgeDiagnostics().sessionEpoch).toBeGreaterThan(epochBefore);
+
+      sdk.bridge.textContainerUpgrade.mockResolvedValue(true);
+      await waitFor(() => sdk.bridge.rebuildPageContainer.mock.calls.length >= 1);
+      await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+      await flushBridge();
+
+      const retryCalls = sdk.bridge.textContainerUpgrade.mock.calls.filter(
+        ([update]) => update.containerName === containerName
+      );
+      expect(retryCalls.some(([update]) => String(update.content).includes(marker))).toBe(true);
+      expect(adapter.getBridgeDiagnostics().operation.stalled).toBe(false);
+    }
+  );
+
+  it('does not let a stale late completion overwrite the recovered session', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    let resolveHung!: (value: string) => void;
+    sdk.bridge.updateImageRawData.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { resolveHung = resolve; })
+    );
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+
+    now += 1_000;
+    await adapter.render(viewModel('91'));
+    await flushBridge();
+
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+    await flushBridge();
+
+    const resultAfterRecovery = adapter.getLastImageResult();
+    const speedAfterRecovery = adapter.getBridgeDiagnostics();
+
+    resolveHung('stale-success');
+    await flushBridge();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(adapter.getLastImageResult()).toBe(resultAfterRecovery);
+    expect(adapter.getLastImageResult()).not.toBe('stale-success');
+    expect(adapter.getBridgeDiagnostics().operation.lastResult).not.toBe('stale-success');
+    expect(adapter.getBridgeDiagnostics().sessionEpoch).toBe(speedAfterRecovery.sessionEpoch);
+    expect(adapter.getBridgeDiagnostics().operation.stalled).toBe(false);
+  });
+
+  it('keeps render() prompt and invokes onRender for every call while stalled', async () => {
+    const previews: string[] = [];
+    const adapter = new HybridEvenG2Adapter((text) => { previews.push(text); }, SHORT_TIMEOUTS);
+    expect(await adapter.connect()).toBe(true);
+    now += 1_000;
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    await adapter.render(viewModel('70'));
+    await flushBridge();
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+
+    const started = Date.now();
+    await adapter.render(viewModel('71'));
+    await adapter.render(viewModel('72'));
+    await adapter.render(viewModel('73'));
+    expect(Date.now() - started).toBeLessThan(40);
+
+    expect(previews).toEqual(['70', '71', '72', '73']);
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+  });
+
+  it('does not enqueue a BLE backlog of 100 renders during a stall', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    const imageCallsAtReady = sdk.bridge.updateImageRawData.mock.calls.length;
+    const textCallsAtReady = sdk.bridge.textContainerUpgrade.mock.calls.length;
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    // Keep recovery from completing so this snapshot stays in the stalled session.
+    sdk.bridge.rebuildPageContainer.mockReturnValue(neverSettling());
+    now += 1_000;
+    await adapter.render(viewModel('81'));
+    await flushBridge();
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+
+    for (let i = 0; i < 100; i++) {
+      await adapter.render(viewModel(String(82 + i)));
+    }
+    await flushBridge();
+
+    const diagnostics = adapter.getBridgeDiagnostics();
+    expect(diagnostics.hudFlushScheduled).toBe(false);
+    expect(diagnostics.hudFlushInFlight).toBe(false);
+    expect(diagnostics.hudDirty).toBe(true);
+    // One hung image for the stalling flush; no extra image/text ops while stalled.
+    expect(sdk.bridge.updateImageRawData.mock.calls.length - imageCallsAtReady).toBe(1);
+    expect(sdk.bridge.textContainerUpgrade.mock.calls.length).toBe(textCallsAtReady);
+
+    // Drain the hung recovery so its backoff cannot leak rebuilds into later tests.
+    await adapter.waitUntilDisconnected();
+  }, 10_000);
+
+  it('pushes the newest model after recovery, not the one that was in flight', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80', '小田急線'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    now += 1_000;
+    await adapter.render(viewModel('81', '小田急線'));
+    await flushBridge();
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+
+    await adapter.render(viewModel('82', '山手線'));
+    await adapter.render(viewModel('99', '中央線'));
+
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.textContainerUpgrade.mockClear();
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+    await flushBridge();
+    await waitFor(
+      () =>
+        sdk.bridge.textContainerUpgrade.mock.calls.some(
+          ([update]) =>
+            update.containerName === 'header' && String(update.content).includes('中央線')
+        )
+    );
+
+    const headerContents = sdk.bridge.textContainerUpgrade.mock.calls
+      .filter(([update]) => update.containerName === 'header')
+      .map(([update]) => String(update.content));
+    expect(headerContents.some((content) => content.includes('中央線'))).toBe(true);
+    expect(headerContents.some((content) => content.includes('山手線'))).toBe(false);
+  });
+
+  it('escalates to disconnect when every recovery attempt also stalls', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    sdk.bridge.rebuildPageContainer.mockReturnValue(neverSettling());
+
+    const disconnected = adapter.waitUntilDisconnected();
+    now += 1_000;
+    await adapter.render(viewModel('90'));
+    await flushBridge();
+
+    await expect(disconnected).resolves.toBeUndefined();
+    expect(adapter.isBridgeConnected()).toBe(false);
+    expect(adapter.getBridgeDiagnostics().status).toBe('DISCONNECTED');
+    expect(adapter.getBridgeDiagnostics().recoveryCount).toBe(3);
+    expect(sdk.bridge.rebuildPageContainer.mock.calls.length).toBe(3);
+  }, 10_000);
+
+  it('resets stallRecoveryFailures after a sustained healthy flush streak', async () => {
+    const adapter = await connectedAdapter();
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    sdk.bridge.rebuildPageContainer.mockRejectedValue(new Error('rebuild failed'));
+
+    const disconnected = adapter.waitUntilDisconnected();
+    now += 1_000;
+    await adapter.render(viewModel('90'));
+    await flushBridge();
+    await disconnected;
+
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(3);
+
+    sdk.bridge.updateImageRawData.mockResolvedValue('success');
+    sdk.bridge.rebuildPageContainer.mockResolvedValue(true);
+    expect(await adapter.connect()).toBe(true);
+
+    await adapter.render(viewModel('91'));
+    await flushBridge();
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(3);
+
+    now += RECOVERY_HEALTH_RESET_MS;
+    await adapter.render(viewModel('92'));
+    await flushBridge();
+    expect(adapter.getBridgeDiagnostics().stallRecoveryFailures).toBe(0);
+  }, 10_000);
+
+  it('reports current operation, growing age, stall and recovery in diagnostics', async () => {
+    const adapter = await connectedAdapter({
+      ...SHORT_TIMEOUTS,
+      stallSettleGraceMs: 80,
+    });
+    await adapter.render(viewModel('80'));
+    await flushBridge();
+
+    sdk.bridge.updateImageRawData.mockReturnValue(neverSettling());
+    now += 1_000;
+    await adapter.render(viewModel('90'));
+    await flushBridge();
+
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.currentOperation === 'speed-image');
+    const age1 = adapter.getBridgeDiagnostics().operationAgeMs;
+    now += 20;
+    const age2 = adapter.getBridgeDiagnostics().operationAgeMs;
+    expect(age1).not.toBeNull();
+    expect(age2).toBeGreaterThan(age1 as number);
+
+    await waitFor(() => adapter.getBridgeDiagnostics().operation.stalled);
+    const stalled = adapter.getBridgeDiagnostics();
+    expect(stalled.operation.stalled).toBe(true);
+    expect(stalled.lastRecoveryReason).toBe('transport-stall');
+    await waitFor(() => adapter.getBridgeDiagnostics().recoveryCount >= 1);
+    expect(adapter.getBridgeDiagnostics().recoveryCount).toBeGreaterThanOrEqual(1);
+    await waitFor(() => adapter.getBridgeDiagnostics().status === 'CONNECTED');
+  });
+});

--- a/tests/ui/debug-panel.test.ts
+++ b/tests/ui/debug-panel.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { renderSyncBadge } from '../../src/ui/debug-panel';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DebugPanel, renderSyncBadge } from '../../src/ui/debug-panel';
+import type { EstimationLogEntry } from '../../src/infrastructure/logging/logger';
+import type { BridgeDiagnosticsSnapshot } from '../../src/infrastructure/even-g2/bridge-operation';
+import { emptyBridgeOperationState } from '../../src/infrastructure/even-g2/bridge-operation';
 
 describe('renderSyncBadge', () => {
   it('renders cloud as ready R2 H3 streaming', () => {
@@ -41,5 +44,151 @@ describe('renderSyncBadge', () => {
     const html = renderSyncBadge(undefined);
     expect(html).toContain('Local Sample');
     expect(html).toContain('#AAAAAA');
+  });
+});
+
+function estimationEntry(): EstimationLogEntry {
+  return {
+    timestampMs: 1_700_000_000_000,
+    rawLocation: null,
+    speedState: {
+      selectedEstimate: { speedKmh: 40, confidence: 0.8, source: 'os-geolocation', timestamp: 1_700_000_000_000 },
+      smoothedSpeedKmh: 40,
+      isStopped: false,
+      isValid: true,
+      candidates: {
+        osSpeed: { speedKmh: 40, confidence: 0.8, source: 'os-geolocation', timestamp: 1_700_000_000_000 },
+        positionDeltaSpeed: null,
+        trackDistanceSpeed: null,
+        deadReckoningSpeed: null,
+        sensorFusionSpeed: null,
+      },
+      navState: {
+        lineId: null,
+        routeId: null,
+        segmentId: null,
+        direction: 'UP',
+        trackPositionMeters: 0,
+        velocityMps: 0,
+        accelerationMps2: 0,
+        accelerationBiasMps2: 0,
+        lastObservationTimestampMs: null,
+        lastPredictionTimestampMs: 1_700_000_000_000,
+        mode: 'gps-locked',
+        confidence: 0.8,
+      },
+    },
+    match: null,
+    journey: {
+      line: null,
+      direction: 'UP',
+      directionName: '上り',
+      previousStation: null,
+      nextStation: null,
+      distanceToNextStationMeters: null,
+      progressRatio: null,
+      stationDataComplete: true,
+      confidence: 0,
+      status: 'TRACKING',
+    },
+    hudViewModel: {
+      header: { lineName: 'Test', serviceOrDirection: '上り' },
+      speed: { displaySpeedKmhText: '40', unitText: 'km/h', isEstimated: false },
+      segment: {
+        previousStationName: 'A',
+        nextStationName: 'B',
+        progressRatio: 0.5,
+        distanceToNextText: '1km',
+      },
+      footer: { leftInfo: '', statusRight: 'GPS' },
+      statusMode: 'GPS',
+      rawFormattedText: '',
+      timestampMs: 1_700_000_000_000,
+    },
+  };
+}
+
+function installDocumentMock(): { innerHTML: string } {
+  const container = { id: 'debug-panel', innerHTML: '' };
+  (globalThis as unknown as { document: unknown }).document = {
+    getElementById: (id: string) => (id === 'debug-panel' ? container : null),
+    createElement: () => ({ id: '', innerHTML: '' }),
+    body: { appendChild: () => {} },
+  };
+  return container;
+}
+
+describe('DebugPanel Even G2 Bridge Transport card', () => {
+  afterEach(() => {
+    delete (globalThis as { document?: unknown }).document;
+  });
+
+  it('renders placeholders when bridge diagnostics are absent', () => {
+    const container = installDocumentMock();
+    const panel = new DebugPanel('debug-panel');
+    panel.update(estimationEntry(), 'success');
+
+    expect(container.innerHTML).toContain('Even G2 Bridge Transport');
+    expect(container.innerHTML).toContain('G2 PNG Update Status');
+    expect(container.innerHTML).toContain('G2 Connection status:');
+    expect(container.innerHTML).toContain('Page Ready:');
+    expect(container.innerHTML).toContain('Operation Started:');
+    expect(container.innerHTML).toContain('Recovery Failures:');
+    expect(container.innerHTML).toMatch(/G2 Connection status: <strong>--<\/strong>/);
+    expect(container.innerHTML).toMatch(/Operation Started: <strong>--<\/strong>/);
+    expect(container.innerHTML).toMatch(/Recovery Failures: <strong>--<\/strong>/);
+  });
+
+  it('renders escaped diagnostics and highlights an overdue operation age', () => {
+    const container = installDocumentMock();
+    const panel = new DebugPanel('debug-panel');
+    const bridge: BridgeDiagnosticsSnapshot = {
+      status: 'STALLED',
+      pageReady: false,
+      sessionEpoch: 4,
+      operation: {
+        ...emptyBridgeOperationState(),
+        currentOperation: 'speed-image',
+        currentStartedAtMs: 1_700_000_000_000,
+        lastCompletedOperation: 'text-header',
+        lastCompletedAtMs: 1_700_000_000_000,
+        lastElapsedMs: 12,
+        lastResult: 'success',
+        stalled: true,
+      },
+      operationAgeMs: 9_000,
+      lastImageResult: 'success',
+      lastImageCompletedAtMs: 1_700_000_000_000,
+      renderGeneration: 8,
+      flushedGeneration: 7,
+      hudFlushScheduled: false,
+      hudFlushInFlight: true,
+      hudDirty: true,
+      recoveryCount: 2,
+      stallRecoveryFailures: 3,
+      lastRecoveryReason: 'transport-stall',
+      lastRecoveryAtMs: 1_700_000_000_100,
+    };
+
+    panel.update(estimationEntry(), 'success', undefined, bridge);
+
+    expect(container.innerHTML).toContain('Even G2 Bridge Transport');
+    expect(container.innerHTML).toContain('G2 PNG Update Status');
+    expect(container.innerHTML).toContain('STALLED');
+    expect(container.innerHTML).toContain('speed-image');
+    expect(container.innerHTML).toContain('#FF6666');
+    expect(container.innerHTML).toContain('9.0s');
+    expect(container.innerHTML).toContain('transport-stall');
+    expect(container.innerHTML).toContain('Session Epoch:');
+    expect(container.innerHTML).toContain('>4<');
+    expect(container.innerHTML).toContain('HUD Dirty:');
+    expect(container.innerHTML).toContain('Recovery Count:');
+    expect(container.innerHTML).toContain('>2<');
+    expect(container.innerHTML).toContain('Recovery Failures:');
+    expect(container.innerHTML).toContain('>3<');
+    expect(container.innerHTML).toContain('Operation Started:');
+    expect(container.innerHTML).toContain(
+      new Date(1_700_000_000_000).toLocaleTimeString()
+    );
   });
 });


### PR DESCRIPTION
Closes #50

Even G2 のグラス HUD だけが固まり、スマートフォン側（GPS / 速度推定 / 路線マッチング / JourneyState / DebugPanel）は動き続ける事象への対策。実装は Grok に委譲し、設計方針とレビューは Opus が担当した。

## 原因

- `HybridEvenG2Adapter` のネイティブ Even Hub SDK 呼び出し（`updateImageRawData` / `textContainerUpgrade` / ページ作成・再構築・終了）を完了期限なしで `await` していた。
- すべての BLE 操作は単一の `bridgeQueue` で直列化されているため、いずれか 1 本が resolve も reject もしないとキューが永久停止し、以後 HUD がグラスへ届かない。
- `lastImageResult` は「最後に完了した」転送しか記録しないため、ハング中も DebugPanel は `success` のままで、異常を判別できなかった。

## 追加した Bridge Operation 監視

- `src/infrastructure/even-g2/bridge-operation.ts` を新設し、`BridgeOperationKind`（`text-header` / `text-segment` / `text-footer` / `speed-image` / `page-create` / `page-recover` / `page-shutdown`）、`BridgeTransportStatus`、`BridgeOperationState`、`BridgeDiagnosticsSnapshot`、各タイムアウト既定値を定義。
- すべてのネイティブ呼び出しを `runNativeOperation(kind, epoch, run)` 経由に統一。sequence / 開始時刻 / 経過時間 / 直近完了 / エラー / stall を一元管理する。
- `getBridgeDiagnostics()` で内部状態のスナップショットを公開（`EvenG2Adapter` インターフェースには任意メンバとして追加）。

## HUD queue の変更

- `hudFlushQueued` を `hudFlushScheduled` / `hudFlushInFlight` / `hudDirty` へ分離し、`scheduledGeneration` / `inFlightGeneration` を追加。
- 不変条件: in-flight 最大 1 件・scheduled 最大 1 件。stall 中に render が何回来ても BLE 操作は積まれない（テストで 100 render を検証）。
- flush 本体の後始末は `finally` で行い、末尾の再スケジュール判定は同期のまま（await を挟むと render を取りこぼす）。

## Watchdog 仕様

| 操作 | 既定タイムアウト | オプション |
| --- | --- | --- |
| text（header / segment / footer） | 5,000 ms | `textOperationTimeoutMs` |
| speed image | 8,000 ms | `imageOperationTimeoutMs` |
| page create / recover / shutdown | 10,000 ms | `pageOperationTimeoutMs` |
| text 遅延警告 | 1,000 ms | `textSlowWarnMs` |
| image・page 遅延警告 | 3,000 ms | `imageSlowWarnMs` |
| stall 後の settle grace | 2,000 ms | `stallSettleGraceMs` |

- SDK Promise は放棄しない。遅延完了は epoch ガード付きの継続としてテレメトリ・ログにだけ使う。
- watchdog 発火時、**ラッパーだけ** `{status:'stalled'}` で決着させる。これがないと hung な `page-create` が再接続ループを、`page-recover` が復旧バックオフを、`page-shutdown` が `stop()` を永久に止めてしまう。
- ラッパーが決着する時点で `handleTransportStall()` は既に session epoch を進め、キューを切断し、`pageReady` を落としている。つまり **timeout を理由に次の通常 BLE 操作が始まることはない**。
- 値の検証は `resolvePositiveTimeoutMs()`（`bridge-ready.ts` の既存ロジックを一般化）に統一。

## Recovery 仕様

1. ハングした操作に `stallSettleGraceMs` だけ完了の猶予を与える（古い BLE と新しい BLE を可能な限り重ねないための妥協。永久には待たない）。
2. `recoverPage('transport-stall')` を `[0, 1000, 3000] ms` のバックオフで最大 3 回試行。成功時は text/image キャッシュを無効化し、最新 ViewModel をフル再送。
3. 3 回連続失敗で `markDisconnected('transport stall recovery exhausted')`。以後は AppController の再接続ループ（1s→10s backoff、`connect()` も watchdog 付き）が担当する。
4. 連続失敗カウンタは HUD flush が一定時間（60 秒）健全に流れた時点でリセット。
5. `FOREGROUND_ENTER` 経由の既存復旧は維持（初回失敗で即 disconnect するのはこの経路のみ）。stall 復旧中の重複 rebuild は抑止する。

## sessionEpoch の利用

- `enqueueBridgeOperation()` が enqueue 時点の epoch を捕捉し、実行時に一致しなければ即スキップ。キュー切断後に残った旧操作が死んだセッションへ BLE を出すことはない。
- `runNativeOperation()` は完了時に epoch を再確認し、不一致なら `{status:'stale'}` として **一切の状態を書き戻さない**（text キャッシュ / `lastImageResult` / `lastRenderedSpeedKmh` / `lastImageUpdateTimeMs`）。
- stall は epoch 単位で記録する（`stalledEpoch`）。boolean だと復旧 rebuild 自身の stall（epoch N+1）を握り潰してしまうため。

## 追加 Telemetry

- 新イベント `bridge-operation`（`operation` / `sequence` / `sessionEpoch` / `startedAtMs` / `completedAtMs` / `elapsedMs` / `result` / `stalled` / `slow` / `error`）。全ネイティブ操作の完了・エラー・stall で送出。`SentryTelemetrySink` は `state-transition` 以外を捨て、診断シンクは診断モード中のみ記録するため本番コストは小さく、診断キャプチャから所要時間分布を取れる。
- `state-transition`（category `bridge`）はライフサイクルのみ: `bridge-page-ready` / `bridge-operation-slow` / `bridge-operation-stalled` / `bridge-recovery-start` / `bridge-recovery-success` / `bridge-recovery-failed`。Sentry breadcrumb の氾濫を避けるため通常操作では出さない。
- `estimation.bridge` に任意フィールド `stalled` / `currentOperation` / `sessionEpoch` / `recoveryCount` を追加（`TELEMETRY_SCHEMA_VERSION` は 1 のまま）。
- Cloudflare telemetry worker に `bridge-operation` のサニタイズを追加（未知 type は拒否されるため、追加しないと診断アップロードが 400 になる）。

## 追加 DebugPanel 項目

新カード「Even G2 Bridge Transport」（既存の `G2 PNG Update Status` はそのまま）:

G2 Connection status / Page Ready / Session Epoch / Current Native Operation / Operation Started / Operation Age（画像タイムアウト超過時は赤）/ Last Completed Operation / Last Completed / Last Operation Duration / Last Image Result / Last Image Completed / Render Generation / Flushed Generation / HUD Flush Scheduled / HUD Flush In Flight / HUD Dirty / Recovery Count / Recovery Failures / Last Recovery Reason

## 追加テスト

`tests/even-g2/even-g2-adapter-transport-watchdog.test.ts`（新規）:

- image Promise stall → watchdog → session 無効化 → rebuild → 最新 ViewModel 再送
- text Promise stall（header / segment / footer それぞれ）
- 旧セッションの遅延 resolve が新セッションの状態を上書きしないこと
- stall 中も `render()` が即時復帰し、Web プレビュー callback は毎回呼ばれること
- stall 中に 100 回 render しても BLE 操作を積まないこと（in-flight 1 + scheduled 1 が上限）
- 復旧後に「stall 開始時の古い model」ではなく最新 model が送られること
- 復旧が毎回 stall する場合に disconnect へエスカレーションすること（暴走防止）
- 診断スナップショット（current operation / operation age / stalled / recoveryCount / lastRecoveryReason）
- 復旧失敗カウンタが 60 秒の健全動作でリセットされること

`tests/ui/debug-panel.test.ts` に新カードの描画テストを追加。

## Mock stall test 結果

`pnpm test`: 36 files / 265 tests すべて green（うち transport watchdog 11 件）。`pnpm lint` clean、`pnpm build` 成功。

## Even G2 実機確認

**未実施。** issue §23 の実走テスト（10〜30 分連続、フォアグラウンド/バックグラウンド切替・ロック等）は本 PR には含まれない。マージ後に実機で確認し、`Bridge operation duration` / `Recovery count` / `Stall count` を DebugPanel と診断テレメトリで観測する必要がある。

## 既知の制約

- SDK にキャンセル API がないため、本当に固まった呼び出しは未解決の Promise を 1 本残す。復旧後の新しい BLE と時間的に重なり得る。アダプタは session epoch でそれを隔離し、古い完了が新しい HUD 状態へ書き戻らないことだけを保証する。
- issue §14 のバックオフ（1回目即時 / 1s / 3s / 10s / 以後30s）に対し、本実装は `[0, 1s, 3s]` の 3 回で打ち切り、以降は AppController の再接続ループ（1s→10s、`connect()` は watchdog 付きでページを作り直す）へ委譲する。アダプタ内で rebuild を無限に回すより、ページごと作り直す既存経路のほうが確実なため。
- 診断モード中は `bridge-operation` イベントがローカルバッファを消費するため、estimation イベントの保持期間が短くなる可能性がある。

## 今後調整が必要な timeout 値

実走データ（`bridge-operation` の `elapsedMs` 分布と `bridge-operation-slow` の発生率）を見て調整する:

- `imageOperationTimeoutMs`（既定 8s）— PNG 転送が恒常的に遅い場合は延長。短すぎると健全な転送を stall 扱いして不要な再構築を招く。
- `textOperationTimeoutMs`（既定 5s）
- `stallSettleGraceMs`（既定 2s）— 復旧の速さと BLE 重なり回避のトレードオフ。
- 復旧バックオフ段数（現在 3 回）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c8cqkFPwuXhY3j49TWS7U
