### PR TITLE
Stop redeploying the telemetry Worker for every patch release

### DIFF
--- a/.claude/skills/bumping-app-version/SKILL.md
+++ b/.claude/skills/bumping-app-version/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: bumping-app-version
+description: Use when the RailGlance app version must change, a release/x.y.z branch or PR is requested, or a new Even Hub beta package (.ehpk) needs to be built and shipped to testers.
+---
+
+# Bumping the App Version
+
+## Overview
+
+A version bump is a checklist with one decision point: does the telemetry Worker need a redeploy? Everything else is mechanical and verified by `pnpm release:check`.
+
+The release identifier is always `railglance@<package.json version>`. CI derives `VITE_APP_RELEASE` from package.json, so there is no GitHub variable to update.
+
+## Decision: Worker redeploy
+
+```dot
+digraph worker_redeploy {
+    "Did major.minor change?" [shape=diamond];
+    "Add railglance@X.Y.* to wrangler.toml" [shape=box];
+    "Did infra/cloudflare/telemetry-worker change since the last deploy?" [shape=diamond];
+    "Redeploy Worker from main AFTER merge, BEFORE distributing the package" [shape=box];
+    "No Worker action" [shape=box];
+
+    "Did major.minor change?" -> "Add railglance@X.Y.* to wrangler.toml" [label="yes"];
+    "Add railglance@X.Y.* to wrangler.toml" -> "Redeploy Worker from main AFTER merge, BEFORE distributing the package";
+    "Did major.minor change?" -> "Did infra/cloudflare/telemetry-worker change since the last deploy?" [label="no"];
+    "Did infra/cloudflare/telemetry-worker change since the last deploy?" -> "Redeploy Worker from main AFTER merge, BEFORE distributing the package" [label="yes"];
+    "Did infra/cloudflare/telemetry-worker change since the last deploy?" -> "No Worker action" [label="no"];
+}
+```
+
+Patch bumps never edit `TELEMETRY_ALLOWED_RELEASES`: the `railglance@X.Y.*` entry already covers them. Never add an exact `railglance@X.Y.Z` entry for a new build. Keep the existing exact entries; devices older than 0.1.4 need them.
+
+To tell whether the Worker directory changed since the last deploy:
+
+```bash
+git log -1 --format='%h %cI' -- infra/cloudflare/telemetry-worker
+cd infra/cloudflare/telemetry-worker && pnpm dlx wrangler deployments list | head -20
+```
+
+If the newest commit is later than the newest deployment, redeploy.
+
+## Procedure
+
+1. **Preconditions.** `git fetch origin` and start from `origin/main`; working tree clean; `gh auth status` succeeds.
+2. **Branch.** `git checkout -b release/X.Y.Z origin/main`.
+3. **Edit versions** in exactly these files:
+   - `package.json` `version`
+   - `app.json` `version`
+   - `.env.example` `VITE_APP_RELEASE=railglance@X.Y.Z`
+   - `infra/cloudflare/telemetry-worker/wrangler.toml` only per the decision above.
+4. **Verify.**
+   ```bash
+   pnpm release:check && pnpm lint && pnpm test && pnpm build && pnpm manifest:evenhub
+   node -p "require('./dist/app.json').version"
+   ```
+   `release:check` fails if the versions disagree, the allowlist would reject the release, or `.env.example` is stale.
+5. **Bundle diff for the PR body.** Find the commit of the previous package build (the merge commit of the last `release/*` PR, or the SHA in the last workflow summary) and list app-bundle changes since then:
+   ```bash
+   git diff --name-only <previous-build-sha> origin/main | grep '^src/' | grep -vE '^src/(scripts|etl)/'
+   ```
+   Files outside that filter (ETL, deploy scripts, Worker, docs) are not in the `.ehpk`.
+6. **Commit and PR.** Title `Bump app package version to X.Y.Z for a new Even Hub beta build`. Body sections: purpose, bundle changes since the last build (from step 5), files changed, post-merge steps (copy the applicable ones from below), verification commands run. Add `Refs #<issue>` when there is one.
+7. **After merge**, in this order:
+   1. Worker redeploy, only if the decision says so: `cd infra/cloudflare/telemetry-worker && pnpm dlx wrangler deploy`, run from an up-to-date `main` checkout.
+   2. `gh workflow run build-evenhub-package.yml --ref main`, then `gh run watch`.
+   3. `gh run download <run-id>` to get `out.ehpk`. The artifact expires after 14 days.
+   4. Confirm the run summary shows `Release: railglance@X.Y.Z`.
+8. **Distribution** (Even Hub Private Testing, then Beta after the device gate in `docs/TELEMETRY_AND_SENTRY.md`) is a separate step and must come after the Worker redeploy when one was needed.
+
+## Quick reference
+
+| Situation | wrangler.toml | Worker deploy | GitHub variables |
+|---|---|---|---|
+| Patch bump, no Worker code change | untouched | no | none |
+| Patch bump, Worker code changed since last deploy | untouched | yes, after merge | none |
+| Minor or major bump | add `railglance@X.Y.*` | yes, after merge | none |
+
+## Common mistakes
+
+- Editing `package.json` but not `app.json`, or the reverse. The package workflow hard-fails.
+- Adding `railglance@X.Y.Z` to the allowlist for a patch release. The wildcard already covers it, and the exact list is what this process replaced.
+- Updating the `evenhub-beta` environment variable `VITE_APP_RELEASE`. It is no longer read; the workflow derives the value.
+- Deploying the Worker before the release PR is merged. The deploy must include the Worker code and toml that are on `main`.
+- Handing the package to testers before the Worker redeploy when the minor changed. The app enrolls with a release the Worker does not know and stops collecting.
+- Running the package workflow from a branch other than `main`. It refuses.
+- Re-running `deploy-r2` or `provision-cloudflare` as part of a version bump. They are unrelated unless the dataset or Terraform changed.

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ R2_CORS_ALLOWED_ORIGINS=*
 # Error tracking. The DSN is intentionally a browser-visible project endpoint, not a secret.
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
-VITE_APP_RELEASE=railglance@0.1.2
+VITE_APP_RELEASE=railglance@0.1.3
 VITE_APP_ENVIRONMENT=prototype
 
 # Build-time source map upload (CI/build environment only; never VITE_-prefixed).

