### PR TITLE
fix: allow Even App WebView loopback origins for R2 and telemetry (#44)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,11 @@
 # Example for Custom Domain: https://data.railglance.example
 VITE_RAILWAY_DATA_BASE_URL=https://pub-xxxxxxxx.r2.dev
 
-# Required by the R2 deployment command. Comma-separate preview/production origins.
-R2_CORS_ALLOWED_ORIGINS=https://railglance.example,https://railglance-preview.example
+# Dataset bucket CORS. Use * because the packaged Even App WebView serves from
+# http://127.0.0.1:<random port>, which cannot be enumerated, and the bucket is
+# already public via pub-*.r2.dev. R2 rejects port-wildcard origins such as
+# http://127.0.0.1:*, so * is the only workable value.
+R2_CORS_ALLOWED_ORIGINS=*
 
 # Error tracking. The DSN is intentionally a browser-visible project endpoint, not a secret.
 VITE_SENTRY_DSN=

--- a/.github/workflows/provision-cloudflare.yml
+++ b/.github/workflows/provision-cloudflare.yml
@@ -124,7 +124,7 @@ jobs:
           )"
 
           if [[ "$(jq 'length' <<<"$origins_json")" -eq 0 ]]; then
-            echo 'R2_CORS_ALLOWED_ORIGINS must contain at least one exact origin.' >&2
+            echo 'R2_CORS_ALLOWED_ORIGINS must contain at least one origin.' >&2
             exit 1
           fi
 

--- a/docs/DEPLOYMENT_R2.md
+++ b/docs/DEPLOYMENT_R2.md
@@ -45,7 +45,7 @@ export R2_ACCOUNT_ID="your_cloudflare_account_id"
 export R2_ACCESS_KEY_ID="your_r2_access_key_id"
 export R2_SECRET_ACCESS_KEY="your_r2_secret_access_key"
 export R2_BUCKET_NAME="railglance-dataset-bucket" # 省略時はデフォルト
-export R2_CORS_ALLOWED_ORIGINS="https://app.example,https://preview.example"
+export R2_CORS_ALLOWED_ORIGINS="*"
 export DATASET_VERSION="1.4.0" # 必須。公開済みでないSemVerを毎回明示
 export MLIT_N02_DIR="/path/to/N02-23/UTF-8" # 必須
 ```
@@ -108,9 +108,12 @@ pnpm build:data:sample
 `dist/railway-dataset/kanto-coverage-report.sample.md` へ書き出します。このデータセットは上記 2.3 の
 MLIT 出典ゲートで必ず拒否されるため、R2 へ配備することはできません。
 
-デプロイ時には `R2_CORS_ALLOWED_ORIGINS` を使って bucket CORS も更新します。ブラウザの Origin と完全一致する
-値を列挙し、`*` は本番では使用しません。反映後はブラウザから `latest.json` と任意の H3 tile を取得し、
-レスポンスの `Access-Control-Allow-Origin` を確認します。
+デプロイ時には `R2_CORS_ALLOWED_ORIGINS` を使って bucket CORS も更新します。値は完全一致 Origin の列挙、
+または単独の `*` のいずれかです。Even App の WebView は `http://127.0.0.1:<OS が割り当てるエフェメラルポート>`
+からバンドルを配信するため Origin を列挙できず、R2 は `http://127.0.0.1:*` のようなポートワイルドカード
+Origin 文字列を拒否します（API error 10040）。データセット bucket はすでに `pub-*.r2.dev` で公開されているため、
+本番では単独の `*` を使います。`*` と完全一致 Origin を混在させると設定ミスとして拒否されます。反映後は
+ブラウザから `latest.json` と任意の H3 tile を取得し、レスポンスの `Access-Control-Allow-Origin` を確認します。
 
 ---
 

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -43,7 +43,7 @@ Cloudflare Worker はparticipant単位のDurable Objectを資格台帳に使う�
 - release制限: `TELEMETRY_ALLOWED_RELEASES` の完全一致。アプリ更新後はオンライン検証が完了するまで新規収集しない。
 - 即時失効: 管理endpointでparticipantを失効させ、以後のtoken更新とuploadを拒否する。
 - レート制限: enrollmentはcampaign単位30回/分、token更新とuploadはparticipant単位240回/分を既定とする。
