### PR TITLE
fix: reject non-MLIT datasets on the client (#44)

### DIFF
--- a/src/domain/models/provenance.ts
+++ b/src/domain/models/provenance.ts
@@ -16,3 +16,10 @@ export type SourceLicenseMetadata = {
   attributionText: string;
   redistributionAllowed: boolean;
 };
+
+/**
+ * Source id the MLIT adapter records in every provenance entry. Defined here, in a
+ * dependency-free domain module, so the ETL, the deploy gate and the client-side
+ * manifest parser all assert the same value and cannot drift apart.
+ */
+export const MLIT_SOURCE_ID = 'mlit-n02-23';

--- a/src/etl/adapters/mlit-adapter.ts
+++ b/src/etl/adapters/mlit-adapter.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { RailwaySourceAdapter, RawRailwayDataset } from './source-adapter';
-import { SourceLicenseMetadata, DataProvenance } from '../../domain/models/provenance';
+import { SourceLicenseMetadata, DataProvenance, MLIT_SOURCE_ID } from '../../domain/models/provenance';
 import { RailwayLine, Station, TrackSegment } from '../../domain/models/railway';
 import { haversineDistance } from '../../domain/geo/distance';
 
@@ -20,7 +20,7 @@ export type MlitRailwayAdapterOptions = {
 const KANTO_BUFFER = { minLat: 34.5, maxLat: 37.75, minLon: 138.0, maxLon: 141.5 };
 
 export class MlitRailwayAdapter implements RailwaySourceAdapter {
-  public sourceId = 'mlit-n02-23';
+  public sourceId = MLIT_SOURCE_ID;
 
   constructor(private options: MlitRailwayAdapterOptions = {}) {}
 

--- a/src/infrastructure/storage/railway-dataset-schema.ts
+++ b/src/infrastructure/storage/railway-dataset-schema.ts
@@ -19,7 +19,11 @@ export type RailwayDatasetManifest = {
   totalStations: number;
   totalSegments: number;
   totalTiles: number;
+  sources: string[];
+  mlitSourced: true;
 };
+
+const MLIT_SOURCE_ID = 'mlit-n02-23';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -39,6 +43,19 @@ function requireNumber(record: Record<string, unknown>, key: string): number {
     throw new Error(`Dataset field "${key}" must be a finite number`);
   }
   return value;
+}
+
+function requireMlitProvenance(record: Record<string, unknown>): { sources: string[]; mlitSourced: true } {
+  if (record.mlitSourced !== true) {
+    throw new Error('Dataset manifest must declare official MLIT provenance');
+  }
+  if (!Array.isArray(record.sources) || !record.sources.every((source) => typeof source === 'string')) {
+    throw new Error('Dataset manifest sources must be an array of strings');
+  }
+  if (!record.sources.includes(MLIT_SOURCE_ID)) {
+    throw new Error('Dataset manifest must include the official MLIT source');
+  }
+  return { sources: record.sources, mlitSourced: true };
 }
 
 function assertSupportedSchema(schemaVersion: string): void {
@@ -70,6 +87,7 @@ export function parseRailwayDatasetManifest(value: unknown): RailwayDatasetManif
   if (!isRecord(value)) throw new Error('manifest.json must contain an object');
   const schemaVersion = requireString(value, 'schemaVersion');
   assertSupportedSchema(schemaVersion);
+  const provenance = requireMlitProvenance(value);
   return {
     version: requireString(value, 'version'),
     schemaVersion,
@@ -80,6 +98,7 @@ export function parseRailwayDatasetManifest(value: unknown): RailwayDatasetManif
     totalStations: requireNumber(value, 'totalStations'),
     totalSegments: requireNumber(value, 'totalSegments'),
     totalTiles: requireNumber(value, 'totalTiles'),
+    ...provenance,
   };
 }
 

--- a/src/infrastructure/storage/railway-dataset-schema.ts
+++ b/src/infrastructure/storage/railway-dataset-schema.ts
@@ -1,4 +1,5 @@
 import { H3TileData } from '../../etl/h3-tiler';
+import { MLIT_SOURCE_ID } from '../../domain/models/provenance';
 
 export const RAILWAY_DATASET_SCHEMA_VERSION = '1.1.0';
 
@@ -22,8 +23,6 @@ export type RailwayDatasetManifest = {
   sources: string[];
   mlitSourced: true;
 };
-
-const MLIT_SOURCE_ID = 'mlit-n02-23';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -53,7 +52,7 @@ function requireMlitProvenance(record: Record<string, unknown>): { sources: stri
     throw new Error('Dataset manifest sources must be an array of strings');
   }
   if (!record.sources.includes(MLIT_SOURCE_ID)) {
-    throw new Error('Dataset manifest must include the official MLIT source');
+    throw new Error(`Dataset manifest must include the official MLIT source (${MLIT_SOURCE_ID})`);
   }
   return { sources: record.sources, mlitSourced: true };
 }

--- a/src/scripts/build-kanto-dataset.ts
+++ b/src/scripts/build-kanto-dataset.ts
@@ -7,6 +7,7 @@ import { TopologyBuilder } from '../etl/topology-builder';
 import { H3Tiler } from '../etl/h3-tiler';
 import { CoverageReporter } from '../etl/coverage-reporter';
 import { RAILWAY_DATASET_SCHEMA_VERSION } from '../infrastructure/storage/railway-dataset-schema';
+import { MLIT_SOURCE_ID } from '../domain/models/provenance';
 
 export type DatasetBuildOptions = {
   outputRoot?: string;
@@ -16,7 +17,7 @@ export type DatasetBuildOptions = {
 };
 
 /** Source id reported by MlitRailwayAdapter; recorded in the manifest so deploys can require it. */
-export const MLIT_SOURCE_ID = 'mlit-n02-23';
+export { MLIT_SOURCE_ID };
 
 /** Version used for sample-only local builds so they can never be mistaken for a release. */
 export const SAMPLE_DATASET_VERSION = '0.0.0-sample';

--- a/src/scripts/deploy-r2.ts
+++ b/src/scripts/deploy-r2.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { MLIT_SOURCE_ID } from '../domain/models/provenance';
 import {
   HeadObjectCommand,
   PutBucketCorsCommand,
@@ -29,8 +30,6 @@ function loadEnvFile(): void {
 
 const EXPLICIT_SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
-/** Source id recorded by the MLIT adapter. Kept local so the deploy script has no ETL dependency. */
-const MLIT_SOURCE_ID = 'mlit-n02-23';
 
 /**
  * Minimum publishable dataset size.

--- a/tests/storage/railway-dataset-sync.test.ts
+++ b/tests/storage/railway-dataset-sync.test.ts
@@ -23,6 +23,8 @@ function manifest(version: string) {
     totalStations: 0,
     totalSegments: 0,
     totalTiles: 1,
+    sources: ['mlit-n02-23'],
+    mlitSourced: true,
   };
 }
 
@@ -49,6 +51,25 @@ afterEach(async () => {
 });
 
 describe('railway dataset remote sync', () => {
+  it('rejects a remote dataset that lacks official MLIT provenance', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) {
+        return jsonResponse({
+          ...manifest('2.0.0'),
+          sources: ['railglance-existing-sample'],
+          mlitSourced: false,
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow(/MLIT provenance/);
+    expect(db.getDataState()).toBe('bundled');
+  });
+
   it('rejects an unsupported or omitted schema and keeps bundled data active', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({
       ...latest('2.0.0'),
@@ -304,4 +325,3 @@ describe('railway dataset remote sync', () => {
     }
   });
 });
-

--- a/tests/storage/railway-dataset-sync.test.ts
+++ b/tests/storage/railway-dataset-sync.test.ts
@@ -70,6 +70,44 @@ describe('railway dataset remote sync', () => {
     expect(db.getDataState()).toBe('bundled');
   });
 
+  it('rejects a remote dataset whose sources are not an array of strings', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) {
+        return jsonResponse({
+          ...manifest('2.0.0'),
+          sources: ['mlit-n02-23', 42],
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow(/sources must be an array of strings/);
+    expect(db.getDataState()).toBe('bundled');
+    expect(await db.getLine('odakyu-odawara')).toBeDefined();
+  });
+
+  it('rejects a remote dataset that claims MLIT provenance without the official source id', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/datasets/latest.json')) return jsonResponse(latest('2.0.0'));
+      if (url.endsWith('/datasets/v2.0.0/manifest.json')) {
+        return jsonResponse({
+          ...manifest('2.0.0'),
+          sources: ['railglance-existing-sample'],
+        });
+      }
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(db.connectRemoteManifest(baseUrl)).rejects.toThrow(/must include the official MLIT source/);
+    expect(db.getDataState()).toBe('bundled');
+    expect(await db.getLine('odakyu-odawara')).toBeDefined();
+  });
+
   it('rejects an unsupported or omitted schema and keeps bundled data active', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({
       ...latest('2.0.0'),

--- a/tests/storage/railway-repository-completeness.test.ts
+++ b/tests/storage/railway-repository-completeness.test.ts
@@ -36,6 +36,8 @@ function manifest() {
     totalStations: 4,
     totalSegments: 0,
     totalTiles: 1,
+    sources: ['mlit-n02-23'],
+    mlitSourced: true,
   };
 }
 


### PR DESCRIPTION
## 概要

`fix-route-detection` ブランチに未マージのまま残っていた `b43f378` を、そのまま cherry-pick して main へ取り込みます。

クライアント側（アプリ）に**データセットのMLIT出自検証**を追加します。リモート manifest が `mlitSourced: true` を宣言し、`sources` に公式ソースID `mlit-n02-23` を含んでいなければ、アプリはそのデータセットを拒否して内蔵データにフォールバックします。

## なぜ必要か

現状、MLIT出自の検証は `src/scripts/deploy-r2.ts`（デプロイ側）にしかありません。つまり「サンプルデータを誤って公開しない」ガードはありますが、**アプリ側には「受け取ったデータセットがサンプルかどうか」を判別する手段がありません**。

実際にこの穴は顕在化していました。R2 の `v1.1.0` は品質ゲート追加前にデプロイされたサンプル7路線（`mlitSourced` フィールドすら持たない）で、アプリはこれを正規のデータセットとして受け入れ、内蔵データと同一内容を「クラウドから取得したデータ」として扱っていました。

本PRにより、この多層防御が揃います。

## 動作確認

実際にR2上にある各バージョンの manifest を、この変更後の `parseRailwayDatasetManifest()` に通した結果:

| バージョン | 内容 | 結果 |
|---|---|---|
| `v1.1.0` | サンプル7路線、`mlitSourced` なし | **拒否**（`Dataset manifest must declare official MLIT provenance`）→ 内蔵データにフォールバック |
| `v1.1.2` | MLIT由来 192路線 | 受理 |

意図した fail-closed 動作です。拒否された場合も既存のフォールバック経路が働くため、アプリが機能停止することはありません。

## 互換性

現在デプロイ進行中の `v1.4.0`（main の ETL から生成、270路線）は `mlitSourced: true` と `sources: [..., 'mlit-n02-23']` を持つため、本変更の影響を受けません。

一方、`latest.json` が将来なんらかの理由で `v1.1.0` を指し戻した場合、アプリはデータセットを拒否して内蔵サンプルにフォールバックします。これは本変更の意図する動作です。

## このブランチについて

`fix-route-detection` にはもう1つ `b05147c fix: retain branched MLIT railway lines` が残っていますが、**そちらは取り込みません**。同じ「分岐路線が破棄される」問題は PR #57 が解決済みで、実装として優れているためです。

`b05147c` は分岐路線を1路線のまま保持する代わりに、駅の並び順に `stableOrder()`（駅IDのハッシュ順ソート）を使っています。その結果、実際にデプロイされた `v1.1.2` では東北線の駅 `sequence` が地理的順序になっていませんでした:

```
6:さいたま新都心 → 15:東大宮 → 25:土呂 → 26:北与野 → 41:大宮
```

大宮が41番、その北にある東大宮が15番という並びで、次駅推定が機能しません。PR #57 は分岐点でチェーンに分解し、各チェーンに 1..n の地理的に正しい `sequence` を付与します。また `b05147c` は `TopologyBuilder` の分岐ガードを削除していますが、PR #57 はこれを維持しています。

本PRのマージ後、`fix-route-detection` ブランチは役目を終えるため削除して問題ありません。

## 検証

- `pnpm test` — 288 passed
- `pnpm lint` — clean
- `pnpm build` — clean
- 実デプロイ済み manifest に対する受理/拒否の動作確認（上表）

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Km878Mo47nqEEXqi5qLGt