--- a/.github/workflows/build-evenhub-package.yml
+++ b/.github/workflows/build-evenhub-package.yml
@@ -90,6 +90,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Check release consistency
+        run: pnpm release:check
+
       - name: Build package and upload source maps
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-evenhub-package.yml
+++ b/.github/workflows/build-evenhub-package.yml
@@ -20,7 +20,6 @@ jobs:
       VITE_RAILWAY_DATA_BASE_URL: ${{ vars.VITE_RAILWAY_DATA_BASE_URL }}
       VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
       VITE_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.VITE_SENTRY_TRACES_SAMPLE_RATE }}
-      VITE_APP_RELEASE: ${{ vars.VITE_APP_RELEASE }}
       VITE_APP_ENVIRONMENT: ${{ vars.VITE_APP_ENVIRONMENT }}
       VITE_TELEMETRY_ENDPOINT: ${{ vars.VITE_TELEMETRY_ENDPOINT }}
       VITE_EVEN_SDK_VERSION: ${{ vars.VITE_EVEN_SDK_VERSION }}
@@ -57,7 +56,6 @@ jobs:
             VITE_RAILWAY_DATA_BASE_URL
             VITE_SENTRY_DSN
             VITE_SENTRY_TRACES_SAMPLE_RATE
-            VITE_APP_RELEASE
             VITE_APP_ENVIRONMENT
             VITE_TELEMETRY_ENDPOINT
             VITE_EVEN_SDK_VERSION
@@ -78,15 +76,13 @@ jobs:
 
           package_version=$(node -p "require('./package.json').version")
           manifest_version=$(node -p "require('./app.json').version")
-          expected_release="railglance@${package_version}"
           if [[ "$manifest_version" != "$package_version" ]]; then
             echo "app.json version must match package.json version" >&2
             exit 1
           fi
-          if [[ "$VITE_APP_RELEASE" != "$expected_release" ]]; then
-            echo "VITE_APP_RELEASE must be $expected_release" >&2
-            exit 1
-          fi
+          # The release identifier is derived from package.json so a version bump
+          # never requires editing an environment variable by hand.
+          echo "VITE_APP_RELEASE=railglance@${package_version}" >> "$GITHUB_ENV"
           if [[ "$VITE_APP_ENVIRONMENT" != "beta" ]]; then
             echo "VITE_APP_ENVIRONMENT must be beta for this workflow" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - run: pnpm release:check
       - run: pnpm test
       - run: pnpm build
       - run: pnpm ehpack

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -132,8 +132,10 @@ Secretは環境間で共有されないため、各コマンドに `--env stagin
 ### 許可releaseの運用
 
 `TELEMETRY_ALLOWED_RELEASES` はパッチワイルドカードで minor 系列ごとに1エントリにまとめる。パッチ版の
-リリースでは `wrangler.toml` を編集せず、Workerも再デプロイしない。minor または major を上げたときだけ
-新しいワイルドカードエントリを追加して `pnpm dlx wrangler deploy` を実行する。古い系列の収集を終える
+リリースでは `wrangler.toml` を編集せず、許可releaseを理由とした Worker の再デプロイも不要になる。minor
+または major を上げたときだけ新しいワイルドカードエントリを追加して `pnpm dlx wrangler deploy` を実行する。
+Worker のコード自体が前回デプロイ以降に変わっている場合は、パッチ版でも再デプロイが必要になる。判定の
+手順は `.claude/skills/bumping-app-version/SKILL.md` を参照する。古い系列の収集を終える
 ときはそのエントリを削除する。特定のパッチ版だけを除外したい場合は、その系列のワイルドカードを完全一致
 エントリの列挙へ戻す。
 

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -40,7 +40,7 @@ Cloudflare Worker はparticipant単位のDurable Objectを資格台帳に使う�
 - enrollment: 同意、初回参加コード、対象releaseを検証する。
 - qualification: 7〜30日、既定14日。participant ID、campaign ID、credential hash、許可release、失効日時を保持する。
 - upload token: HMAC署名、5〜60分、既定15分。campaign、participant、environment、許可releaseをscopeに含める。
-- release制限: `TELEMETRY_ALLOWED_RELEASES` の完全一致。アプリ更新後はオンライン検証が完了するまで新規収集しない。
+- release制限: `TELEMETRY_ALLOWED_RELEASES` の各エントリは完全一致（`railglance@0.1.3`）またはパッチワイルドカード（`railglance@0.1.*`）。ワイルドカードは同じ major.minor の数字パッチだけに一致し、prerelease 接尾辞や別 minor には一致しない。それ以外の位置の `*` はリテラル扱いで fail closed する。アプリ更新後はオンライン検証が完了するまで新規収集しない。
 - 即時失効: 管理endpointでparticipantを失効させ、以後のtoken更新とuploadを拒否する。
 - レート制限: enrollmentはcampaign単位30回/分、token更新とuploadはparticipant単位240回/分を既定とする。
 - 入力制限: Origin allowlist、120 KB、200 events、schema、値域を検証する。allowlist の各エントリは通常は完全一致。末尾が `:*` のエントリだけは当該 `scheme://host` の任意の数値ポートを許可し、Even App WebView の loopback Origin（`http://127.0.0.1:<エフェメラルポート>`）に使う。裸の `*` は `:*` で終わらないためリテラル `Origin: *` への完全一致になり、ブラウザはそれを送れないので fail closed する。
@@ -129,6 +129,24 @@ TELEMETRY_ADMIN_TOKEN="development-only-admin-token"
 現在の `wrangler.toml` にはnamed environmentを定義していない。将来 `[env.staging]` などを追加した場合、
 Secretは環境間で共有されないため、各コマンドに `--env staging` を付けて環境ごとに登録する。
 
