### PR TITLE
chore: bump to 0.1.3 for a new Even Hub beta build (#44)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "package_id": "com.railglance.traintracker",
   "edition": "202601",
   "name": "RailGlance Train HUD",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "min_app_version": "2.0.0",
   "min_sdk_version": "0.0.12",
   "entrypoint": "index.html",

--- a/infra/cloudflare/telemetry-worker/wrangler.toml
+++ b/infra/cloudflare/telemetry-worker/wrangler.toml
@@ -47,7 +47,7 @@ dead_letter_queue = "railglance-telemetry-dlq"
 TELEMETRY_ALLOWED_ORIGINS = "http://localhost:5173,http://127.0.0.1:*,http://localhost:*"
 TELEMETRY_CAMPAIGN_ID = "railglance-beta-2026"
 TELEMETRY_QUALIFICATION_DAYS = "14"
-TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2"
+TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2,railglance@0.1.3"
 TELEMETRY_TOKEN_TTL_SECONDS = "900"
 
 # Set with `wrangler secret put`; never place either value in this file or the .ehpk.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "railglance",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "concurrently -k -s first \"vite\" \"wait-on http://localhost:5173 && evenhub-simulator http://localhost:5173\"",


### PR DESCRIPTION
## 目的

実機確認用に Even Hub ベータパッケージ 0.1.3 をビルドできるようにします。

## アプリバンドルへの実質的な変更は1つだけです

現在実機にインストールされている 0.1.2 は 2026-08-21 のCIビルド（`49ab9fb1`）です。それ以降 main に入った変更のうち、**パッケージされるアプリのコードに含まれるのは PR #58 のクライアント側MLIT出自検証だけ**です。

```
$ git diff --name-only 49ab9fb1 origin/main | grep '^src/' | grep -vE '^src/(scripts|etl)/'
src/domain/models/provenance.ts
src/infrastructure/storage/railway-dataset-schema.ts
```

他（PR #56 のCORS対応、PR #57 のETL分岐分解）は、デプロイスクリプト・ETL・テレメトリWorkerに閉じており、アプリのバンドルには入りません。

そのため **R2 の v1.4.0（270路線 / 3124駅）の実走確認自体は 0.1.2 のままでも可能**です。本PRは PR #58 の安全網を実機へ載せるためのものです。

## 変更内容

| ファイル | 内容 |
|---|---|
| `package.json` | `0.1.2` → `0.1.3` |
| `app.json` | `0.1.2` → `0.1.3`（CIが両者の一致を検証） |
| `infra/cloudflare/telemetry-worker/wrangler.toml` | `TELEMETRY_ALLOWED_RELEASES` に `railglance@0.1.3` を追加 |

### テレメトリ許可リリースの追加が必須である理由

Worker の `TELEMETRY_ALLOWED_RELEASES` は `railglance@0.1.0,0.1.1,0.1.2` で止まっています。この状態で 0.1.3 をビルドして実機に入れると、アプリは `release-blocked` 状態になり診断収集を停止します（`src/infrastructure/telemetry/runtime-telemetry.ts`）。実走で集めたいデータがまさに診断ログなので、これを忘れるとテスト走行が無駄になります。

**このPRのマージだけでは反映されません。Worker の再デプロイが必要です。**

## マージ後に必要な手順

1. **GitHub環境変数 `VITE_APP_RELEASE` を `railglance@0.1.3` へ更新**
   `build-evenhub-package.yml` は `VITE_APP_RELEASE` が `railglance@<package.json version>` と一致しない場合、ビルド前に hard fail します。環境 `evenhub-beta` の変数で、更新にはリポジトリ管理権限が必要です。

2. **テレメトリWorkerの再デプロイ**
   ```
   cd infra/cloudflare/telemetry-worker && npx wrangler deploy
   ```

3. **パッケージビルド**
   ```
   gh workflow run build-evenhub-package.yml --ref main
   ```
   このワークフローは main ブランチからのみ実行可能です。成果物 `out.ehpk` はArtifactとして14日間保持されます。

## 検証

- `pnpm test` — 290 passed
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm manifest:evenhub` で `dist/app.json` の version が `0.1.3` になることを確認
- CIのバージョン整合チェック（`package.json` と `app.json` の一致）をローカルで再現し通過を確認
- リポジトリ内に `0.1.2` の取り残し参照がないことを確認

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Km878Mo47nqEEXqi5qLGt