-- 入力制限: exact Origin、120 KB、200 events、schema、値域を検証する。
+- 入力制限: Origin allowlist、120 KB、200 events、schema、値域を検証する。allowlist の各エントリは通常は完全一致。末尾が `:*` のエントリだけは当該 `scheme://host` の任意の数値ポートを許可し、Even App WebView の loopback Origin（`http://127.0.0.1:<エフェメラルポート>`）に使う。裸の `*` は `:*` で終わらないためリテラル `Origin: *` への完全一致になり、ブラウザはそれを送れないので fail closed する。
 
 Cloudflare Rate Limiting bindingのカウンタはCloudflare拠点単位であるため、これを唯一の不正利用対策とはしない。
 資格照合と併用する。設定根拠は
@@ -63,7 +63,7 @@ GitHubの`Settings` → `Secrets and variables` → `Actions`で次を設定す�
 | Repository Secret | `R2_ACCESS_KEY_ID` | Terraform stateとR2 CORSを操作するS3互換Access Key ID |
 | Repository Secret | `R2_SECRET_ACCESS_KEY` | 上記Access KeyのSecret |
 | Repository Variable | `R2_BUCKET_NAME` | Dataset bucket名。既定値は`railglance-dataset-bucket` |
-| Repository Variable | `R2_CORS_ALLOWED_ORIGINS` | 完全一致Originをカンマ区切りで指定する |
+| Repository Variable | `R2_CORS_ALLOWED_ORIGINS` | 完全一致Originをカンマ区切りで指定する。例外として単独の `*` だけを許可する（公開データセット bucket と Even App WebView のエフェメラルポート Origin のため。`*` と完全一致 Origin の混在は拒否） |
 | Repository Variable（任意） | `TF_STATE_BUCKET_NAME` | Terraform state bucket名。未設定時は`railglance-terraform-state` |
 | Repository Variable（ドメイン導入後） | `CLOUDFLARE_ZONE_ID` | Cloudflare Zone ID。ドメイン未導入中は設定しない |
 
@@ -129,7 +129,9 @@ TELEMETRY_ADMIN_TOKEN="development-only-admin-token"
 現在の `wrangler.toml` にはnamed environmentを定義していない。将来 `[env.staging]` などを追加した場合、
 Secretは環境間で共有されないため、各コマンドに `--env staging` を付けて環境ごとに登録する。
 
-`wrangler.toml` でcampaign ID、資格日数、対象release、token TTL、exact Originを設定する。release更新前に
+`wrangler.toml` でcampaign ID、資格日数、対象release、token TTL、Origin allowlistを設定する。allowlistは
+通常完全一致だが、末尾が `:*` のエントリは当該 `scheme://host` の任意の数値ポートを許可する（Even App
+WebView の loopback Origin用）。release更新前に
 新旧releaseをallowlistへ追加し、移行後に旧releaseを外す。資格失効は管理tokenを外部へ露出しない管理環境から行う。
 
 Cloudflareに登録したSecret値は読み戻せないため、失効操作を行う管理端末では、パスワード管理ツールに保管した

--- a/infra/cloudflare/telemetry-worker/src/index.ts
+++ b/infra/cloudflare/telemetry-worker/src/index.ts
@@ -86,6 +86,14 @@ function jsonResponse(status: number, body: JsonObject, origin: string | null): 
   return new Response(JSON.stringify(body), { status, headers });
 }
 