+### 許可releaseの運用
+
+`TELEMETRY_ALLOWED_RELEASES` はパッチワイルドカードで minor 系列ごとに1エントリにまとめる。パッチ版の
+リリースでは `wrangler.toml` を編集せず、Workerも再デプロイしない。minor または major を上げたときだけ
+新しいワイルドカードエントリを追加して `pnpm dlx wrangler deploy` を実行する。古い系列の収集を終える
+ときはそのエントリを削除する。特定のパッチ版だけを除外したい場合は、その系列のワイルドカードを完全一致
+エントリの列挙へ戻す。
+
+照合ロジックは `src/infrastructure/telemetry/release-allowlist.ts` にあり、アプリとWorkerが同じ関数を
+import する。アプリ側も enroll/refresh 応答の `allowedReleases` を自分の release と照合するため、
+ワイルドカードを解釈できないクライアント（0.1.3以前）が残っている間は、そのクライアントの完全一致
+エントリをリストに残す。切り替え手順は次の通り。
+
+1. ワイルドカード対応版のアプリを配布する。この時点では `wrangler.toml` を変えない。
+2. 対応版が端末に載った後、`railglance@0.1.3,railglance@0.1.*` のように旧クライアント用の完全一致と
+   ワイルドカードを併記して Worker を再デプロイする。
+3. 旧クライアントが残っていないことを確認してから完全一致エントリを削除する。
+
 `wrangler.toml` でcampaign ID、資格日数、対象release、token TTL、Origin allowlistを設定する。allowlistは
 通常完全一致だが、末尾が `:*` のエントリは当該 `scheme://host` の任意の数値ポートを許可する（Even App
 WebView の loopback Origin用）。release更新前に
@@ -177,7 +195,6 @@ GitHubの `Settings` → `Environments` → `New environment` で `evenhub-beta`
 | `VITE_SENTRY_TRACES_SAMPLE_RATE` | `0.1` | performance traceの送信率 |
 | `SENTRY_ORG` | Sentry organization slug | Sentry Project Settings URLのorganization部分 |
 | `SENTRY_PROJECT` | Sentry project slug | Sentry Project Settings URLのproject部分 |
-| `VITE_APP_RELEASE` | `railglance@0.1.0`など | `railglance@` + `package.json`のversion。Workerの許可releaseとも完全一致させる |
 | `VITE_APP_ENVIRONMENT` | `beta` | SentryとTelemetry上の環境名 |
 | `VITE_TELEMETRY_ENDPOINT` | Telemetry WorkerのHTTPS URL | 独自ドメイン導入前はデプロイ結果の`workers.dev` URL |
 | `VITE_EVEN_SDK_VERSION` | `0.0.12`など | 使用中のEven Hub SDK version |
@@ -205,7 +222,9 @@ GitHubの `Settings` → `Environments` → `New environment` で `evenhub-beta`
 `SENTRY_AUTH_TOKEN`だけをSecretへ置き、Repository Variable、`.env`、ログ、`.ehpk`には保存しない。
 
 workflowは手動実行専用で、`main`以外からの配布、必須設定の不足、`app.json`と`package.json`のversion不一致、
-`VITE_APP_RELEASE`の不一致、Sentry upload後にsource mapが`dist`へ残っている状態を拒否する。Node.js 26で
+Sentry upload後にsource mapが`dist`へ残っている状態を拒否する。`VITE_APP_RELEASE` は workflow が
+`package.json` の version から `railglance@<version>` として導出するため、Environment variable には置かない。
+Workerの `TELEMETRY_ALLOWED_RELEASES` がこの値に一致することを確認する。Node.js 26で
 `pnpm ehpack`を実行し、成功時はWorkflow SummaryとArtifactsに未圧縮の`out.ehpk`を14日間保存する。
 
 実行はGitHubの `Actions` → `Build Even Hub Beta Package` → `Run workflow` からbranchに`main`を選ぶ。

--- a/docs/TELEMETRY_AND_SENTRY.md
+++ b/docs/TELEMETRY_AND_SENTRY.md
@@ -138,14 +138,15 @@ Secretは環境間で共有されないため、各コマンドに `--env stagin
 エントリの列挙へ戻す。
 
 照合ロジックは `src/infrastructure/telemetry/release-allowlist.ts` にあり、アプリとWorkerが同じ関数を
-import する。アプリ側も enroll/refresh 応答の `allowedReleases` を自分の release と照合するため、
-ワイルドカードを解釈できないクライアント（0.1.3以前）が残っている間は、そのクライアントの完全一致
-エントリをリストに残す。切り替え手順は次の通り。
+import する。アプリ側も enroll/refresh 応答の `allowedReleases` を自分の release と照合する。
+ワイルドカードを解釈できないクライアント（0.1.3以前）は自分の release 文字列が配列に完全一致で
+含まれるかだけを見るので、ワイルドカードエントリが混ざっていても影響を受けない。したがって
+`railglance@0.1.3,railglance@0.1.*` のように旧クライアント用の完全一致とワイルドカードを併記した
+リストを、ワイルドカード対応版のアプリを配布する**前に** Worker へデプロイしておく。Worker のコードも
+同時に更新されるため、デプロイは対応版がマージされた `main` から行う。旧クライアントが残っていない
+ことを確認してから完全一致エントリを削除する。
 
-1. ワイルドカード対応版のアプリを配布する。この時点では `wrangler.toml` を変えない。
-2. 対応版が端末に載った後、`railglance@0.1.3,railglance@0.1.*` のように旧クライアント用の完全一致と
-   ワイルドカードを併記して Worker を再デプロイする。
-3. 旧クライアントが残っていないことを確認してから完全一致エントリを削除する。
+バージョンアップ作業の手順は `.claude/skills/bumping-app-version/SKILL.md` にまとめている。
 
 `wrangler.toml` でcampaign ID、資格日数、対象release、token TTL、Origin allowlistを設定する。allowlistは
 通常完全一致だが、末尾が `:*` のエントリは当該 `scheme://host` の任意の数値ポートを許可する（Even App

--- a/infra/cloudflare/telemetry-worker/src/index.ts
+++ b/infra/cloudflare/telemetry-worker/src/index.ts
@@ -1,3 +1,5 @@
+import { isReleaseAllowed, parseAllowedReleases } from '../../../../src/infrastructure/telemetry/release-allowlist';
+
 // Cloudflare Queues accepts at most 128 KB per message. Keep room for serialization metadata.
 const MAX_BODY_BYTES = 120_000;
 const MAX_SESSION_BODY_BYTES = 4_096;
