### PR TITLE
feat: cover Kanto by publishing branching and disconnected MLIT lines (#44)

### DIFF
--- a/src/etl/adapters/mlit-adapter.ts
+++ b/src/etl/adapters/mlit-adapter.ts
@@ -129,21 +129,25 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
         segments.push(...lineSegments);
         continue;
       }
-      for (const chain of this.decomposeIntoLinearChains(lineStations, lineSegments)) {
-        if (chain.stations.length < 2 || chain.segments.length < 1) continue;
+      const emittedChains = this.decomposeIntoLinearChains(lineStations, lineSegments)
+        .filter((chain) => chain.stations.length >= 2 && chain.segments.length >= 1);
+      const names = this.disambiguateDuplicateNames(
+        emittedChains.map((chain) => this.chainDisplayName(line.name, chain)),
+      );
+      for (const [index, chain] of emittedChains.entries()) {
         const discriminator = chain.stations.map((station) => station.id).join(':');
         const newLineId = `mlit-line-${this.hash(`${key}:${discriminator}`)}`;
         const remappedIds = new Map<string, string>();
-        const remappedStations = chain.stations.map((station, index) => {
+        const remappedStations = chain.stations.map((station, stationIndex) => {
           const stationCode = stationCodeById.get(station.id) ?? station.id;
           const newStationId = `mlit-station-${this.hash(`${key}:${discriminator}:${stationCode}`)}`;
           remappedIds.set(station.id, newStationId);
-          return { ...station, id: newStationId, lineId: newLineId, sequence: index + 1 };
+          return { ...station, id: newStationId, lineId: newLineId, sequence: stationIndex + 1 };
         });
         lines.push({
           ...line,
           id: newLineId,
-          name: `${line.name}（${chain.stations[0].name}〜${chain.stations[chain.stations.length - 1].name}）`,
+          name: names[index],
         });
         stations.push(...remappedStations);
         segments.push(...chain.segments.map((segment) => {
@@ -242,10 +246,40 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
     return visited.size === connectedIds.length ? ordered : null;
   }
 
+  private chainDisplayName(
+    lineName: string,
+    chain: { stations: Station[]; isCycle: boolean },
+  ): string {
+    const first = chain.stations[0]?.name ?? '';
+    const last = chain.stations[chain.stations.length - 1]?.name ?? '';
+    const inner = chain.isCycle ? `${first}・循環` : `${first}〜${last}`;
+    return `${lineName}（${inner}）`;
+  }
+
+  // Duplicate names within one MLIT line key get a 1-based ordinal on every
+  // colliding member (`・1`, `・2`, …) in the already-deterministic chain
+  // emission order. Non-colliding names are left unsuffixed. Every member of
+  // a colliding group is suffixed so no chain is silently privileged; the
+  // suffix is a pure function of that emission order and does not depend on
+  // how many siblings a chain "would have" under a different grouping.
+  private disambiguateDuplicateNames(names: string[]): string[] {
+    const counts = new Map<string, number>();
+    for (const name of names) {
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    const seen = new Map<string, number>();
+    return names.map((name) => {
+      if ((counts.get(name) ?? 0) < 2) return name;
+      const ordinal = (seen.get(name) ?? 0) + 1;
+      seen.set(name, ordinal);
+      return `${name.slice(0, -1)}・${ordinal}）`;
+    });
+  }
+
   private decomposeIntoLinearChains(
     stations: Station[],
     segments: TrackSegment[],
-  ): Array<{ stations: Station[]; segments: TrackSegment[] }> {
+  ): Array<{ stations: Station[]; segments: TrackSegment[]; isCycle: boolean }> {
     const stationById = new Map(stations.map((station) => [station.id, station]));
     const adjacency = new Map<string, Set<string>>();
     const segmentByEdge = new Map<string, TrackSegment>();
@@ -359,7 +393,7 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
     chain: { stationIds: string[]; isCycle: boolean },
     stationById: Map<string, Station>,
     segmentByEdge: Map<string, TrackSegment>,
-  ): { stations: Station[]; segments: TrackSegment[] } {
+  ): { stations: Station[]; segments: TrackSegment[]; isCycle: boolean } {
     const stations = chain.stationIds.flatMap((id) => {
       const station = stationById.get(id);
       return station ? [station] : [];
@@ -375,7 +409,7 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
       const segment = segmentByEdge.get(this.undirectedEdgeKey(from, to));
       return segment ? [segment] : [];
     });
-    return { stations, segments };
+    return { stations, segments, isCycle: chain.isCycle };
   }
 
   private undirectedEdgeKey(a: string, b: string): string {

--- a/src/etl/adapters/mlit-adapter.ts
+++ b/src/etl/adapters/mlit-adapter.ts
@@ -60,6 +60,7 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
 
     const lineByKey = new Map<string, RailwayLine>();
     const stationsByLine = new Map<string, Station[]>();
+    const stationCodeById = new Map<string, string>();
     for (const feature of stationFeatures) {
       const coordinates = this.lineCoordinates(feature);
       if (!coordinates || !coordinates.some(([lat, lon]) => this.inKanto(lat, lon))) continue;
@@ -78,6 +79,7 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
         longitude: midpoint[1],
         provenance: [provenance],
       };
+      stationCodeById.set(station.id, stationCode);
       const list = stationsByLine.get(line.id) ?? [];
       if (!list.some((candidate) => candidate.id === station.id)) list.push(station);
       stationsByLine.set(line.id, list);
@@ -117,14 +119,46 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
     const lines: RailwayLine[] = [];
     const stations: Station[] = [];
     const segments: TrackSegment[] = [];
-    for (const line of lineByKey.values()) {
+    for (const [key, line] of lineByKey) {
       const lineStations = stationsByLine.get(line.id) ?? [];
       const lineSegments = rawSegmentsByLine.get(line.id) ?? [];
       const orderedStations = this.orderSimpleConnectedLine(lineStations, lineSegments);
-      if (!orderedStations) continue;
-      lines.push(line);
-      stations.push(...orderedStations.map((station, index) => ({ ...station, sequence: index + 1 })));
-      segments.push(...lineSegments);
+      if (orderedStations) {
+        lines.push(line);
+        stations.push(...orderedStations.map((station, index) => ({ ...station, sequence: index + 1 })));
+        segments.push(...lineSegments);
+        continue;
+      }
+      for (const chain of this.decomposeIntoLinearChains(lineStations, lineSegments)) {
+        if (chain.stations.length < 2 || chain.segments.length < 1) continue;
+        const discriminator = chain.stations.map((station) => station.id).join(':');
+        const newLineId = `mlit-line-${this.hash(`${key}:${discriminator}`)}`;
+        const remappedIds = new Map<string, string>();
+        const remappedStations = chain.stations.map((station, index) => {
+          const stationCode = stationCodeById.get(station.id) ?? station.id;
+          const newStationId = `mlit-station-${this.hash(`${key}:${discriminator}:${stationCode}`)}`;
+          remappedIds.set(station.id, newStationId);
+          return { ...station, id: newStationId, lineId: newLineId, sequence: index + 1 };
+        });
+        lines.push({
+          ...line,
+          id: newLineId,
+          name: `${line.name}（${chain.stations[0].name}〜${chain.stations[chain.stations.length - 1].name}）`,
+        });
+        stations.push(...remappedStations);
+        segments.push(...chain.segments.map((segment) => {
+          const fromStationId = remappedIds.get(segment.fromStationId) ?? segment.fromStationId;
+          const toStationId = remappedIds.get(segment.toStationId) ?? segment.toStationId;
+          const endpointKey = [fromStationId, toStationId].sort().join(':');
+          return {
+            ...segment,
+            id: `mlit-segment-${this.hash(`${newLineId}:${endpointKey}`)}`,
+            lineId: newLineId,
+            fromStationId,
+            toStationId,
+          };
+        }));
+      }
     }
 
     return { lines, stations, segments };
@@ -206,6 +240,146 @@ export class MlitRailwayAdapter implements RailwaySourceAdapter {
       current = (adjacency.get(current) ?? []).find((id) => !visited.has(id)) ?? '';
     }
     return visited.size === connectedIds.length ? ordered : null;
+  }
+
+  private decomposeIntoLinearChains(
+    stations: Station[],
+    segments: TrackSegment[],
+  ): Array<{ stations: Station[]; segments: TrackSegment[] }> {
+    const stationById = new Map(stations.map((station) => [station.id, station]));
+    const adjacency = new Map<string, Set<string>>();
+    const segmentByEdge = new Map<string, TrackSegment>();
+    for (const segment of segments) {
+      if (!stationById.has(segment.fromStationId) || !stationById.has(segment.toStationId)) continue;
+      if (segment.fromStationId === segment.toStationId) continue;
+      adjacency.set(segment.fromStationId, (adjacency.get(segment.fromStationId) ?? new Set()).add(segment.toStationId));
+      adjacency.set(segment.toStationId, (adjacency.get(segment.toStationId) ?? new Set()).add(segment.fromStationId));
+      segmentByEdge.set(this.undirectedEdgeKey(segment.fromStationId, segment.toStationId), segment);
+    }
+    const neighborsOf = (id: string): string[] => [...(adjacency.get(id) ?? [])].sort((a, b) => a.localeCompare(b));
+    const chains = this.connectedComponents([...adjacency.keys()], neighborsOf)
+      .flatMap((component) => this.chainsInComponent(component, neighborsOf))
+      .map((chain) => this.materializeChain(chain, stationById, segmentByEdge))
+      .filter((chain) => chain.stations.length >= 2 && chain.segments.length >= 1);
+    chains.sort((a, b) => {
+      const left = a.stations.map((station) => station.id).join('\0');
+      const right = b.stations.map((station) => station.id).join('\0');
+      return left.localeCompare(right);
+    });
+    return chains;
+  }
+
+  private connectedComponents(nodes: string[], neighborsOf: (id: string) => string[]): string[][] {
+    const visited = new Set<string>();
+    const components: string[][] = [];
+    for (const start of [...nodes].sort((a, b) => a.localeCompare(b))) {
+      if (visited.has(start)) continue;
+      const component: string[] = [];
+      const queue = [start];
+      visited.add(start);
+      while (queue.length > 0) {
+        const node = queue.shift()!;
+        component.push(node);
+        for (const neighbor of neighborsOf(node)) {
+          if (visited.has(neighbor)) continue;
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+      component.sort((a, b) => a.localeCompare(b));
+      components.push(component);
+    }
+    components.sort((a, b) => a.join('\0').localeCompare(b.join('\0')));
+    return components;
+  }
+
+  private chainsInComponent(
+    component: string[],
+    neighborsOf: (id: string) => string[],
+  ): Array<{ stationIds: string[]; isCycle: boolean }> {
+    const degree = (id: string) => neighborsOf(id).length;
+    const used = new Set<string>();
+    const walk = (start: string, first: string): { stationIds: string[]; isCycle: boolean } => {
+      used.add(this.undirectedEdgeKey(start, first));
+      const stationIds = [start];
+      let prev = start;
+      let curr = first;
+      while (curr !== start) {
+        stationIds.push(curr);
+        if (degree(curr) !== 2) return { stationIds, isCycle: false };
+        const next = neighborsOf(curr).find((id) => id !== prev);
+        if (!next) return { stationIds, isCycle: false };
+        const edge = this.undirectedEdgeKey(curr, next);
+        if (used.has(edge)) return { stationIds, isCycle: next === start };
+        used.add(edge);
+        prev = curr;
+        curr = next;
+      }
+      return { stationIds, isCycle: true };
+    };
+
+    const chains: Array<{ stationIds: string[]; isCycle: boolean }> = [];
+    const terminals = component.filter((id) => degree(id) !== 2).sort((a, b) => a.localeCompare(b));
+    for (const terminal of terminals) {
+      for (const neighbor of neighborsOf(terminal)) {
+        if (used.has(this.undirectedEdgeKey(terminal, neighbor))) continue;
+        chains.push(walk(terminal, neighbor));
+      }
+    }
+    while (true) {
+      const start = component
+        .filter((id) => neighborsOf(id).some((neighbor) => !used.has(this.undirectedEdgeKey(id, neighbor))))
+        .sort((a, b) => a.localeCompare(b))[0];
+      if (!start) break;
+      const first = neighborsOf(start).find((neighbor) => !used.has(this.undirectedEdgeKey(start, neighbor)));
+      if (!first) break;
+      chains.push(walk(start, first));
+    }
+    return chains.map((chain) => this.canonicalizeChain(chain));
+  }
+
+  private canonicalizeChain(chain: { stationIds: string[]; isCycle: boolean }): { stationIds: string[]; isCycle: boolean } {
+    const { stationIds, isCycle } = chain;
+    if (stationIds.length < 2) return chain;
+    if (!isCycle) {
+      return stationIds[0].localeCompare(stationIds[stationIds.length - 1]) > 0
+        ? { stationIds: [...stationIds].reverse(), isCycle: false }
+        : chain;
+    }
+    const minId = [...stationIds].sort((a, b) => a.localeCompare(b))[0];
+    const minIndex = stationIds.indexOf(minId);
+    const rotated = [...stationIds.slice(minIndex), ...stationIds.slice(0, minIndex)];
+    if (rotated.length >= 3 && rotated[1].localeCompare(rotated[rotated.length - 1]) > 0) {
+      return { stationIds: [rotated[0], ...rotated.slice(1).reverse()], isCycle: true };
+    }
+    return { stationIds: rotated, isCycle: true };
+  }
+
+  private materializeChain(
+    chain: { stationIds: string[]; isCycle: boolean },
+    stationById: Map<string, Station>,
+    segmentByEdge: Map<string, TrackSegment>,
+  ): { stations: Station[]; segments: TrackSegment[] } {
+    const stations = chain.stationIds.flatMap((id) => {
+      const station = stationById.get(id);
+      return station ? [station] : [];
+    });
+    const pairs: Array<[string, string]> = [];
+    for (let index = 0; index < chain.stationIds.length - 1; index++) {
+      pairs.push([chain.stationIds[index], chain.stationIds[index + 1]]);
+    }
+    if (chain.isCycle && chain.stationIds.length >= 2) {
+      pairs.push([chain.stationIds[chain.stationIds.length - 1], chain.stationIds[0]]);
+    }
+    const segments = pairs.flatMap(([from, to]) => {
+      const segment = segmentByEdge.get(this.undirectedEdgeKey(from, to));
+      return segment ? [segment] : [];
+    });
+    return { stations, segments };
+  }
+
+  private undirectedEdgeKey(a: string, b: string): string {
+    return a.localeCompare(b) < 0 ? `${a}:${b}` : `${b}:${a}`;
   }
 
   private inKanto(lat: number, lon: number): boolean {

--- a/tests/etl/mlit-adapter.test.ts
+++ b/tests/etl/mlit-adapter.test.ts
@@ -1,13 +1,78 @@
 import { afterAll, describe, expect, it } from 'vitest';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { MlitRailwayAdapter } from '../../src/etl/adapters/mlit-adapter';
+import { TopologyBuilder } from '../../src/etl/topology-builder';
+import { Station, TrackSegment } from '../../src/domain/models/railway';
 
 const sourceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'railglance-mlit-test-'));
+const LINE_NAME = '試験線';
+const OPERATOR = '試験鉄道';
+const LINE_KEY = `${OPERATOR}\u0000${LINE_NAME}`;
+const BASE_PROPERTIES = {
+  N02_001: '12', N02_002: '5', N02_003: LINE_NAME, N02_004: OPERATOR,
+};
 
 function writeGeoJson(filename: string, features: unknown[]): void {
   fs.writeFileSync(path.join(sourceDirectory, filename), JSON.stringify({ type: 'FeatureCollection', features }));
+}
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function stationFeature(name: string, code: string, lon: number, lat: number) {
+  return {
+    type: 'Feature',
+    properties: { ...BASE_PROPERTIES, N02_005: name, N02_005c: code },
+    geometry: { type: 'LineString', coordinates: [[lon, lat], [lon, lat]] },
+  };
+}
+
+function sectionFeature(coordinates: Array<[number, number]>) {
+  return {
+    type: 'Feature',
+    properties: BASE_PROPERTIES,
+    geometry: { type: 'LineString', coordinates },
+  };
+}
+
+async function loadFixture(stations: unknown[], sections: unknown[]) {
+  writeGeoJson('N02-23_Station.geojson', stations);
+  writeGeoJson('N02-23_RailroadSection.geojson', sections);
+  return new MlitRailwayAdapter({ sourceDirectory, strict: true }).load();
+}
+
+function originalLineId(): string {
+  return `mlit-line-${hash(LINE_KEY)}`;
+}
+
+function originalStationId(code: string): string {
+  return `mlit-station-${hash(`${LINE_KEY}:${code}`)}`;
+}
+
+function identitySnapshot(result: { lines: Array<{ id: string; name: string }>; stations: Station[]; segments: TrackSegment[] }) {
+  return {
+    lines: result.lines.map((line) => ({ id: line.id, name: line.name })),
+    stations: result.stations.map((station) => ({
+      id: station.id, lineId: station.lineId, name: station.name, sequence: station.sequence,
+    })),
+    segments: result.segments.map((segment) => ({
+      id: segment.id, lineId: segment.lineId, fromStationId: segment.fromStationId, toStationId: segment.toStationId,
+    })),
+  };
+}
+
+function uniqueNeighborCounts(stations: Station[], segments: TrackSegment[]): number[] {
+  const adjacency = new Map<string, Set<string>>();
+  for (const station of stations) adjacency.set(station.id, new Set());
+  for (const segment of segments) {
+    adjacency.get(segment.fromStationId)?.add(segment.toStationId);
+    adjacency.get(segment.toStationId)?.add(segment.fromStationId);
+  }
+  return [...adjacency.values()].map((neighbors) => neighbors.size);
 }
 
 afterAll(() => {
@@ -16,28 +81,13 @@ afterAll(() => {
 
 describe('MlitRailwayAdapter', () => {
   it('converts real N02 GeoJSON attributes and keeps provenance', async () => {
-    const baseProperties = {
-      N02_001: '12', N02_002: '5', N02_003: '試験線', N02_004: '試験鉄道',
-    };
-    writeGeoJson('N02-23_Station.geojson', [
-      {
-        type: 'Feature',
-        properties: { ...baseProperties, N02_005: '始点', N02_005c: '001' },
-        geometry: { type: 'LineString', coordinates: [[139, 35], [139, 35]] },
-      },
-      {
-        type: 'Feature',
-        properties: { ...baseProperties, N02_005: '終点', N02_005c: '002' },
-        geometry: { type: 'LineString', coordinates: [[139, 35.01], [139, 35.01]] },
-      },
-    ]);
-    writeGeoJson('N02-23_RailroadSection.geojson', [{
-      type: 'Feature',
-      properties: baseProperties,
-      geometry: { type: 'LineString', coordinates: [[139, 35], [139, 35.005], [139, 35.01]] },
-    }]);
-
-    const result = await new MlitRailwayAdapter({ sourceDirectory, strict: true }).load();
+    const result = await loadFixture(
+      [
+        stationFeature('始点', '001', 139, 35),
+        stationFeature('終点', '002', 139, 35.01),
+      ],
+      [sectionFeature([[139, 35], [139, 35.005], [139, 35.01]])],
+    );
     expect(result.lines).toHaveLength(1);
     expect(result.lines[0]).toMatchObject({ name: '試験線', operatorName: '試験鉄道' });
     expect(result.stations.map((station) => station.sequence)).toEqual([1, 2]);
@@ -52,4 +102,183 @@ describe('MlitRailwayAdapter', () => {
   it('requires an explicit source for a publishable build', async () => {
     await expect(new MlitRailwayAdapter({ sourceDirectory: '', strict: true }).load()).rejects.toThrow(/MLIT_N02_DIR/);
   });
+
+  it('emits a plain linear line unchanged, including ids and station sequence', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('始点', '001', 139, 35),
+        stationFeature('中間', '002', 139, 35.01),
+        stationFeature('終点', '003', 139, 35.02),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139, 35.02]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0].id).toBe(originalLineId());
+    expect(result.lines[0].name).toBe(LINE_NAME);
+    expect(result.lines[0].operatorName).toBe(OPERATOR);
+    expect(result.stations).toHaveLength(3);
+    expect(result.stations.map((station) => station.sequence)).toEqual([1, 2, 3]);
+    expect(result.stations.map((station) => station.id).sort()).toEqual(
+      ['001', '002', '003'].map(originalStationId).sort(),
+    );
+    expect(result.stations.every((station) => station.lineId === originalLineId())).toBe(true);
+    expect(result.segments).toHaveLength(2);
+    expect(result.segments.every((segment) => segment.lineId === originalLineId())).toBe(true);
+    expect(result.segments.every((segment) => segment.id.startsWith('mlit-segment-'))).toBe(true);
+  });
+
+  it('splits a Y-shaped branching line into non-branching chains with distinct station ids', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('始点', '001', 139, 35),
+        stationFeature('中間', '002', 139, 35.01),
+        stationFeature('分岐', '003', 139, 35.02),
+        stationFeature('終点', '004', 139, 35.03),
+        stationFeature('支線', '005', 139.01, 35.02),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139, 35.02]]),
+        sectionFeature([[139, 35.02], [139, 35.03]]),
+        sectionFeature([[139, 35.02], [139.01, 35.02]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(3);
+    expect(result.lines.every((line) => line.id !== originalLineId())).toBe(true);
+    expect(result.lines.every((line) => line.operatorName === OPERATOR)).toBe(true);
+    expect(result.lines.every((line) => line.operatorId === result.lines[0].operatorId)).toBe(true);
+    expect(result.lines.every((line) => /試験線（.+〜.+）/.test(line.name))).toBe(true);
+
+    const stationIds = result.stations.map((station) => station.id);
+    expect(new Set(stationIds).size).toBe(stationIds.length);
+
+    const junctionCopies = result.stations.filter((station) => station.name === '分岐');
+    expect(junctionCopies.length).toBeGreaterThan(1);
+    expect(new Set(junctionCopies.map((station) => station.id)).size).toBe(junctionCopies.length);
+    expect(new Set(junctionCopies.map((station) => station.lineId)).size).toBe(junctionCopies.length);
+
+    for (const line of result.lines) {
+      const lineStations = result.stations.filter((station) => station.lineId === line.id);
+      const lineSegments = result.segments.filter((segment) => segment.lineId === line.id);
+      expect(lineStations.length).toBeGreaterThanOrEqual(2);
+      expect(lineSegments.length).toBeGreaterThanOrEqual(1);
+      expect(Math.max(...uniqueNeighborCounts(lineStations, lineSegments))).toBeLessThanOrEqual(2);
+      expect(lineStations.map((station) => station.sequence)).toEqual(
+        lineStations.map((_, index) => index + 1),
+      );
+      expect(line.name).toBe(`試験線（${lineStations[0].name}〜${lineStations[lineStations.length - 1].name}）`);
+    }
+
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('emits each disconnected linear component as its own line', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('北始', '001', 139, 35),
+        stationFeature('北終', '002', 139, 35.01),
+        stationFeature('南始', '003', 139.3, 35),
+        stationFeature('南終', '004', 139.3, 35.01),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139.3, 35], [139.3, 35.01]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(2);
+    expect(result.lines.every((line) => line.id !== originalLineId())).toBe(true);
+    const namedFromEndpoints = (codeA: string, nameA: string, codeB: string, nameB: string): string => {
+      const [first, last] = originalStationId(codeA) < originalStationId(codeB) ? [nameA, nameB] : [nameB, nameA];
+      return `${LINE_NAME}（${first}〜${last}）`;
+    };
+    const names = result.lines.map((line) => line.name).sort();
+    expect(names).toEqual([
+      namedFromEndpoints('001', '北始', '002', '北終'),
+      namedFromEndpoints('003', '南始', '004', '南終'),
+    ].sort());
+    expect(result.stations).toHaveLength(4);
+    expect(new Set(result.stations.map((station) => station.id)).size).toBe(4);
+    expect(result.segments).toHaveLength(2);
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('drops a chain that would have fewer than two stations or one segment', async () => {
+    const isolatedOnly = await loadFixture(
+      [stationFeature('孤駅', '001', 139, 35)],
+      [],
+    );
+    expect(isolatedOnly.lines).toHaveLength(0);
+    expect(isolatedOnly.stations).toHaveLength(0);
+    expect(isolatedOnly.segments).toHaveLength(0);
+
+    const branchedWithOrphan = await loadFixture(
+      [
+        stationFeature('始点', '001', 139, 35),
+        stationFeature('分岐', '002', 139, 35.01),
+        stationFeature('終点', '003', 139, 35.02),
+        stationFeature('支線', '004', 139.01, 35.01),
+        stationFeature('孤駅', '099', 139.5, 36),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139, 35.02]]),
+        sectionFeature([[139, 35.01], [139.01, 35.01]]),
+      ],
+    );
+    expect(branchedWithOrphan.lines).toHaveLength(3);
+    expect(branchedWithOrphan.stations.some((station) => station.name === '孤駅')).toBe(false);
+    expect(branchedWithOrphan.stations.length).toBeGreaterThanOrEqual(2);
+    expect(branchedWithOrphan.segments.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits a simple cycle as a single line with the original name and ids', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('環一', '001', 139, 35),
+        stationFeature('環二', '002', 139, 35.01),
+        stationFeature('環三', '003', 139.01, 35.005),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139.01, 35.005]]),
+        sectionFeature([[139.01, 35.005], [139, 35]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0].id).toBe(originalLineId());
+    expect(result.lines[0].name).toBe(LINE_NAME);
+    expect(result.stations).toHaveLength(3);
+    expect(result.stations.map((station) => station.id).sort()).toEqual(
+      ['001', '002', '003'].map(originalStationId).sort(),
+    );
+    expect(result.segments).toHaveLength(3);
+    expect(Math.max(...uniqueNeighborCounts(result.stations, result.segments))).toBe(2);
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('produces identical ids and ordering across two loads of the same branching input', async () => {
+    const stations = [
+      stationFeature('始点', '001', 139, 35),
+      stationFeature('分岐', '002', 139, 35.01),
+      stationFeature('終点', '003', 139, 35.02),
+      stationFeature('支線', '004', 139.01, 35.01),
+    ];
+    const sections = [
+      sectionFeature([[139, 35], [139, 35.01]]),
+      sectionFeature([[139, 35.01], [139, 35.02]]),
+      sectionFeature([[139, 35.01], [139.01, 35.01]]),
+    ];
+    const first = await loadFixture(stations, sections);
+    const second = await loadFixture(stations, sections);
+    expect(identitySnapshot(first)).toEqual(identitySnapshot(second));
+    expect(first.lines.length).toBeGreaterThan(1);
+  });
 });
+

--- a/tests/etl/mlit-adapter.test.ts
+++ b/tests/etl/mlit-adapter.test.ts
@@ -263,7 +263,114 @@ describe('MlitRailwayAdapter', () => {
     expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
   });
 
-  it('produces identical ids and ordering across two loads of the same branching input', async () => {
+  it('names a cycle chain with ・循環 instead of adjacent endpoints', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('分岐', '001', 139, 35),
+        stationFeature('環一', '002', 139, 35.01),
+        stationFeature('環二', '003', 139.01, 35.005),
+        stationFeature('支線端', '004', 139.02, 35),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139.01, 35.005]]),
+        sectionFeature([[139.01, 35.005], [139, 35]]),
+        sectionFeature([[139, 35], [139.02, 35]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(2);
+    const ring = result.lines.find((line) => {
+      const lineStations = result.stations.filter((station) => station.lineId === line.id);
+      const lineSegments = result.segments.filter((segment) => segment.lineId === line.id);
+      return lineStations.length === lineSegments.length;
+    });
+    const tail = result.lines.find((line) => line.id !== ring?.id);
+    expect(ring).toBeDefined();
+    expect(tail).toBeDefined();
+
+    const ringStations = result.stations.filter((station) => station.lineId === ring!.id);
+    const ringSegments = result.segments.filter((segment) => segment.lineId === ring!.id);
+    expect(ringStations).toHaveLength(3);
+    expect(ringSegments).toHaveLength(3);
+    expect(ring!.name).toMatch(/^試験線（.+・循環）$/);
+    expect(ring!.name).not.toMatch(/〜/);
+    expect(tail!.name).toMatch(/^試験線（.+〜.+）$/);
+    expect(tail!.name).not.toMatch(/循環/);
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('suffixes every member of a colliding name group within one line key', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('西端', '001', 139, 35),
+        stationFeature('大宮', '002', 139, 35.01),
+        stationFeature('武蔵浦和', '003', 139, 35.02),
+        stationFeature('与野', '004', 139, 35.03),
+        stationFeature('赤羽', '005', 139, 35.04),
+        stationFeature('東端', '006', 139, 35.05),
+        stationFeature('浦和', '007', 139.01, 35.02),
+        stationFeature('北浦和', '008', 139.01, 35.03),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139, 35.02]]),
+        sectionFeature([[139, 35.02], [139, 35.03]]),
+        sectionFeature([[139, 35.03], [139, 35.04]]),
+        sectionFeature([[139, 35.04], [139, 35.05]]),
+        sectionFeature([[139, 35.01], [139.01, 35.02]]),
+        sectionFeature([[139.01, 35.02], [139.01, 35.03]]),
+        sectionFeature([[139.01, 35.03], [139, 35.04]]),
+      ],
+    );
+
+    const colliding = result.lines.filter((line) => {
+      const names = result.stations.filter((station) => station.lineId === line.id).map((station) => station.name);
+      return names.includes('武蔵浦和') || names.includes('浦和');
+    });
+    expect(colliding).toHaveLength(2);
+    const unsuffixed = colliding.map((line) => line.name.replace(/・\d+）$/, '）'));
+    expect(unsuffixed[0]).toBe(unsuffixed[1]);
+    expect(unsuffixed[0]).toMatch(/^試験線（.+〜.+）$/);
+    expect(new Set(colliding.map((line) => line.name))).toEqual(
+      new Set([`${unsuffixed[0].slice(0, -1)}・1）`, `${unsuffixed[0].slice(0, -1)}・2）`]),
+    );
+    const uniqueNames = new Set(result.lines.map((line) => line.name));
+    expect(uniqueNames.size).toBe(result.lines.length);
+    const others = result.lines.filter((line) => !colliding.includes(line));
+    expect(others.every((line) => !/・\d+）$/.test(line.name))).toBe(true);
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('disambiguates colliding cycle names with the same ・ordinal scheme', async () => {
+    const result = await loadFixture(
+      [
+        stationFeature('環駅', '001', 139, 35),
+        stationFeature('環駅', '002', 139, 35.01),
+        stationFeature('環駅', '003', 139.01, 35.005),
+        stationFeature('環駅', '004', 139.3, 35),
+        stationFeature('環駅', '005', 139.3, 35.01),
+        stationFeature('環駅', '006', 139.31, 35.005),
+      ],
+      [
+        sectionFeature([[139, 35], [139, 35.01]]),
+        sectionFeature([[139, 35.01], [139.01, 35.005]]),
+        sectionFeature([[139.01, 35.005], [139, 35]]),
+        sectionFeature([[139.3, 35], [139.3, 35.01]]),
+        sectionFeature([[139.3, 35.01], [139.31, 35.005]]),
+        sectionFeature([[139.31, 35.005], [139.3, 35]]),
+      ],
+    );
+
+    expect(result.lines).toHaveLength(2);
+    expect(result.lines.every((line) => line.name === '試験線（環駅・循環・1）' || line.name === '試験線（環駅・循環・2）')).toBe(true);
+    expect(new Set(result.lines.map((line) => line.name))).toEqual(
+      new Set(['試験線（環駅・循環・1）', '試験線（環駅・循環・2）']),
+    );
+    expect(() => new TopologyBuilder().buildTopology(result.lines, result.stations, result.segments)).not.toThrow();
+  });
+
+  it('produces identical ids, names and ordering when input features are permuted', async () => {
     const stations = [
       stationFeature('始点', '001', 139, 35),
       stationFeature('分岐', '002', 139, 35.01),
@@ -275,8 +382,14 @@ describe('MlitRailwayAdapter', () => {
       sectionFeature([[139, 35.01], [139, 35.02]]),
       sectionFeature([[139, 35.01], [139.01, 35.01]]),
     ];
+    // Hard-coded derangement of feature order so Map/Set insertion order
+    // differs between the two loads. Writing the same array twice would
+    // still pass if every .sort() in the decomposer were deleted, because
+    // V8 iteration follows insertion order.
+    const permutedStations = [stations[3], stations[1], stations[0], stations[2]];
+    const permutedSections = [sections[2], sections[0], sections[1]];
     const first = await loadFixture(stations, sections);
-    const second = await loadFixture(stations, sections);
+    const second = await loadFixture(permutedStations, permutedSections);
     expect(identitySnapshot(first)).toEqual(identitySnapshot(second));
     expect(first.lines.length).toBeGreaterThan(1);
   });


### PR DESCRIPTION
## 背景

R2 に載っているデータセット `v1.1.0` は MLIT データなしでビルドされたサンプル 7 路線でした（品質ゲート追加前の 2026-08-05 デプロイ）。「実データをデプロイすれば解決するはず」と考えて実際に N02-23 をダウンロードしてビルドしたところ、**その先にもう一つ問題が埋まっていました**。

`MlitRailwayAdapter` は路線の駅グラフが「分岐のない一本道」または「単一の環状」でない限り `orderSimpleConnectedLine()` が `null` を返し、呼び出し側がその路線を丸ごと捨てていました。実データで計測した結果、**関東候補 186 路線のうち 26 路線が無言で破棄**されており、その中身は関東の主要 JR 線ほぼ全てでした。

つまりデプロイを実行するだけでは、利用者が最も多い路線に乗車中はアプリが何も表示できないままでした。

### 破棄されていた 26 路線の内訳（実データで分類）

| 理由 | 件数 | 該当路線 |
|---|---|---|
| 実際の分岐（3 方向以上の駅） | 12 | 東北線（大宮ほか 7 箇所）、東海道線（新橋 deg=4）、総武線、京王線、大江戸線、南武線、武蔵野線、京葉線、鶴見線、水郡線、東武小泉線、ユーカリが丘線 |
| 分断（複数の非連結成分） | 13 | 中央線、常磐線、上越線、信越線、内房線、外房線、高崎線、成田線、新幹線各線、京成成田空港線、JR 東海東海道線 |
| データ不足 | 1 | 北陸新幹線（1 駅・正当な破棄、そのまま維持） |

分断の原因は、MLIT `RailroadSection` が駅間単位ではなく細かい線路断片であることです。端点が駅から 1500 m 以内に無い断片はスキップされ、グラフが分断されます（例: 中央線は 204 断片中 133 個が脱落）。

## 変更内容

分岐・分断した路線を捨てる代わりに、**分岐のない最大チェーンへ分解**して 1 チェーン 1 路線として出力します。`TopologyBuilder` の分岐不変条件（同一路線内で 1 駅に 3 本以上のセグメントが接続すると例外）はそのまま維持しています — そのエラーメッセージ自身が `split branches into explicit routes before publishing` とこの前処理を要求しているためです。

- 既に一本道／環状の路線は従来の `orderSimpleConnectedLine` を通り、**出力は完全に不変**
- 分解したチェーンは端点から命名（`東北線（大宮〜赤羽）`）、環状は `12号線大江戸線（飯田橋・循環）`
- 同一路線内で名前が衝突する場合は決定的な出力順で全メンバーに連番を付与
- チェーンごとの識別子を line/station/segment の各 id にハッシュ。**接合駅が複数チェーンに複製されても、Dexie が `id` のみで駅を管理しているため上書きされる事故を防ぐ**ための必須措置
- `schemaVersion` は `1.1.0` 据え置き。データ内容の変更であり、上げると配布済み端末がデータセットを拒否します

## カバレッジ

| | 路線 | 駅 | セグメント | タイル |
|---|---:|---:|---:|---:|
| 現在の R2（サンプルのみ） | 7 | 56 | 49 | 254 |
| 修正前のビルド | 167 | 2317 | 2151 | 807 |
| **修正後** | **270** | **3124** | **2860** | **1035** |

復活した主要路線: 東北線（20 系統 97 駅）、中央線（4 系統 67 駅、うち神田〜高尾 31 駅）、東海道線（16 系統 75 駅）、常磐線（70 駅）、総武線（両国〜銚子 40 駅）、京王線（32 駅）、大江戸線（28 駅の環状＋光が丘支線 11 駅）、南武線（尻手〜立川 25 駅）、武蔵野線、京葉線、高崎線、内房線、外房線、成田線、鶴見線、水郡線（33 駅）、上越線、信越線（直江津〜矢代田 35 駅）

## 検証

### 既存データへの無影響（最重要）

HEAD 版アダプタと新版アダプタの出力を実データで突き合わせ:

- 既存 160 路線: **消失 0・変化 0**（id、名前、事業者、駅の順序と `sequence`、セグメント id と座標点数まで完全一致）
- **小田急小田原線（実走テスト路線、47 駅）は id まで含めて完全に不変**
- 駅 id 衝突 **0**、セグメント id 衝突 **0**
- 命名修正の前後で **id 集合は完全一致**、変わったのは名前 15 件のみ（環状 5 + 衝突 10）

### 病的なグラフ形状の実地テスト

合成 GeoJSON で Y 字分岐 / 純環状 / ロリポップ（環＋尾）/ 8 の字 / 十字（degree 4）/ 非連結 / 単一辺 / 二重 Y 字を投入し、全ケースで分岐なし・id 衝突なし・`sequence` が 1..n で整合・`TopologyBuilder` 例外なしを確認。

### 決定性

実データで 2 回ビルドし、id・名前・駅順序・セグメントが完全一致することを確認（`provenance.acquiredAt` は既存挙動としてビルド毎に変わります）。テスト側もフィクスチャの並び順を入れ替えて比較する形に修正し、**decomposer のソートを外すと実際に失敗すること**を確認済みです（従来のテストは同一ファイルを 2 回読むだけで、ソートを全て削除しても通る空虚なものでした）。

### 自動テスト

`pnpm test` 287 passed / `pnpm lint` clean / `pnpm build` clean / 実データフルビルドで `TopologyBuilder` 例外なし

## レビュー

実装は Grok、レビューは Opus（独立エージェント）。Opus は分解アルゴリズムについて「emit されるチェーンは必ず単純パスか単純閉路であり、`TopologyBuilder` を例外に落とすことは構造的に不可能」「`while(true)` の停止性は各反復で必ず 1 本以上の辺が消費されることから保証される」と論証した上で、環状の命名問題・名前衝突・決定性テストの空虚さを検出しました。3 点とも本 PR で修正済みです。

将来 MLIT データが更新された際の id 変動については、全リモートテーブルが `[datasetVersion+id]` キーで、バージョン変更時に `deleteInactiveRemoteVersions` が旧版を破棄する設計であり、`localStorage` 等の永続化も無いことを確認しました。id が変わってもタイルが再取得されるだけで利用者の状態は失われないため、許容と判断しています。

## 既知の制約（別課題）

MLIT の線路断片が分断されているため、東北線は約 20 チェーン（1 チェーン平均 5 駅程度）に分割されます。マップマッチング自体は機能しますが、走行中に路線ロックの引き継ぎが頻発し、HUD の表示名が区間ごとに変わります（`東北線（A〜B）` → `東北線（B〜C）`）。次駅推定の見通しもチェーン境界で途切れます。

データが全く無い現状より明確に良いため公開の障害にはしませんが、根本的な改善は連続する `RailroadSection` を駅間で連結することです。これにより分断由来の 13 路線（失敗の半数）が解消され、残るチェーンも大幅に長くなります。今回はジオメトリ品質を実測（駅間直線距離の 80% 未満しか覆わないセグメントは 10.8% のみ、小田原線の中央値 0.91 は駅座標がプラットフォーム中点であることによる想定内の差）した上で、スコープ外としました。

## マージ後の手順

```
gh workflow run deploy-r2.yml -f dataset_version=1.4.0
```

`deploy-r2.yml` は main ブランチからのみ実行可能です。R2 の既存 `v1.1.0` は immutable なので新バージョンを採番します（内蔵サンプルが 1.3.0 を名乗るため 1.4.0）。

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Km878Mo47nqEEXqi5qLGt