+function originMatchesAllowlistEntry(origin: string, entry: string): boolean {
+  if (!entry.endsWith(':*')) return origin === entry;
+  // Prefix includes the final ':' so `http://127.0.0.1:*` cannot match `http://127.0.0.10:80`.
+  const prefix = entry.slice(0, entry.lastIndexOf(':') + 1);
+  if (!origin.startsWith(prefix)) return false;
+  return /^\d+$/.test(origin.slice(prefix.length));
+}
+
 function allowedOrigin(request: Request, env: WorkerEnvironment): string | null | false {
   const origin = request.headers.get('origin');
   if (!origin) return null;
@@ -93,7 +101,7 @@ function allowedOrigin(request: Request, env: WorkerEnvironment): string | null 
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
-  return allowed.includes(origin) ? origin : false;
+  return allowed.some((entry) => originMatchesAllowlistEntry(origin, entry)) ? origin : false;
 }
 
 function matchesSecret(actual: string, expected: string): boolean {

--- a/infra/cloudflare/telemetry-worker/wrangler.toml
+++ b/infra/cloudflare/telemetry-worker/wrangler.toml
@@ -42,8 +42,9 @@ max_retries = 5
 dead_letter_queue = "railglance-telemetry-dlq"
 
 [vars]
-# Override with an exact comma-separated allowlist per environment.
-TELEMETRY_ALLOWED_ORIGINS = "http://localhost:5173"
+# Local Vite plus Even App WebView origins. The WebView is served by a loopback
+# HTTP server on an OS-assigned ephemeral port, so host is stable but the port is not.
+TELEMETRY_ALLOWED_ORIGINS = "http://localhost:5173,http://127.0.0.1:*,http://localhost:*"
 TELEMETRY_CAMPAIGN_ID = "railglance-beta-2026"
 TELEMETRY_QUALIFICATION_DAYS = "14"
 TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2"

--- a/infra/cloudflare/terraform/main.tf
+++ b/infra/cloudflare/terraform/main.tf
@@ -86,11 +86,16 @@ variable "dataset_bucket_name" {
 
 variable "cors_allowed_origins" {
   type        = list(string)
-  description = "Exact web application origins allowed to read public dataset objects"
+  description = "Web application origins allowed to read public dataset objects. Exact origins, or a sole '*' when the Even App WebView's ephemeral-port loopback origin cannot be enumerated."
 
+  # Sole '*' is allowed because the dataset bucket is already public (pub-*.r2.dev),
+  # the Even App WebView origin is http://127.0.0.1:<ephemeral port> and cannot be
+  # enumerated, and R2 rejects port-wildcard origin strings (API error 10040).
   validation {
-    condition     = length(var.cors_allowed_origins) > 0 && !contains(var.cors_allowed_origins, "*")
-    error_message = "At least one exact CORS origin is required; wildcard is not allowed."
+    condition = length(var.cors_allowed_origins) > 0 && (
+      !contains(var.cors_allowed_origins, "*") || length(var.cors_allowed_origins) == 1
+    )
+    error_message = "At least one exact CORS origin is required, except a sole '*'; mixing '*' with exact origins is not allowed."
   }
 }
 

--- a/src/scripts/deploy-r2.ts
+++ b/src/scripts/deploy-r2.ts
@@ -172,8 +172,21 @@ export async function deployToR2(options: R2DeployOptions = {}): Promise<void> {
   if (allowedOrigins.length === 0) {
     throw new Error('R2_CORS_ALLOWED_ORIGINS is required in .env or environment (comma-separated application origins).');
   }
-  if (allowedOrigins.includes('*')) {
-    throw new Error('R2_CORS_ALLOWED_ORIGINS must contain exact origins; wildcard is not allowed.');
+  // Exact origins cannot cover the Even App WebView: it is served from
+  // http://127.0.0.1:<ephemeral port>, and R2 rejects port-wildcard origin strings.
+  // A bare '*' is accepted by R2 and is safe here because the dataset bucket is already
+  // public (pub-*.r2.dev). Require it as the sole entry so a mixed list cannot look
+  // like a tightened allowlist while actually allowing every origin.
+  const wildcardOnly = allowedOrigins.length === 1 && allowedOrigins[0] === '*';
+  if (allowedOrigins.includes('*') && !wildcardOnly) {
+    throw new Error(
+      'R2_CORS_ALLOWED_ORIGINS may use "*" only as the sole entry; mixing it with exact origins is a configuration mistake.'
+    );
+  }
+  if (wildcardOnly) {
+    console.warn(
+      '[R2 Deploy] Using CORS origin "*". Intentional: the dataset bucket is public (pub-*.r2.dev) so CORS is not a security boundary, and the Even App WebView serves from an ephemeral-port loopback origin that cannot be enumerated.'
+    );
   }
 
   const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;

--- a/tests/scripts/deploy-r2.test.ts
+++ b/tests/scripts/deploy-r2.test.ts
@@ -155,6 +155,43 @@ describe('deployToR2', () => {
     expectNoUploads();
   });
 
+  describe('CORS origin allowlist', () => {
+    it('accepts a sole wildcard because the public dataset bucket cannot enumerate Even App loopback ports', async () => {
+      setCredentials();
+      process.env.R2_CORS_ALLOWED_ORIGINS = '*';
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      aws.send.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {
+        name: 'NotFound', $metadata: { httpStatusCode: 404 },
+      })).mockResolvedValue({});
+
+      try {
+        await deploy();
+        const corsCommand = aws.send.mock.calls.find(([command]) => command.constructor.name === 'PutBucketCorsCommand')?.[0];
+        expect(corsCommand?.input).toMatchObject({
+          CORSConfiguration: { CORSRules: [{ AllowedOrigins: ['*'] }] },
+        });
+        expect(warn).toHaveBeenCalledWith(expect.stringMatching(/pub-\*\.r2\.dev/));
+        expect(warn).toHaveBeenCalledWith(expect.stringMatching(/ephemeral-port|ephemeral port/i));
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('rejects a mixed CORS list that includes a wildcard', async () => {
+      setCredentials();
+      process.env.R2_CORS_ALLOWED_ORIGINS = '*,https://foo.example';
+      await expect(deploy()).rejects.toThrow(/sole entry/);
+      expectNoUploads();
+    });
+
+    it('still rejects an empty CORS origin list', async () => {
+      setCredentials();
+      delete process.env.R2_CORS_ALLOWED_ORIGINS;
+      await expect(deploy()).rejects.toThrow(/R2_CORS_ALLOWED_ORIGINS is required/);
+      expectNoUploads();
+    });
+  });
+
   describe('fail-closed dataset gates (no object may be uploaded)', () => {
     beforeEach(() => {
       setCredentials();

--- a/tests/telemetry/worker.test.ts
+++ b/tests/telemetry/worker.test.ts
@@ -241,6 +241,14 @@ describe('Cloudflare telemetry Worker', () => {
     expect(await reject('http://127.0.0.1:56984@evil.com')).toBe(403);
   });
 
+  it('fails closed on a bare wildcard origin entry instead of allowing every origin', async () => {
+    const env = environment();
+    env.TELEMETRY_ALLOWED_ORIGINS = '*';
+    const response = await worker.fetch(uploadRequest(await validToken(), batch(), 'https://evil.example'), env);
+    expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
   it('rejects invalid tokens, coordinate ranges, session consistency, and event count', async () => {
     const env = environment();
     expect((await worker.fetch(uploadRequest('wrong'), env)).status).toBe(401);

--- a/tests/telemetry/worker.test.ts
+++ b/tests/telemetry/worker.test.ts
@@ -207,6 +207,40 @@ describe('Cloudflare telemetry Worker', () => {
     expect((await worker.fetch(uploadRequest(await validToken()), env)).status).toBe(429);
   });
 
+  it('echoes an ephemeral-port loopback origin when the allowlist uses a port wildcard', async () => {
+    const env = environment();
+    env.TELEMETRY_ALLOWED_ORIGINS = 'http://localhost:5173,http://127.0.0.1:*';
+    const token = await validToken();
+
+    const ephemeral = await worker.fetch(uploadRequest(token, batch(), 'http://127.0.0.1:56984'), env);
+    expect(ephemeral.status).toBe(202);
+    expect(ephemeral.headers.get('access-control-allow-origin')).toBe('http://127.0.0.1:56984');
+
+    const lowPort = await worker.fetch(uploadRequest(token, batch(), 'http://127.0.0.1:1'), env);
+    expect(lowPort.status).toBe(202);
+    expect(lowPort.headers.get('access-control-allow-origin')).toBe('http://127.0.0.1:1');
+
+    const exactDev = await worker.fetch(uploadRequest(token, batch(), 'http://localhost:5173'), env);
+    expect(exactDev.status).toBe(202);
+    expect(exactDev.headers.get('access-control-allow-origin')).toBe('http://localhost:5173');
+  });
+
+  it('rejects scheme-mismatched and malformed suffixes against a port-wildcard allowlist', async () => {
+    const env = environment();
+    env.TELEMETRY_ALLOWED_ORIGINS = 'http://127.0.0.1:*';
+    const token = await validToken();
+    const reject = async (origin: string) => {
+      const response = await worker.fetch(uploadRequest(token, batch(), origin), env);
+      expect(response.headers.get('access-control-allow-origin')).toBeNull();
+      return response.status;
+    };
+
+    expect(await reject('https://127.0.0.1:56984')).toBe(403);
+    expect(await reject('http://127.0.0.1:56984.evil.com')).toBe(403);
+    expect(await reject('http://127.0.0.1:56984/path')).toBe(403);
+    expect(await reject('http://127.0.0.1:56984@evil.com')).toBe(403);
+  });
+
   it('rejects invalid tokens, coordinate ranges, session consistency, and event count', async () => {
     const env = environment();
     expect((await worker.fetch(uploadRequest('wrong'), env)).status).toBe(401);


### PR DESCRIPTION
## 背景 — 実機で根本原因を特定

PR #47 で追加した診断表示によって、Issue #44 の `Load failed` の原因を実機上で切り分けられました。原因はアプリのコードでも Even Hub のネットワーク権限でもなく、**R2 バケットとテレメトリ Worker の CORS 許可リストが開発環境用のまま**だったことです。

`wrangler tail` で実機からの `Origin` ヘッダーを捕捉したところ、アプリ起動ごとに値が変わっていました:

```
起動1回目: Origin: http://127.0.0.1:56862
起動2回目: Origin: http://127.0.0.1:56984
起動3回目: Origin: http://127.0.0.1:57048
```

パッケージ済み `.ehpk` を Even App にインストールした場合、WebView は **loopback 上の HTTP サーバー経由**で配信され、ポートは OS が起動ごとに割り当てます。ホストは固定でもポートは不定なので、固定 Origin の許可リストでは原理的に一致しません。既存の許可リストは `http://localhost:5173`（Vite 開発サーバー）と失効済み ngrok URL のみで、これは別の開発フロー（デスクトップシミュレータ／`evenhub qr` での開発サーバー直読み）用でした。

## 変更内容

### 1. テレメトリ Worker — ポートワイルドカード対応

`TELEMETRY_ALLOWED_ORIGINS` のエントリが `:*` で終わる場合、その `scheme://host` の**任意の数値ポート**を許可します。それ以外のエントリは従来どおり完全一致です。

セキュリティ上の実装要点:
- パターンの接頭辞は**末尾の `:` を含めて**切り出すため、`http://127.0.0.1:*` が `http://127.0.0.10:80` に誤マッチしません
- 残りの部分全体が `/^\d+$/` に一致することを要求するため、`http://127.0.0.1:56984.evil.com` / `:56984/path` / `:56984@evil.com` などは拒否されます
- マッチ時は**パターンではなくリクエストの Origin をそのままエコー**します（`vary: Origin` は設定済み）
- 裸の `*` は `:*` で終わらないため、ブラウザが送信不可能なリテラル `Origin: *` への完全一致に退化し、**fail closed** します（この挙動をピン留めするテストを追加）

### 2. `deploy-r2.ts` — 単独 `*` を許可

`pnpm deploy:r2` は毎回 `PutBucketCors` を実行するため、この変更がないと次回のデータセットデプロイで CORS 設定が上書きされ、実機が再び壊れます。

Cloudflare API に対して実地検証した結果:
- `http://127.0.0.1:*` のようなポートワイルドカード → **R2 が拒否**（API error 10040）
- 単独の `*` → **受理**。適用後 `curl -H "Origin: http://127.0.0.1:56984"` で `Access-Control-Allow-Origin: *` が返り、データが取得できることを確認

そのため `*` を許可しますが、**単独エントリの場合のみ**とし、`*,https://foo.example` のような混在は設定ミスとして拒否します（許可リストを絞ったように見えて実際は全許可、という状態を防ぐため）。使用時は理由を説明する警告を出力します。データセットバケットは既に `pub-*.r2.dev` で公開済みのため、CORS はここではセキュリティ境界として機能していません。

### 3. Terraform / ドキュメントの整合

`R2_CORS_ALLOWED_ORIGINS` には利用者が 2 つあり、要求が矛盾していました。`infra/cloudflare/terraform/main.tf` の変数検証が `*` を含むリストを一律拒否していたため、上記の必須値では `terraform plan` が失敗し、逆に完全一致 Origin を設定すると `terraform apply` が今回の修正を無言で巻き戻す状態でした（バケット CORS は Terraform 管理下のため）。

`deploy-r2.ts` と同じ「単独 `*` のみ許可」ルールに揃え、矛盾していたドキュメント 2 箇所（`docs/DEPLOYMENT_R2.md` の「`*` は本番では使用しません」、`docs/TELEMETRY_AND_SENTRY.md` の「exact Origin」）も更新しました。

## 検証

### 実機（Even G2 + iPhone、移動中に実施）

| 項目 | 結果 |
|---|---|
| R2 manifest への接続 | ✅ |
| GPS 位置に応じた H3 Cell 表示 | ✅ |
| H3 タイルのオンデマンド取得 | ✅ |
| テレメトリ参加登録・アップロード | ✅ |

Worker ログで裏付け済み: `POST /campaign/enroll → 201`、`POST /v1/telemetry → 202`（複数回）。

### デプロイ後の本番動作確認

```
Origin: http://127.0.0.1:56984            → 204 + ACAO エコー   （許可）
Origin: http://127.0.0.1:56984.evil.com   → 403、ACAO なし      （拒否）
Origin: https://evil.example              → 403                （拒否）
```

### Terraform 検証ロジックの実地テスト

変数検証のみを切り出した最小構成で `terraform plan` を実行し、`deploy-r2.ts` と同一の挙動を確認:

| 入力 | 結果 |
|---|---|
| `["*"]` | ACCEPT |
| `["https://a.example"]` | ACCEPT |
| `["https://a.example","https://b.example"]` | ACCEPT |
| `["*","https://a.example"]` | REJECT |
| `[]` | REJECT |
| `["*","*"]` | REJECT |

### 自動テスト

- `pnpm test` — 278/278 passed
- `pnpm lint` — clean
- `pnpm build` — clean
- `terraform fmt -check` — clean

## 適用状況

- テレメトリ Worker: **本番デプロイ済み**（Version ID `4697967d`、Opus によるセキュリティレビュー通過後に実施）
- R2 バケット CORS: **適用済み**（`origins: ["*"]`）
- **未対応**: GitHub リポジトリ変数 `R2_CORS_ALLOWED_ORIGINS` は現在も `http://localhost:5173,https://a426-...ngrok-free.app` のままです。**次回のデータセットデプロイまたは provision 実行の前に `*` へ変更する必要があります**（変更しないと今回の CORS 修正が巻き戻ります）。

## 別途対応が必要な事項（このPRの範囲外）

R2 上のデータセット `v1.1.0` は `mlitSourced` フィールドを持たず、7 路線 / 56 駅 / 49 セグメント / 254 タイルと、バンドル済みサンプルのベースライン値と完全に一致します。つまり **MLIT 由来の本物の関東データではなくサンプルデータが配信されています**（品質ゲート追加前の 2026-08-05 デプロイ）。実走で本来のカバレッジを得るには、`deploy-r2.yml` を新しい `DATASET_VERSION` で実行する必要があります。

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Km878Mo47nqEEXqi5qLGt