@@ -503,10 +505,7 @@ function campaignId(env: WorkerEnvironment): string {
 }
 
 function allowedReleases(env: WorkerEnvironment): string[] {
-  return (env.TELEMETRY_ALLOWED_RELEASES ?? '')
-    .split(',')
-    .map((release) => release.trim())
-    .filter((release) => release.length > 0 && release.length <= 200);
+  return parseAllowedReleases(env.TELEMETRY_ALLOWED_RELEASES);
 }
 
 function qualificationStub(env: WorkerEnvironment, participantId: string): DurableObjectStub {
@@ -583,7 +582,7 @@ async function enrollCampaign(
   }
   const releases = allowedReleases(env);
   if (releases.length === 0) return jsonResponse(503, { error: 'allowed_releases_not_configured' }, origin);
-  if (!releases.includes(source.release)) return jsonResponse(403, { error: 'release_not_allowed' }, origin);
+  if (!isReleaseAllowed(source.release, releases)) return jsonResponse(403, { error: 'release_not_allowed' }, origin);
 
   const participantId = `p_${randomCredentialPart(18)}`;
   const credentialSecret = randomCredentialPart();
@@ -645,7 +644,7 @@ async function refreshDiagnosticSession(
   if (record.qualificationExpiresAt <= nowSeconds) return jsonResponse(410, { error: 'qualification_expired' }, origin);
   if (record.campaignId !== campaignId(env)) return jsonResponse(410, { error: 'campaign_ended' }, origin);
   const releases = allowedReleases(env);
-  if (!releases.includes(source.release)) return jsonResponse(403, { error: 'release_not_allowed' }, origin);
+  if (!isReleaseAllowed(source.release, releases)) return jsonResponse(403, { error: 'release_not_allowed' }, origin);
   if (JSON.stringify(record.allowedReleases) !== JSON.stringify(releases)) {
     record.allowedReleases = releases;
     await storeQualification(env, record);
@@ -709,9 +708,9 @@ async function acceptTelemetryBatch(
   if (
     batch.events.some((event) => (
       typeof event.release !== 'string' ||
-      !tokenPayload.allowedReleases.includes(event.release) ||
-      !qualification.allowedReleases.includes(event.release) ||
-      !allowedReleases(env).includes(event.release) ||
+      !isReleaseAllowed(event.release, tokenPayload.allowedReleases) ||
+      !isReleaseAllowed(event.release, qualification.allowedReleases) ||
+      !isReleaseAllowed(event.release, allowedReleases(env)) ||
       event.environment !== tokenPayload.environment
     ))
   ) return jsonResponse(403, { error: 'token_scope_mismatch' }, origin);

--- a/infra/cloudflare/telemetry-worker/wrangler.toml
+++ b/infra/cloudflare/telemetry-worker/wrangler.toml
@@ -47,6 +47,11 @@ dead_letter_queue = "railglance-telemetry-dlq"
 TELEMETRY_ALLOWED_ORIGINS = "http://localhost:5173,http://127.0.0.1:*,http://localhost:*"
 TELEMETRY_CAMPAIGN_ID = "railglance-beta-2026"
 TELEMETRY_QUALIFICATION_DAYS = "14"
+# Comma-separated. Each entry is either an exact release (`railglance@0.1.3`) or a
+# patch wildcard (`railglance@0.1.*`) that matches any numeric patch of that
+# major.minor. A `*` anywhere else is a literal and never matches.
+# Clients older than 0.1.4 compare exact strings, so keep their exact entries
+# until those devices are retired; see docs/TELEMETRY_AND_SENTRY.md.
 TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2,railglance@0.1.3"
 TELEMETRY_TOKEN_TTL_SECONDS = "900"
 

--- a/infra/cloudflare/telemetry-worker/wrangler.toml
+++ b/infra/cloudflare/telemetry-worker/wrangler.toml
@@ -50,9 +50,10 @@ TELEMETRY_QUALIFICATION_DAYS = "14"
 # Comma-separated. Each entry is either an exact release (`railglance@0.1.3`) or a
 # patch wildcard (`railglance@0.1.*`) that matches any numeric patch of that
 # major.minor. A `*` anywhere else is a literal and never matches.
-# Clients older than 0.1.4 compare exact strings, so keep their exact entries
-# until those devices are retired; see docs/TELEMETRY_AND_SENTRY.md.
-TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2,railglance@0.1.3"
+# Clients older than 0.1.4 compare exact strings and ignore wildcard entries, so
+# keep their exact entries until those devices are retired. See
+# docs/TELEMETRY_AND_SENTRY.md and .claude/skills/bumping-app-version/SKILL.md.
+TELEMETRY_ALLOWED_RELEASES = "railglance@0.1.0,railglance@0.1.1,railglance@0.1.2,railglance@0.1.3,railglance@0.1.*"
 TELEMETRY_TOKEN_TTL_SECONDS = "900"
 
 # Set with `wrangler secret put`; never place either value in this file or the .ehpk.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "deploy:r2": "pnpm build:data && tsx src/scripts/deploy-r2.ts",
     "deploy:r2:dry-run": "tsx src/scripts/deploy-r2.ts --dry-run",
     "manifest:evenhub": "tsx src/scripts/build-evenhub-manifest.ts",
+    "release:check": "tsx src/scripts/check-release.ts",
     "ehpack": "pnpm build && pnpm manifest:evenhub && evenhub pack dist/app.json dist",
     "lint": "eslint . --max-warnings=0",
     "preview": "vite preview",

--- a/src/infrastructure/telemetry/release-allowlist.ts
+++ b/src/infrastructure/telemetry/release-allowlist.ts
@@ -1,0 +1,32 @@
+/**
+ * Release allowlist matching shared by the app and the telemetry Worker.
+ *
+ * An entry is either an exact release string (`railglance@0.1.3`) or a patch
+ * wildcard (`railglance@0.1.*`) whose `*` stands for the whole patch segment
+ * and matches only digits. A `*` anywhere else is a literal character, so a
+ * bare `*` or `railglance@*` never matches a real release (fail closed).
+ */
+
+const MAX_ENTRY_LENGTH = 200;
+const PATCH_WILDCARD_SUFFIX = '.*';
+
+function matchesEntry(release: string, entry: string): boolean {
+  if (release === entry) return true;
+  if (!entry.endsWith(PATCH_WILDCARD_SUFFIX)) return false;
+  const prefix = entry.slice(0, -PATCH_WILDCARD_SUFFIX.length);
+  if (!/^[^*]+@\d+\.\d+$/.test(prefix)) return false;
+  if (!release.startsWith(`${prefix}.`)) return false;
+  return /^\d+$/.test(release.slice(prefix.length + 1));
+}
+
+export function isReleaseAllowed(release: string, entries: readonly string[]): boolean {
+  if (release.length === 0) return false;
+  return entries.some((entry) => matchesEntry(release, entry));
+}
+
+export function parseAllowedReleases(source: string | undefined): string[] {
+  return (source ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry.length <= MAX_ENTRY_LENGTH);
+}

--- a/src/infrastructure/telemetry/runtime-telemetry.ts
+++ b/src/infrastructure/telemetry/runtime-telemetry.ts
@@ -11,6 +11,7 @@ import {
   TelemetryHttpError,
   type TelemetrySink,
 } from './sinks';
+import { isReleaseAllowed } from './release-allowlist';
 import type { TelemetryEvent, TelemetryIdentity } from './types';
 
 const TOKEN_REFRESH_SKEW_MS = 5 * 60_000;
@@ -330,7 +331,7 @@ export class RuntimeTelemetryManager implements TelemetrySink {
       qualificationExpiresAtMs <= Date.now() ||
       !Array.isArray(result.allowedReleases) ||
       !result.allowedReleases.every((release) => typeof release === 'string') ||
-      !result.allowedReleases.includes(this.identity.release)
+      !isReleaseAllowed(this.identity.release, result.allowedReleases)
     ) {
       throw new Error('送信tokenの応答が不正です。');
     }
@@ -413,7 +414,7 @@ export class RuntimeTelemetryManager implements TelemetrySink {
       qualificationExpiresAtMs <= Date.now() ||
       !Array.isArray(result.allowedReleases) ||
       !result.allowedReleases.every((release) => typeof release === 'string') ||
-      !result.allowedReleases.includes(this.identity.release) ||
+      !isReleaseAllowed(this.identity.release, result.allowedReleases) ||
       typeof result.uploadToken !== 'string' || !result.uploadToken ||
       typeof result.uploadTokenExpiresAt !== 'string'
     ) throw new Error('キャンペーン参加応答が不正です。');

--- a/src/scripts/check-release.ts
+++ b/src/scripts/check-release.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { isReleaseAllowed, parseAllowedReleases } from '../infrastructure/telemetry/release-allowlist';
+
+/**
+ * Release consistency gate used by the version-bump workflow and CI.
+ *
+ * Checks that package.json and app.json carry the same version, that the
+ * Worker allowlist in wrangler.toml accepts `railglance@<version>`, and that
+ * .env.example points local development at the same release.
+ */
+
+export type ReleaseFiles = {
+  packageJson: string;
+  appJson: string;
+  wranglerToml: string;
+  envExample: string;
+};
+
+export type ReleaseCheckResult = { release: string; problems: string[] };
+
+const RELEASE_PREFIX = 'railglance@';
+
+function allowlistFromToml(toml: string): string[] | null {
+  const match = /^\s*TELEMETRY_ALLOWED_RELEASES\s*=\s*"([^"]*)"/m.exec(toml);
+  return match ? parseAllowedReleases(match[1]) : null;
+}
+
+function releaseFromEnvExample(env: string): string | null {
+  const match = /^VITE_APP_RELEASE=(.*)$/m.exec(env);
+  return match ? match[1].trim() : null;
+}
+
+export function checkRelease(files: ReleaseFiles): ReleaseCheckResult {
+  const packageVersion = String(JSON.parse(files.packageJson).version);
+  const appVersion = String(JSON.parse(files.appJson).version);
+  const release = `${RELEASE_PREFIX}${packageVersion}`;
+  const problems: string[] = [];
+
+  if (appVersion !== packageVersion) {
+    problems.push(`app.json version ${appVersion} must match package.json version ${packageVersion}`);
+  }
+
+  const allowlist = allowlistFromToml(files.wranglerToml);
+  if (allowlist === null) {
+    problems.push('wrangler.toml has no TELEMETRY_ALLOWED_RELEASES entry');
+  } else if (!isReleaseAllowed(release, allowlist)) {
+    const [major, minor] = packageVersion.split('.');
+    problems.push(
+      `TELEMETRY_ALLOWED_RELEASES does not cover ${release}; add ${RELEASE_PREFIX}${major}.${minor}.* and redeploy the Worker`
+    );
+  }
+
+  const envRelease = releaseFromEnvExample(files.envExample);
+  if (envRelease !== release) {
+    problems.push(`.env.example VITE_APP_RELEASE should be ${release}`);
+  }
+
+  return { release, problems };
+}
+
+export function readReleaseFiles(root: string): ReleaseFiles {
+  const read = (relative: string) => readFileSync(new URL(relative, root), 'utf8');
+  return {
+    packageJson: read('package.json'),
+    appJson: read('app.json'),
+    wranglerToml: read('infra/cloudflare/telemetry-worker/wrangler.toml'),
+    envExample: read('.env.example'),
+  };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const root = new URL('../../', import.meta.url).href;
+  const result = checkRelease(readReleaseFiles(root));
+  if (result.problems.length > 0) {
+    for (const problem of result.problems) console.error(`✗ ${problem}`);
+    process.exit(1);
+  }
+  console.log(`✓ ${result.release} is consistent across package.json, app.json, wrangler.toml, and .env.example`);
+}

--- a/src/scripts/check-release.ts
+++ b/src/scripts/check-release.ts
@@ -1,80 +1,11 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { isReleaseAllowed, parseAllowedReleases } from '../infrastructure/telemetry/release-allowlist';
+import { checkRelease, readReleaseFiles } from './release-check';
 
-/**
- * Release consistency gate used by the version-bump workflow and CI.
- *
- * Checks that package.json and app.json carry the same version, that the
- * Worker allowlist in wrangler.toml accepts `railglance@<version>`, and that
- * .env.example points local development at the same release.
- */
-
-export type ReleaseFiles = {
-  packageJson: string;
-  appJson: string;
-  wranglerToml: string;
-  envExample: string;
-};
-
-export type ReleaseCheckResult = { release: string; problems: string[] };
-
-const RELEASE_PREFIX = 'railglance@';
-
-function allowlistFromToml(toml: string): string[] | null {
-  const match = /^\s*TELEMETRY_ALLOWED_RELEASES\s*=\s*"([^"]*)"/m.exec(toml);
-  return match ? parseAllowedReleases(match[1]) : null;
+// CLI entrypoint for `pnpm release:check`. Deliberately has no "am I the main
+// module" guard: a guard that misfires would let CI pass without checking.
+const root = new URL('../../', import.meta.url).href;
+const result = checkRelease(readReleaseFiles(root));
+if (result.problems.length > 0) {
+  for (const problem of result.problems) console.error(`✗ ${problem}`);
+  process.exit(1);
 }
-
-function releaseFromEnvExample(env: string): string | null {
-  const match = /^VITE_APP_RELEASE=(.*)$/m.exec(env);
-  return match ? match[1].trim() : null;
-}
-
-export function checkRelease(files: ReleaseFiles): ReleaseCheckResult {
-  const packageVersion = String(JSON.parse(files.packageJson).version);
-  const appVersion = String(JSON.parse(files.appJson).version);
-  const release = `${RELEASE_PREFIX}${packageVersion}`;
-  const problems: string[] = [];
-
-  if (appVersion !== packageVersion) {
-    problems.push(`app.json version ${appVersion} must match package.json version ${packageVersion}`);
-  }
-
-  const allowlist = allowlistFromToml(files.wranglerToml);
-  if (allowlist === null) {
-    problems.push('wrangler.toml has no TELEMETRY_ALLOWED_RELEASES entry');
-  } else if (!isReleaseAllowed(release, allowlist)) {
-    const [major, minor] = packageVersion.split('.');
-    problems.push(
-      `TELEMETRY_ALLOWED_RELEASES does not cover ${release}; add ${RELEASE_PREFIX}${major}.${minor}.* and redeploy the Worker`
-    );
-  }
-
-  const envRelease = releaseFromEnvExample(files.envExample);
-  if (envRelease !== release) {
-    problems.push(`.env.example VITE_APP_RELEASE should be ${release}`);
-  }
-
-  return { release, problems };
-}
-
-export function readReleaseFiles(root: string): ReleaseFiles {
-  const read = (relative: string) => readFileSync(new URL(relative, root), 'utf8');
-  return {
-    packageJson: read('package.json'),
-    appJson: read('app.json'),
-    wranglerToml: read('infra/cloudflare/telemetry-worker/wrangler.toml'),
-    envExample: read('.env.example'),
-  };
-}
-
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  const root = new URL('../../', import.meta.url).href;
-  const result = checkRelease(readReleaseFiles(root));
-  if (result.problems.length > 0) {
-    for (const problem of result.problems) console.error(`✗ ${problem}`);
-    process.exit(1);
-  }
-  console.log(`✓ ${result.release} is consistent across package.json, app.json, wrangler.toml, and .env.example`);
-}
+console.log(`✓ ${result.release} is consistent across package.json, app.json, wrangler.toml, and .env.example`);

