### PR TITLE
Bump app package version to 0.1.4 for a new Even Hub beta build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ R2_CORS_ALLOWED_ORIGINS=*
 # Error tracking. The DSN is intentionally a browser-visible project endpoint, not a secret.
 VITE_SENTRY_DSN=
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
-VITE_APP_RELEASE=railglance@0.1.3
+VITE_APP_RELEASE=railglance@0.1.4
 VITE_APP_ENVIRONMENT=prototype
 
 # Build-time source map upload (CI/build environment only; never VITE_-prefixed).

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "package_id": "com.railglance.traintracker",
   "edition": "202601",
   "name": "RailGlance Train HUD",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "min_app_version": "2.0.0",
   "min_sdk_version": "0.0.12",
   "entrypoint": "index.html",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "railglance",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "concurrently -k -s first \"vite\" \"wait-on http://localhost:5173 && evenhub-simulator http://localhost:5173\"",


### PR DESCRIPTION
## Purpose
Patch version bump to 0.1.4 for the next Even Hub beta build.

## Bundle changes since the last build (0.1.3)
- `src/infrastructure/telemetry/release-allowlist.ts` — allow patch wildcards in the telemetry release allowlist (8ccef63)
- `src/infrastructure/telemetry/runtime-telemetry.ts`, `src/main.ts` — drop a stale consent tick when the qualification lapses (69957a6)
- `src/ui/diagnostic-panel.ts` — show the persisted diagnostic participation after a restart (1ebbf4c)

## Files changed
- `package.json` — version 0.1.3 → 0.1.4
- `app.json` — version 0.1.3 → 0.1.4
- `.env.example` — `VITE_APP_RELEASE=railglance@0.1.4`
- `infra/cloudflare/telemetry-worker/wrangler.toml` — untouched (patch bump, no major.minor change)

## Post-merge steps
1. **Redeploy the telemetry Worker** — its `wrangler.toml` picked up the `railglance@0.1.x` wildcard entry on 2026-09-06 (3663fcf) but the last live deployment is from 2026-08-16, so the deployed Worker doesn't have that wildcard yet. Run `pnpm dlx wrangler deploy` from `infra/cloudflare/telemetry-worker` on an up-to-date `main` checkout, before distributing the package.
2. `gh workflow run build-evenhub-package.yml --ref main`, then watch the run and download `out.ehpk`.
3. Confirm the run summary shows `Release: railglance@0.1.4`.
4. Distribute via Even Hub Private Testing, then Beta per the device gate in `docs/TELEMETRY_AND_SENTRY.md`.

## Verification
- `pnpm release:check` — ✓ railglance@0.1.4 consistent across package.json, app.json, wrangler.toml, and .env.example
- `pnpm lint` — clean
- `pnpm test` — 316 passed (40 files)
- `pnpm build` — succeeded
- `pnpm manifest:evenhub` — succeeded
- `node -p "require('./dist/app.json').version"` → `0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4EVQQbr1DwFBGuMx6hNy9