--- a/src/scripts/release-check.ts
+++ b/src/scripts/release-check.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { isReleaseAllowed, parseAllowedReleases } from '../infrastructure/telemetry/release-allowlist';
+
+/**
+ * Release consistency checks used by `pnpm release:check` (see check-release.ts).
+ *
+ * Checks that package.json and app.json carry the same version, that the
+ * Worker allowlist in wrangler.toml accepts `railglance@<version>`, and that
+ * .env.example points local development at the same release.
+ */
+
+export type ReleaseFiles = {
+  packageJson: string;
+  appJson: string;
+  wranglerToml: string;
+  envExample: string;
+};
+
+export type ReleaseCheckResult = { release: string; problems: string[] };
+
+const RELEASE_PREFIX = 'railglance@';
+
+function allowlistFromToml(toml: string): string[] | null {
+  const match = /^\s*TELEMETRY_ALLOWED_RELEASES\s*=\s*"([^"]*)"/m.exec(toml);
+  return match ? parseAllowedReleases(match[1]) : null;
+}
+
+function releaseFromEnvExample(env: string): string | null {
+  const match = /^VITE_APP_RELEASE=(.*)$/m.exec(env);
+  return match ? match[1].trim() : null;
+}
+
+export function checkRelease(files: ReleaseFiles): ReleaseCheckResult {
+  const packageVersion = String(JSON.parse(files.packageJson).version);
+  const appVersion = String(JSON.parse(files.appJson).version);
+  const release = `${RELEASE_PREFIX}${packageVersion}`;
+  const problems: string[] = [];
+
+  if (appVersion !== packageVersion) {
+    problems.push(`app.json version ${appVersion} must match package.json version ${packageVersion}`);
+  }
+
+  const allowlist = allowlistFromToml(files.wranglerToml);
+  if (allowlist === null) {
+    problems.push('wrangler.toml has no TELEMETRY_ALLOWED_RELEASES entry');
+  } else if (!isReleaseAllowed(release, allowlist)) {
+    const [major, minor] = packageVersion.split('.');
+    problems.push(
+      `TELEMETRY_ALLOWED_RELEASES does not cover ${release}; add ${RELEASE_PREFIX}${major}.${minor}.* and redeploy the Worker`
+    );
+  }
+
+  const envRelease = releaseFromEnvExample(files.envExample);
+  if (envRelease !== release) {
+    problems.push(`.env.example VITE_APP_RELEASE should be ${release}`);
+  }
+
+  return { release, problems };
+}
+
+export function readReleaseFiles(root: string): ReleaseFiles {
+  const read = (relative: string) => readFileSync(new URL(relative, root), 'utf8');
+  return {
+    packageJson: read('package.json'),
+    appJson: read('app.json'),
+    wranglerToml: read('infra/cloudflare/telemetry-worker/wrangler.toml'),
+    envExample: read('.env.example'),
+  };
+}

--- a/tests/scripts/check-release.test.ts
+++ b/tests/scripts/check-release.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { checkRelease } from '../../src/scripts/check-release';
+
+const files = (overrides: Partial<Record<'packageJson' | 'appJson' | 'wranglerToml' | 'envExample', string>> = {}) => ({
+  packageJson: '{"name":"railglance","version":"0.1.4"}',
+  appJson: '{"version":"0.1.4"}',
+  wranglerToml: '[vars]\nTELEMETRY_ALLOWED_RELEASES = "railglance@0.1.3,railglance@0.1.*"\n',
+  envExample: 'VITE_APP_RELEASE=railglance@0.1.4\n',
+  ...overrides,
+});
+
+describe('checkRelease', () => {
+  it('passes when versions agree and the allowlist covers the release', () => {
+    expect(checkRelease(files())).toEqual({ release: 'railglance@0.1.4', problems: [] });
+  });
+
+  it('reports an app.json version that differs from package.json', () => {
+    const result = checkRelease(files({ appJson: '{"version":"0.1.3"}' }));
+    expect(result.problems).toEqual([expect.stringMatching(/app\.json.*0\.1\.3.*package\.json.*0\.1\.4/)]);
+  });
+
+  it('reports a release the Worker allowlist would reject', () => {
+    const result = checkRelease(files({ packageJson: '{"version":"0.2.0"}', appJson: '{"version":"0.2.0"}', envExample: 'VITE_APP_RELEASE=railglance@0.2.0\n' }));
+    expect(result.problems).toEqual([expect.stringMatching(/TELEMETRY_ALLOWED_RELEASES.*railglance@0\.2\.0.*railglance@0\.2\.\*/)]);
+  });
+
+  it('reports a stale VITE_APP_RELEASE in .env.example', () => {
+    const result = checkRelease(files({ envExample: 'FOO=1\nVITE_APP_RELEASE=railglance@0.1.2\n' }));
+    expect(result.problems).toEqual([expect.stringMatching(/\.env\.example.*railglance@0\.1\.4/)]);
+  });
+
+  it('reports a wrangler.toml without the allowlist variable', () => {
+    const result = checkRelease(files({ wranglerToml: '[vars]\n' }));
+    expect(result.problems).toEqual([expect.stringMatching(/TELEMETRY_ALLOWED_RELEASES/)]);
+  });
+});

--- a/tests/scripts/check-release.test.ts
+++ b/tests/scripts/check-release.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { checkRelease } from '../../src/scripts/check-release';
+import { checkRelease } from '../../src/scripts/release-check';
 
 const files = (overrides: Partial<Record<'packageJson' | 'appJson' | 'wranglerToml' | 'envExample', string>> = {}) => ({
   packageJson: '{"name":"railglance","version":"0.1.4"}',

--- a/tests/telemetry/release-allowlist.test.ts
+++ b/tests/telemetry/release-allowlist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { isReleaseAllowed, parseAllowedReleases } from '../../src/infrastructure/telemetry/release-allowlist';
+
+describe('isReleaseAllowed', () => {
+  it('matches an exact entry', () => {
+    expect(isReleaseAllowed('railglance@0.1.3', ['railglance@0.1.3'])).toBe(true);
+    expect(isReleaseAllowed('railglance@0.1.4', ['railglance@0.1.3'])).toBe(false);
+  });
+
+  it('matches any numeric patch when the patch segment is a wildcard', () => {
+    expect(isReleaseAllowed('railglance@0.1.0', ['railglance@0.1.*'])).toBe(true);
+    expect(isReleaseAllowed('railglance@0.1.42', ['railglance@0.1.*'])).toBe(true);
+  });
+
+  it('does not let a patch wildcard cross minor, major, or prerelease boundaries', () => {
+    expect(isReleaseAllowed('railglance@0.2.0', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.10.0', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@1.1.0', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.4-beta', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.4.1', ['railglance@0.1.*'])).toBe(false);
+  });
+
+  it('treats a wildcard anywhere but the whole patch segment as a literal', () => {
+    expect(isReleaseAllowed('railglance@0.1.3', ['*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.3', ['railglance@*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.3', ['railglance@0.*.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.3', ['railglance@0.1.3*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.3', ['railglance@0.1.*-beta'])).toBe(false);
+    expect(isReleaseAllowed('*', ['*'])).toBe(true);
+  });
+
+  it('accepts a mixed list of exact and wildcard entries', () => {
+    const entries = ['railglance@0.1.3', 'railglance@0.2.*'];
+    expect(isReleaseAllowed('railglance@0.1.3', entries)).toBe(true);
+    expect(isReleaseAllowed('railglance@0.2.7', entries)).toBe(true);
+    expect(isReleaseAllowed('railglance@0.1.4', entries)).toBe(false);
+  });
+
+  it('never matches an empty release or an empty list', () => {
+    expect(isReleaseAllowed('', ['railglance@0.1.*'])).toBe(false);
+    expect(isReleaseAllowed('railglance@0.1.3', [])).toBe(false);
+  });
+});
+
+describe('parseAllowedReleases', () => {
+  it('splits, trims, and drops blank or oversized entries', () => {
+    expect(parseAllowedReleases(' railglance@0.1.3 , railglance@0.1.*,, ')).toEqual([
+      'railglance@0.1.3',
+      'railglance@0.1.*',
+    ]);
+    expect(parseAllowedReleases(`a,${'x'.repeat(201)}`)).toEqual(['a']);
+    expect(parseAllowedReleases(undefined)).toEqual([]);
+  });
+});

--- a/tests/telemetry/telemetry.test.ts
+++ b/tests/telemetry/telemetry.test.ts
@@ -236,6 +236,43 @@ describe('RuntimeTelemetryManager', () => {
     await restarted.shutdown();
   });
 
+  it('accepts enrollment and token refresh responses whose allowedReleases use a patch wildcard', async () => {
+    const qualificationStore = new MemoryQualificationStore();
+    const qualificationExpiresAt = new Date(Date.now() + 14 * 86_400_000).toISOString();
+    const uploadTokenExpiresAt = new Date(Date.now() + 15 * 60_000).toISOString();
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/campaign/enroll')) return new Response(JSON.stringify({
+        participantId: 'p_test', campaignId: 'campaign-test', campaignCredential: 'p_test.credential',
+        qualificationExpiresAt, allowedReleases: ['railglance@0.1.*'], uploadToken: 'initial-token',
+        uploadTokenExpiresAt,
+      }), { status: 201 });
+      if (url.endsWith('/session')) return new Response(JSON.stringify({
+        token: 'refreshed-token', expiresAt: uploadTokenExpiresAt,
+        qualificationExpiresAt, allowedReleases: ['railglance@0.1.*'],
+      }), { status: 201 });
+      return new Response('{}', { status: 202 });
+    });
+    const manager = new RuntimeTelemetryManager(
+      new MemorySink(), readTelemetryConfig({ VITE_TELEMETRY_ENDPOINT: 'https://telemetry.example' }),
+      { sessionId: 'session-1', release: 'railglance@0.1.4', environment: 'test' }, fetchFn, qualificationStore
+    );
+    await manager.initialize();
+    await manager.startDiagnostic('tester-code');
+    expect(manager.isDiagnosticEnabled()).toBe(true);
+    expect(qualificationStore.value?.allowedReleases).toEqual(['railglance@0.1.*']);
+    await manager.shutdown();
+
+    const patched = new RuntimeTelemetryManager(
+      new MemorySink(), readTelemetryConfig({ VITE_TELEMETRY_ENDPOINT: 'https://telemetry.example' }),
+      { sessionId: 'session-2', release: 'railglance@0.1.5', environment: 'test' }, fetchFn, qualificationStore
+    );
+    await patched.initialize();
+    expect(patched.isDiagnosticEnabled()).toBe(true);
+    expect(qualificationStore.value?.lastValidatedRelease).toBe('railglance@0.1.5');
+    await patched.shutdown();
+  });
+
   it('stops collection immediately when a persisted qualification is revoked', async () => {
     const qualificationStore = new MemoryQualificationStore();
     qualificationStore.value = {

--- a/tests/telemetry/worker.test.ts
+++ b/tests/telemetry/worker.test.ts
@@ -207,6 +207,51 @@ describe('Cloudflare telemetry Worker', () => {
     expect((await worker.fetch(uploadRequest(await validToken()), env)).status).toBe(429);
   });
 
+  it('accepts a patch-wildcard release entry across enrollment, refresh, and upload', async () => {
+    const env = environment();
+    env.TELEMETRY_ALLOWED_RELEASES = 'railglance@0.1.*';
+    const enrollment = await worker.fetch(new Request('https://worker.example/v1/telemetry/campaign/enroll', {
+      method: 'POST',
+      body: JSON.stringify({
+        schemaVersion: 1, sessionId: 'session-1', release: 'railglance@0.1.7',
+        environment: 'prototype', consent: true, accessCode: 'tester-code',
+      }),
+    }), env);
+    expect(enrollment.status).toBe(201);
+    const enrolled = await enrollment.json() as { campaignCredential: string; allowedReleases: string[]; uploadToken: string };
+    expect(enrolled.allowedReleases).toEqual(['railglance@0.1.*']);
+
+    const refresh = await worker.fetch(new Request('https://worker.example/v1/telemetry/session', {
+      method: 'POST',
+      body: JSON.stringify({
+        schemaVersion: 1, campaignCredential: enrolled.campaignCredential,
+        release: 'railglance@0.1.8', environment: 'prototype',
+      }),
+    }), env);
+    expect(refresh.status).toBe(201);
+
+    const payload = batch();
+    payload.events[0].release = 'railglance@0.1.8';
+    expect((await worker.fetch(uploadRequest(enrolled.uploadToken, payload), env)).status).toBe(202);
+
+    const nextMinor = batch();
+    nextMinor.events[0].release = 'railglance@0.2.0';
+    expect((await worker.fetch(uploadRequest(enrolled.uploadToken, nextMinor), env)).status).toBe(403);
+  });
+
+  it('rejects enrollment from a release outside the patch wildcard', async () => {
+    const env = environment();
+    env.TELEMETRY_ALLOWED_RELEASES = 'railglance@0.1.*';
+    const response = await worker.fetch(new Request('https://worker.example/v1/telemetry/campaign/enroll', {
+      method: 'POST',
+      body: JSON.stringify({
+        schemaVersion: 1, sessionId: 'session-1', release: 'railglance@0.2.0',
+        environment: 'prototype', consent: true, accessCode: 'tester-code',
+      }),
+    }), env);
+    expect(response.status).toBe(403);
+  });
+
   it('echoes an ephemeral-port loopback origin when the allowlist uses a port wildcard', async () => {
     const env = environment();
     env.TELEMETRY_ALLOWED_ORIGINS = 'http://localhost:5173,http://127.0.0.1:*';


### PR DESCRIPTION
## 目的

PR #59 で顕在化した問題を解消します。`TELEMETRY_ALLOWED_RELEASES` にパッチ版を 1 つずつ完全一致で列挙し、そのたびに Worker を再デプロイする運用をやめます。あわせて、バージョンアップ作業を agent skill として手順化します。

## 変更内容

### 1. 許可 release のパッチワイルドカード

- `TELEMETRY_ALLOWED_RELEASES` の各エントリは、完全一致（`railglance@0.1.3`）またはパッチワイルドカード（`railglance@0.1.*`）を受け付けます。
- ワイルドカードは同じ major.minor の数字パッチだけに一致します。`0.1.4-beta` や `0.10.0` には一致せず、パッチ位置以外の `*` はリテラル扱いで fail closed します。
- 照合関数は `src/infrastructure/telemetry/release-allowlist.ts` に 1 つだけ置き、アプリと Worker の両方が import します。アプリ側も enroll/refresh 応答の `allowedReleases` を自分の release と照合するため、Worker だけの変更では成立しません。
- `wrangler.toml` には既存の完全一致エントリを残したまま `railglance@0.1.*` を追加しました。0.1.3 以前のクライアントは自分の release 文字列が配列に含まれるかだけを見るので、ワイルドカードエントリの存在に影響されません。段階的な切り替えは不要です。

### 2. `VITE_APP_RELEASE` の手動更新を廃止

ビルドワークフローが `package.json` の version から `railglance@<version>` を導出します。`evenhub-beta` 環境の変数 `VITE_APP_RELEASE` は読まれなくなったので、削除して構いません（この PR では触っていません）。

### 3. `pnpm release:check`

`package.json` と `app.json` の一致、Worker の allowlist が `railglance@<version>` を受け付けること、`.env.example` の `VITE_APP_RELEASE` が最新であることを検証します。CI とパッケージビルドの両ワークフローで実行します。

### 4. `.claude/skills/bumping-app-version`

バージョンアップの手順をチェックリスト化しました。判断点は「Worker の再デプロイが必要か」の 1 つだけで、minor/major が変わったとき、または前回デプロイ以降に Worker ディレクトリが変わったときにだけ再デプロイします。

## マージ後に必要な手順

**次のリリース（0.1.4）を配布する前に、`main` から Worker を再デプロイしてください。** Worker のコード（ワイルドカード解釈）と allowlist の両方がこの PR で変わっており、再デプロイなしでは 0.1.4 が enroll できません。

```
cd infra/cloudflare/telemetry-worker && pnpm dlx wrangler deploy
```

0.1.4 のリリース PR 自体は `wrangler.toml` を触りません。

## 検証

- `pnpm test` — 305 passed（新規: allowlist 境界 7 件、Worker のワイルドカード enroll/refresh/upload 2 件、クライアント側応答受理 1 件、release:check 5 件）
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm release:check` — 0.1.3 で pass
- `wrangler deploy --dry-run` — 共有モジュールがバンドルに含まれることを確認
- スキルの検証: スキルなしのエージェントは 10 tool call かけて手順を再構築し、旧 docs の誤った段階手順に引きずられた。スキルありでは 7 call で toml 不変更・merge 後 Worker 再デプロイ・GitHub 変数不要を正しく判断した。

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4ftpirXiev5SL4rvqnQeY
